### PR TITLE
Remove cv2 dependency for bentoml and update dataframe handle_cli func

### DIFF
--- a/bentoml/handlers/dataframe_handler.py
+++ b/bentoml/handlers/dataframe_handler.py
@@ -83,26 +83,23 @@ class DataframeHandler(RequestHandler, CliHandler):
         if parsed_args.input_json_orient:
             options['input_json_orient'] = parsed_args.input_json_orient
 
-        try:
-            if file_path.endswith('.csv'):
-                df = pd.read_csv(file_path)
-            elif file_path.endswith('.json'):
-                df = pd.read_json(file_path, orient=options['input_json_orient'], dtype=False)
+        if file_path.endswith('.csv'):
+            df = pd.read_csv(file_path)
+        elif file_path.endswith('.json'):
+            df = pd.read_json(file_path, orient=options['input_json_orient'], dtype=False)
 
-            if options['input_columns_require']:
-                check_missing_columns(options['input_columns_require'], df.columns)
+        if options['input_columns_require']:
+            check_missing_columns(options['input_columns_require'], df.columns)
 
-            output = func(df)
+        output = func(df)
 
-            if parsed_args.output == 'json' or not parsed_args.output:
-                if isinstance(output, pd.DataFrame):
-                    result = output.to_json(orient=options['output_json_orient'])
-                    result = json.loads(result)
-                    result = json.dumps(result, indent=2)
-                else:
-                    result = json.dumps(output)
-                sys.stdout.write(result)
+        if parsed_args.output == 'json' or not parsed_args.output:
+            if isinstance(output, pd.DataFrame):
+                result = output.to_json(orient=options['output_json_orient'])
+                result = json.loads(result)
+                result = json.dumps(result, indent=2)
             else:
-                raise NotImplementedError
-        except Exception as e:
+                result = json.dumps(output)
+            sys.stdout.write(result)
+        else:
             raise NotImplementedError

--- a/bentoml/handlers/dataframe_handler.py
+++ b/bentoml/handlers/dataframe_handler.py
@@ -78,16 +78,16 @@ class DataframeHandler(RequestHandler, CliHandler):
         parser.add_argument('--input_json_orient', default='records')
         parsed_args = parser.parse_args(args)
         options = merge_dicts(default_options, options)
+        file_path = parsed_args.input
 
         if parsed_args.input_json_orient:
             options['input_json_orient'] = parsed_args.input_json_orient
 
-        with open(parsed_args.input, 'r') as content_file:
-            content = content_file.read()
-            if content_file.name.endswith('.csv'):
-                df = pd.read_csv(content)
-            elif content_file.name.endswith('.json'):
-                df = pd.read_json(content, orient=options['input_json_orient'], dtype=False)
+        try:
+            if file_path.endswith('.csv'):
+                df = pd.read_csv(file_path)
+            elif file_path.endswith('.json'):
+                df = pd.read_json(file_path, orient=options['input_json_orient'], dtype=False)
 
             if options['input_columns_require']:
                 check_missing_columns(options['input_columns_require'], df.columns)
@@ -104,3 +104,5 @@ class DataframeHandler(RequestHandler, CliHandler):
                 sys.stdout.write(result)
             else:
                 raise NotImplementedError
+        except Exception as e:
+            raise NotImplementedError

--- a/bentoml/handlers/image_handler.py
+++ b/bentoml/handlers/image_handler.py
@@ -21,8 +21,8 @@ from __future__ import print_function
 import json
 import os
 import sys
-import cv2
 import numpy as np
+from six import string_types
 from werkzeug.utils import secure_filename
 from flask import request, Response, make_response
 from bentoml.handlers.base_handlers import RequestHandler, CliHandler
@@ -103,6 +103,12 @@ class ImageHandler(RequestHandler, CliHandler):
             check_file_format(file_path, options['accept_file_extensions'])
             if not os.path.isabs(file_path):
                 file_path = os.path.abspath(file_path)
+
+            try:
+                if not cv2:
+                    cv2 = __import__('cv2')
+            except:
+                cv2 = __import__('cv2')
 
             image = cv2.imread(file_path)
             output = func(image)

--- a/bentoml/handlers/image_handler.py
+++ b/bentoml/handlers/image_handler.py
@@ -104,10 +104,9 @@ class ImageHandler(RequestHandler, CliHandler):
                 file_path = os.path.abspath(file_path)
 
             try:
-                if not cv2:
-                    cv2 = __import__('cv2')
-            except:
-                cv2 = __import__('cv2')
+                import cv2
+            except ImportError:
+                raise ImportError("opencv-python package is required to use ImageHandler")
 
             image = cv2.imread(file_path)
             output = func(image)

--- a/bentoml/handlers/image_handler.py
+++ b/bentoml/handlers/image_handler.py
@@ -22,7 +22,6 @@ import json
 import os
 import sys
 import numpy as np
-from six import string_types
 from werkzeug.utils import secure_filename
 from flask import request, Response, make_response
 from bentoml.handlers.base_handlers import RequestHandler, CliHandler

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,7 @@ install_requires = [
     'dill',
     'python-json-logger',
     'boto3',
-    'Werkzeug',
-    'opencv-python'
+    'Werkzeug'
 ]
 
 optional_requires = [


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
* instead of reading file then read into dataframe, use pandas's built
in func instead.

* remove image handler's cv2 dependency, only import the package when we
need it.


Does this close any currently open issues?
------------------------------------------
no

How was this patch tested?
--------------------------
n/a