### PR TITLE
Fix loading pip installed BentoService

### DIFF
--- a/bentoml/archive/archiver.py
+++ b/bentoml/archive/archiver.py
@@ -123,10 +123,7 @@ __VERSION__ = "{pypi_package_version}"
 
 __module_path = os.path.abspath(os.path.dirname(__file__))
 
-# Prepend __module_path to sys.path for loading extra python dependencies
-sys.path.insert(0, __module_path)
 {service_name} = load_bento_service_class(__module_path)
-sys.path.remove(__module_path)
 
 cli=create_bentoml_cli(__module_path)
 

--- a/bentoml/archive/loader.py
+++ b/bentoml/archive/loader.py
@@ -55,6 +55,7 @@ def load_bento_service_class(archive_path):
     Load a BentoService class from saved archive in given path
 
     :param archive_path: A BentoArchive path generated from BentoService.save call
+        or the path to pip installed BentoArchive directory
     :return: BentoService class
     """
     if is_s3_url(archive_path):
@@ -74,7 +75,7 @@ def load_bento_service_class(archive_path):
         raise BentoMLException('Can not locate module_file {} in archive {}'.format(
             config['module_file'], archive_path))
 
-    # Prepend archive_path to sys.path, to make python code deps avaiable
+    # Prepend archive_path to sys.path for loading extra python dependencies
     sys.path.insert(0, archive_path)
 
     module_name = config['module_name']
@@ -100,11 +101,11 @@ def load_bento_service_class(archive_path):
 
     model_service_class = module.__getattribute__(config['service_name'])
     # Set _bento_archive_path, which tells BentoService where to load its artifacts
-    model_service_class._bento_archive_path = os.path.join(archive_path, config['service_name'])
+    model_service_class._bento_archive_path = archive_path
 
     return model_service_class
 
 
 def load(archive_path):
     svc_cls = load_bento_service_class(archive_path)
-    return svc_cls()
+    return svc_cls.from_archive(archive_path)

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -307,7 +307,10 @@ class BentoService(BentoServiceBase):
             path = temporary_path
 
         artifacts_path = path
-        if not os.path.isdir(os.path.join(artifacts_path, 'artifacts')):
+        # For pip installed BentoService, artifacts directory is located at
+        # 'package_path/artifacts/', but for loading from BentoArchive, it is
+        # in 'path/{service_name}/artifacts/'
+        if not os.path.isdir(os.path.join(path, 'artifacts')):
             artifacts_path = os.path.join(path, cls.name())
 
         bentoml_config = load_bentoml_config(path)


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
- Fix artifact path not found issue when loading pip installed BentoService

Does this close any currently open issues?
------------------------------------------
n/a

How was this patch tested?
--------------------------
n/a