### PR TITLE
Include tests directory in format and linter script

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,3 +3,5 @@ set -e
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
 yapf -i $(find $GIT_ROOT/bentoml -name "*.py")
+yapf -i $(find $GIT_ROOT/tests -name "*.py")
+

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,5 +5,6 @@ GIT_ROOT=$(git rev-parse --show-toplevel)
 cd $GIT_ROOT
 
 pylint --rcfile="./pylintrc" bentoml
+pylint --rcfile="./pylintrc" tests
 pycodestyle bentoml
 pycodestyle tests

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -30,8 +30,7 @@ def test_run_command_with_input_file():
 
     cli = create_bentoml_cli()
     run_cmd = cli.commands["<API_NAME>"]
-    result = runner.invoke(
-        run_cmd, ['predict', saved_path, '--input', input_path])
+    result = runner.invoke(run_cmd, ['predict', saved_path, '--input', input_path])
 
     assert result.exit_code == 0
     result_json = json.loads(result.output)

--- a/tests/handlers/test_image_handler.py
+++ b/tests/handlers/test_image_handler.py
@@ -12,7 +12,7 @@ except ImportError:
     from bentoml.handlers import ImageHandler
 
 
-class FakeImageModel(object):
+class TestImageModel(object):
     def predict(self, image_ndarray):
         return image_ndarray.shape
 
@@ -30,12 +30,12 @@ BASE_TEST_PATH = "/tmp/bentoml-test"
 
 
 def test_image_handler(capsys):
-    fake_model = FakeImageModel()
-    ms = ImageHandlerModel.pack(clf=fake_model)
+    test_model = TestImageModel()
+    ms = ImageHandlerModel.pack(clf=test_model)
     api = ms.get_service_apis()[0]
 
-    fake_args = ['--input=./tests/test_image_1.jpg']
-    api.handle_cli(fake_args)
+    test_args = ['--input=./tests/test_image_1.jpg']
+    api.handle_cli(test_args)
     out, err = capsys.readouterr()
 
     assert out.strip().endswith('(360, 480, 3)')

--- a/tests/handlers/test_image_handler.py
+++ b/tests/handlers/test_image_handler.py
@@ -13,14 +13,14 @@ except ImportError:
 
 
 class TestImageModel(object):
+
     def predict(self, image_ndarray):
         return image_ndarray.shape
 
 
-@artifacts([
-    PickleArtifact('clf')
-])
+@artifacts([PickleArtifact('clf')])
 class ImageHandlerModel(BentoService):
+
     @api(ImageHandler)
     def predict(self, input_data):
         return self.artifacts.clf.predict(input_data)

--- a/tests/server/test_model_api_server.py
+++ b/tests/server/test_model_api_server.py
@@ -2,7 +2,6 @@ import os
 import json
 import sys
 
-
 try:
     import bentoml
     from bentoml.server import BentoAPIServer

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -5,9 +5,11 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from bentoml.archive.archiver import _validate_version_str  # noqa: E402
 
+
 def test_validate_version_str_fails():
     with pytest.raises(ValueError):
         _validate_version_str('44&')
+
 
 def test_validate_version_str_pass():
     _validate_version_str('abc_123')

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from bentoml.archive.archiver import _validate_version_str  # noqa: E402
+
+def test_validate_version_str_fails():
+    with pytest.raises(ValueError):
+        _validate_version_str('44&')
+
+def test_validate_version_str_pass():
+    _validate_version_str('abc_123')

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8,14 +8,13 @@ from bentoml.artifact import PickleArtifact  # noqa: E402
 
 
 class MyTestModel(object):
+
     def predict(self, input_data):
         return int(input_data) * 2
 
 
 @bentoml.env(conda_pip_dependencies=['scikit-learn'])
-@bentoml.artifacts([
-    PickleArtifact('model')
-])
+@bentoml.artifacts([PickleArtifact('model')])
 class MyTestBentoService(bentoml.BentoService):
 
     @bentoml.api(bentoml.handlers.DataframeHandler)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,16 +5,6 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import bentoml  # noqa: E402
 from bentoml.artifact import PickleArtifact  # noqa: E402
-from bentoml.archive.archiver import _validate_version_str  # noqa: E402
-
-
-def test_validate_version_str_fails():
-    with pytest.raises(ValueError):
-        _validate_version_str('44&')
-
-
-def test_validate_version_str_pass():
-    _validate_version_str('abc_123')
 
 
 class MyTestModel(object):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,20 +5,17 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 import bentoml  # noqa: E402
 from bentoml.artifact import PickleArtifact  # noqa: E402
 
-
-
 BASE_TEST_PATH = "/tmp/bentoml-test"
 
 
 class MyFakeModel(object):
+
     def predict(self, df):
         df['age'] = df['age'].add(5)
         return df
 
 
-@bentoml.artifacts([
-    PickleArtifact('fake_model')
-])
+@bentoml.artifacts([PickleArtifact('fake_model')])
 @bentoml.env()
 class MyFakeBentoModel(bentoml.BentoService):
     """


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
./script/format.sh ./script/lint.sh now also applies to python files under /tests directory


Does this close any currently open issues?
------------------------------------------
n/a

How was this patch tested?
--------------------------
n/a