### PR TITLE
Use semantic versioning for BentoService and its generated PyPI package

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -5,8 +5,7 @@ scanner:
 pycodestyle:
     max-line-length: 100
 
-    exclude:
-      - examples
+    exclude: [ 'examples' ]
 
 only_mention_files_with_errors: True
 

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -5,6 +5,9 @@ scanner:
 pycodestyle:
     max-line-length: 100
 
+    exclude:
+      - examples
+
 only_mention_files_with_errors: True
 
 message:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include README.md
 graft docs
 
-# Don't include Examples
+# Don't include examples, tests directory
 prune examples
 prune tests
 

--- a/bentoml/__init__.py
+++ b/bentoml/__init__.py
@@ -22,7 +22,8 @@ from bentoml import handlers
 from bentoml.version import __version__
 
 from bentoml.service import BentoService, api_decorator as api, \
-    env_decorator as env, artifacts_decorator as artifacts
+    env_decorator as env, artifacts_decorator as artifacts, \
+    ver_decorator as ver
 from bentoml.server import metrics
 from bentoml.archive import save, load
 

--- a/bentoml/archive/archiver.py
+++ b/bentoml/archive/archiver.py
@@ -153,8 +153,8 @@ def _validate_version_str(version_str):
     * Consist of only ALPHA / DIGIT / "-" / "." / "_"
     * Length between 1-128
     """
-    regex = r"[A-Za-z0-9_.-]{1,128}"
-    if re.fullmatch(regex, version_str) is None:
+    regex = r"[A-Za-z0-9_.-]{1,128}\Z"
+    if re.match(regex, version_str) is None:
         raise ValueError('Invalid BentoArchive version: "{}", it can only consist'
                          ' ALPHA / DIGIT / "-" / "." / "_", and must be less than'
                          '128 characthers'.format(version_str))

--- a/bentoml/archive/archiver.py
+++ b/bentoml/archive/archiver.py
@@ -149,26 +149,30 @@ DEFAULT_BENTO_ARCHIVE_DESCRIPTION = """\
 
 def _validate_version_str(version_str):
     """
-    Validate that version str starts with char, has length >= 4
+    Validate that version str format:
+    * Consist of only ALPHA / DIGIT / "-" / "." / "_"
+    * Length between 1-128
     """
-    regex = r"^[a-zA-Z][a-zA-Z0-9_]{3,}"
-    if re.match(regex, version_str) is None:
-        raise ValueError('Invalid version format: "{}"'.format(version_str))
+    regex = r"[A-Za-z0-9_.-]{1,128}"
+    if re.fullmatch(regex, version_str) is None:
+        raise ValueError('Invalid BentoArchive version: "{}", it can only consist'
+                         ' ALPHA / DIGIT / "-" / "." / "_", and must be less than'
+                         '128 characthers'.format(version_str))
 
 
 def _generate_new_version_str():
     """
-    Generate a version string in the format of YYYY_MM_DD_RandomHash
+    Generate a version string in the format of YYYY-MM-DD-Hash
     """
     time_obj = datetime.now()
     date_string = time_obj.strftime('%Y_%m_%d')
     random_hash = uuid.uuid4().hex[:8]
 
-    return 'b' + date_string + '_' + random_hash
+    return date_string + '_' + random_hash
 
 
 # TODO: make pypi version consistent with archive version, and use Semantic versioning for both
-def save(bento_service, dst, version=None, pypi_package_version="1.0.0"):
+def save(bento_service, dst, version=None):
     """
     Save given BentoService along with all artifacts to target path
     """
@@ -176,6 +180,14 @@ def save(bento_service, dst, version=None, pypi_package_version="1.0.0"):
     if version is None:
         version = _generate_new_version_str()
     _validate_version_str(version)
+
+    # BentoML uses semantic versioning for BentoService distribution
+    # The parameter version(or auto generated version) will be used as
+    # PATCH field in the final version, where MAJOR and MINOR are specified
+    # along with the BentoService class definition with @version decorator
+    version = '.'.join(
+        [str(bento_service._version_major),
+         str(bento_service._version_minor), version])
 
     # Full path containing saved BentoArchive, it the dst path with service name
     # and service version as prefix. e.g.:
@@ -185,15 +197,15 @@ def save(bento_service, dst, version=None, pypi_package_version="1.0.0"):
 
     if is_s3_url(dst):
         with TempDirectory() as tempdir:
-            _save(bento_service, tempdir, version, pypi_package_version)
+            _save(bento_service, tempdir, version)
             upload_to_s3(full_saved_path, tempdir)
     else:
-        _save(bento_service, dst, version, pypi_package_version)
+        _save(bento_service, dst, version)
 
     return full_saved_path
 
 
-def _save(bento_service, dst, version=None, pypi_package_version="1.0.0"):
+def _save(bento_service, dst, version=None):
     Path(os.path.join(dst), bento_service.name).mkdir(parents=True, exist_ok=True)
     # Update path to subfolder in the form of 'base/service_name/version/'
     path = os.path.join(dst, bento_service.name, version)
@@ -230,12 +242,11 @@ def _save(bento_service, dst, version=None, pypi_package_version="1.0.0"):
     with open(os.path.join(path, bento_service.name, '__init__.py'), "w") as f:
         f.write(
             INIT_PY_TEMPLATE.format(service_name=bento_service.name, module_name=module_name,
-                                    pypi_package_version=pypi_package_version))
+                                    pypi_package_version=version))
 
     # write setup.py, make exported model pip installable
     setup_py_content = BENTO_MODEL_SETUP_PY_TEMPLATE.format(
-        name=bento_service.name, pypi_package_version=pypi_package_version,
-        long_description=model_description)
+        name=bento_service.name, pypi_package_version=version, long_description=model_description)
     with open(os.path.join(path, 'setup.py'), 'w') as f:
         f.write(setup_py_content)
 

--- a/bentoml/server/bento_api_server.py
+++ b/bentoml/server/bento_api_server.py
@@ -93,7 +93,8 @@ def bento_service_api_wrapper(api, service_name, service_version, logger):
     """
     Create api function for flask route
     """
-    summary_name = str(service_name) + '_' + str(service_version) + '_' + str(api.name)
+    summary_name = str(service_name) + '_' + str(service_version.replace('.', '_')) + '_' + str(
+        api.name)
     request_metric_time = Summary(summary_name, summary_name + ' request latency')
 
     def wrapper():

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -198,8 +198,8 @@ def ver_decorator(major, minor):
     """
 
     def decorator(bento_service_cls):
-        bento_service_cls.__version_major = major
-        bento_service_cls.__version_minor = minor
+        bento_service_cls._version_major = major
+        bento_service_cls._version_minor = minor
         return bento_service_cls
 
     return decorator

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -181,7 +181,8 @@ def ver_decorator(major, minor):
     uses semantic versioning for BentoService distribution:
 
     MAJOR is incremented when you make breaking API changes
-    MINOR is incremented when you add new functionality without breaking the existing API or functionality
+    MINOR is incremented when you add new functionality without breaking the
+        existing API or functionality
     PATCH is incremented when you make backwards-compatible bug fixes
 
     'Patch' is provided(or auto generated) when calling BentoService#save,

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -176,6 +176,35 @@ def env_decorator(**kwargs):
     return decorator
 
 
+def ver_decorator(major, minor):
+    """Decorator for specifying the version of a custom BentoService, BentoML
+    uses semantic versioning for BentoService distribution:
+
+    MAJOR is incremented when you make breaking API changes
+    MINOR is incremented when you add new functionality without breaking the existing API or functionality
+    PATCH is incremented when you make backwards-compatible bug fixes
+
+    'Patch' is provided(or auto generated) when calling BentoService#save,
+    while 'Major' and 'Minor' can be defined with '@ver' decorator
+
+    >>>  @ver(major=1, minor=4)
+    >>>  @artifacts([PickleArtifact('model')])
+    >>>  class MyMLService(BentoService):
+    >>>     pass
+    >>>
+    >>>  svc = MyMLService.pack(model="my ML model object")
+    >>>  svc.save('/path_to_archive', version="2019-08.iteration20")
+    >>>  # The final produced BentoArchive verion will be "1.4.2019-08.iteration20"
+    """
+
+    def decorator(bento_service_cls):
+        bento_service_cls.__version_major = major
+        bento_service_cls.__version_minor = minor
+        return bento_service_cls
+
+    return decorator
+
+
 class BentoService(BentoServiceBase):
     """
     BentoService packs a list of artifacts and exposes service APIs
@@ -183,9 +212,10 @@ class BentoService(BentoServiceBase):
     users can customize the artifacts and environments required for
     a ML service.
 
-    >>>  from bentoml import BentoService, env, api, artifacts
+    >>>  from bentoml import BentoService, env, api, artifacts, ver
     >>>  from bentoml.handlers import DataframeHandler
     >>>
+    >>>  @ver(major=1, minor=4)
     >>>  @artifacts([PickleArtifact('clf')])
     >>>  @env(conda_dependencies: [ 'scikit-learn' ])
     >>>  class MyMLService(BentoService):
@@ -216,6 +246,10 @@ class BentoService(BentoServiceBase):
 
     # This can only be set by BentoML library when loading from archive
     _bento_service_version = None
+
+    # See `ver_decorator` function above for more information
+    _version_major = 0
+    _version_minor = 0
 
     def __init__(self, artifacts=None, env=None):
         if artifacts is None:

--- a/examples/quick-start/main.py
+++ b/examples/quick-start/main.py
@@ -5,12 +5,13 @@ from sklearn import datasets
 
 # Use local bentoml code
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
-from bentoml import BentoService, load, api, env, artifacts
+from bentoml import BentoService, load, api, env, artifacts, ver
 from bentoml.artifact import PickleArtifact
 from bentoml.handlers import JsonHandler
 
 @artifacts([PickleArtifact('clf')])
 @env(conda_dependencies=["scikit-learn"])
+@ver(major=1, minor=0)
 class IrisClassifier(BentoService):
     """
     Iris SVM Classifier

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -13,6 +13,7 @@ class MyTestModel(object):
         return int(input_data) * 2
 
 
+@bentoml.ver(major=2, minor=10)
 @bentoml.env(conda_pip_dependencies=['scikit-learn'])
 @bentoml.artifacts([PickleArtifact('model')])
 class MyTestBentoService(bentoml.BentoService):
@@ -35,8 +36,9 @@ def test_save_and_load_model(tmpdir):
     version = "test_" + uuid.uuid4().hex
     saved_path = ms.save(str(tmpdir), version=version)
 
-    model_path = os.path.join(str(tmpdir), 'MyTestBentoService', version)
-    assert os.path.exists(model_path)
+    expected_version = "2.10.{}".format(version)
+    assert saved_path == os.path.join(str(tmpdir), 'MyTestBentoService', expected_version)
+    assert os.path.exists(saved_path)
 
     model_service = bentoml.load(saved_path)
 
@@ -48,8 +50,7 @@ def test_save_and_load_model(tmpdir):
 
     # Check api methods are available
     assert model_service.predict(1) == 2
-
-    assert model_service.version == version
+    assert model_service.version == expected_version
 
 
 @pytest.mark.skip(reason="Setup s3 creds in travis or use a mock")


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
- added `@ver` decorator for specifying model service's MAJOR, MINOR version

Does this close any currently open issues?
------------------------------------------
 #75

How was this patch tested?
--------------------------
