### PR TITLE
fix python requirement layer issue

### DIFF
--- a/bentoml/deployment/aws_lambda_template.py
+++ b/bentoml/deployment/aws_lambda_template.py
@@ -73,7 +73,7 @@ def generate_serverless_configuration_for_aws(apis, output_path, additional_opti
         function_config = {
             'handler': 'handler.{name}'.format(name=api.name),
             'layers': [
-                '{Ref: PythonRequirementsLambdaLayer}'
+                {"Ref": "PythonRequirementsLambdaLayer"}
             ],
             'events': [{
                 'http': {


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
This fix issue for deployoing to aws lambda.  It will use the correct name for layers that generated by python-requirements plugin

Does this close any currently open issues?
------------------------------------------


How was this patch tested?
--------------------------
