### PR TITLE
Add gunicorn support for bentoml

### DIFF
--- a/bentoml/archive/archiver.py
+++ b/bentoml/archive/archiver.py
@@ -117,7 +117,6 @@ import os
 import sys
 
 from bentoml import archive
-from bentoml.server import BentoAPIServer
 from bentoml.cli import create_bentoml_cli
 
 __VERSION__ = "{pypi_package_version}"

--- a/bentoml/archive/archiver.py
+++ b/bentoml/archive/archiver.py
@@ -308,7 +308,8 @@ def _save(bento_service, dst, version=None):
     with open(os.path.join(path, 'Dockerfile'), 'w') as f:
         f.write(
             BENTO_SERVER_SINGLE_MODEL_DOCKERFILE_TEMPLATE.format(
-                conda_env_name=bento_service.env.get_conda_env_name(), service_name=bento_service.name))
+                conda_env_name=bento_service.env.get_conda_env_name(),
+                service_name=bento_service.name))
 
     # write bentoml.yml
     bentoml_yml_content = BENTOML_CONFIG_YAML_TEMPLATE.format(

--- a/bentoml/archive/archiver.py
+++ b/bentoml/archive/archiver.py
@@ -105,7 +105,7 @@ RUN conda env create -f /bento/environment.yml
 
 ENV PATH /opt/conda/envs/$conda_env/bin:$PATH
 
-RUN conda install pip && pip install -r /bento/requirements.txt
+RUN conda install pip && pip install -r /bento/requirements.txt && pip install gunicorn
 
 # Run Gunicorn server with path to module.
 CMD ["bentoml serve-gunicorn /bento"]

--- a/bentoml/archive/archiver.py
+++ b/bentoml/archive/archiver.py
@@ -108,19 +108,13 @@ ENV PATH /opt/conda/envs/$conda_env/bin:$PATH
 RUN conda install pip && pip install -r /bento/requirements.txt
 
 # Run Gunicorn server with path to module.
-CMD ["python /bento/{service_name}/__init__.py"]
+CMD ["bentoml serve-gunicorn /bento"]
 """
 
 # TODO: improve this with import hooks PEP302?
 INIT_PY_TEMPLATE = """\
-from __future__ import unicode_literals
 import os
 import sys
-
-import argparse
-import multiprocessing
-import gunicorn.app.base
-from gunicorn.six import iteritems
 
 from bentoml import archive
 from bentoml.server import BentoAPIServer
@@ -139,48 +133,7 @@ def load():
     return archive.load(__module_path)
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument('-p', '--port')
-parser.add_argument('-w', '--workers')
-
-
-class GunicornApplication(gunicorn.app.base.BaseApplication):
-    def __init__(self, app, args=None):
-        if args:
-            parsed_args = parser.parse_args(args)
-            print(parsed_args)
-            self.options = {{}}
-            if parsed_args.workers:
-                self.options['workers'] = parsed_args.workers or (
-                    multiprocessing.cpu_count() // 2) + 1
-            if parsed_args.port:
-                self.options['bind'] = '%s:%s' % ('127.0.0.1', parsed_args.port) or '%s:%s' % (
-                    '127.0.0.1', '5000')
-        else:
-            self.options = {{
-                'workers': (multiprocessing.cpu_count() // 2) + 1,
-                'bind': '%s:%s' % ('127.0.0.1', '5000')
-            }}
-        self.application = app
-        super(GunicornApplication, self).__init__()
-
-    def load_config(self):
-        config = dict([(key, value) for key, value in iteritems(self.options)
-                       if key in self.cfg.settings and value is not None])
-        for key, value in iteritems(config):
-            self.cfg.set(key.lower(), value)
-
-    def load(self):
-        return self.application
-
-
 __all__ = ['__version__', '{service_name}', 'load']
-
-
-if __name__ == '__main__':
-    ms = load()
-    server = BentoAPIServer(ms)
-    GunicornApplication(server.app, sys.argv[1:]).run()
 """
 
 BENTOML_CONFIG_YAML_TEMPLATE = """\
@@ -308,8 +261,7 @@ def _save(bento_service, dst, version=None):
     with open(os.path.join(path, 'Dockerfile'), 'w') as f:
         f.write(
             BENTO_SERVER_SINGLE_MODEL_DOCKERFILE_TEMPLATE.format(
-                conda_env_name=bento_service.env.get_conda_env_name(),
-                service_name=bento_service.name))
+                conda_env_name=bento_service.env.get_conda_env_name()))
 
     # write bentoml.yml
     bentoml_yml_content = BENTOML_CONFIG_YAML_TEMPLATE.format(

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -21,8 +21,8 @@ from __future__ import print_function
 import json
 import click
 import multiprocessing
-import gunicorn.app.base
 
+import gunicorn.app.base
 from gunicorn.six import iteritems
 
 from bentoml.archive import load

--- a/bentoml/server/gunicorn_server.py
+++ b/bentoml/server/gunicorn_server.py
@@ -1,0 +1,47 @@
+import multiprocessing
+
+import gunicorn.app.base
+from gunicorn.six import iteritems
+
+
+def get_gunicorn_worker_count():
+    """
+    Generate an recommend gunicorn worker process count
+
+    Gunicorn's documentation recommand 2 times of cpu cores + 1.
+    For ml model serving, it might consumer more computing resources, therefore
+    we recommend half of the number of cpu cores + 1
+    """
+
+    return (multiprocessing.cpu_count() // 2) + 1
+
+
+class GunicornApplication(gunicorn.app.base.BaseApplication):  # pylint: disable=abstract-method
+    """
+    A custom Gunicorn application.
+
+    Usage::
+
+        >>> import GunicornApplication
+        >>>
+        >>> gunicorn_app = GunicornApplication(app, 5000, 2)
+        >>> gunicorn_app.run()
+
+    :param app: a Flask app, flask.Flask.app
+    :param port: the port you want to run gunicorn server on
+    :param workers: number of worker processes
+    """
+
+    def __init__(self, app, port, workers):
+        self.options = {'workers': workers, 'bind': '%s:%s' % ('127.0.0.1', port)}
+        self.application = app
+        super(GunicornApplication, self).__init__()
+
+    def load_config(self):
+        config = dict([(key, value) for key, value in iteritems(self.options)
+                       if key in self.cfg.settings and value is not None])
+        for key, value in iteritems(config):
+            self.cfg.set(key.lower(), value)
+
+    def load(self):
+        return self.application

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ install_requires = [
     'Werkzeug',
     'pathlib2',
     'requests',
-    'packaging',
-    'gunicorn'
+    'packaging'
 ]
 
 dev_requires = [
@@ -43,8 +42,9 @@ dev_requires = [
 cv2 = [ 'opencv-python' ]
 pytorch  = [ 'torch', 'torchvision' ]
 tensorflow = [ 'tensorflow' ]
+gunicorn = [ 'gunicorn' ]
 
-optional_requires = cv2 + pytorch + tensorflow
+optional_requires = cv2 + pytorch + tensorflow + gunicorn
 dev_all = install_requires + dev_requires + optional_requires
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ install_requires = [
     'Werkzeug',
     'pathlib2',
     'requests',
-    'packaging'
+    'packaging',
+    'gunicorn'
 ]
 
 dev_requires = [


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
* Use gunicon instead of flask for DockerFile
  - take 2 optional arguments
    1. -w, --workers, default number of core / 2 + 1
    2. -p, --port, default 5000

```bash
cd archive_path
python __init__.py --port 4000 --workers 3
```

Does this close any currently open issues?
------------------------------------------


How was this patch tested?
--------------------------
