### PR TITLE
Fix BentoArchive version format when not specified with @ver decorator

### DIFF
--- a/bentoml/archive/archiver.py
+++ b/bentoml/archive/archiver.py
@@ -171,7 +171,6 @@ def _generate_new_version_str():
     return date_string + '_' + random_hash
 
 
-# TODO: make pypi version consistent with archive version, and use Semantic versioning for both
 def save(bento_service, dst, version=None):
     """
     Save given BentoService along with all artifacts to target path
@@ -181,13 +180,15 @@ def save(bento_service, dst, version=None):
         version = _generate_new_version_str()
     _validate_version_str(version)
 
-    # BentoML uses semantic versioning for BentoService distribution
-    # The parameter version(or auto generated version) will be used as
-    # PATCH field in the final version, where MAJOR and MINOR are specified
-    # along with the BentoService class definition with @version decorator
-    version = '.'.join(
-        [str(bento_service._version_major),
-         str(bento_service._version_minor), version])
+    if bento_service._version_major is not None and bento_service._version_minor is not None:
+        # BentoML uses semantic versioning for BentoService distribution
+        # when user specified the MAJOR and MINOR version number along with
+        # the BentoService class definition with '@ver' decorator.
+        # The parameter version(or auto generated version) here will be used as
+        # PATCH field in the final version:
+        version = '.'.join(
+            [str(bento_service._version_major),
+             str(bento_service._version_minor), version])
 
     # Full path containing saved BentoArchive, it the dst path with service name
     # and service version as prefix. e.g.:

--- a/bentoml/artifact/__init__.py
+++ b/bentoml/artifact/__init__.py
@@ -27,6 +27,5 @@ from bentoml.artifact.xgboost_artifact import XgboostModelArtifact
 
 __all__ = [
     'ArtifactSpec', 'ArtifactInstance', 'ArtifactCollection', 'PickleArtifact',
-    'PytorchModelArtifact', 'TextFileArtifact', 'TfKerasModelArtifact',
-    'XgboostModelArtifact'
+    'PytorchModelArtifact', 'TextFileArtifact', 'TfKerasModelArtifact', 'XgboostModelArtifact'
 ]

--- a/bentoml/server/bento_api_server.py
+++ b/bentoml/server/bento_api_server.py
@@ -93,8 +93,7 @@ def bento_service_api_wrapper(api, service_name, service_version, logger):
     """
     Create api function for flask route
     """
-    summary_name = str(service_name) + '_' + str(service_version.replace('.', '_')) + '_' + str(
-        api.name)
+    summary_name = str(service_name) + '_' + str(api.name)
     request_metric_time = Summary(summary_name, summary_name + ' request latency')
 
     def wrapper():

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -252,8 +252,8 @@ class BentoService(BentoServiceBase):
     _bento_service_version = None
 
     # See `ver_decorator` function above for more information
-    _version_major = 0
-    _version_minor = 0
+    _version_major = None
+    _version_minor = None
 
     def __init__(self, artifacts=None, env=None):
         if artifacts is None:


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
- ignore major/minor version when they are not specified by user - so we don't have the "0.0." prefix by default