### PR TITLE
Deploy to AWS Sagemaker

### DIFF
--- a/bentoml/archive/archiver.py
+++ b/bentoml/archive/archiver.py
@@ -28,7 +28,8 @@ from bentoml.utils.s3 import is_s3_url, upload_to_s3
 from bentoml.utils.tempdir import TempDirectory
 from bentoml.archive.py_module_utils import copy_used_py_modules
 from bentoml.archive.templates import BENTO_MODEL_SETUP_PY_TEMPLATE, \
-    MANIFEST_IN_TEMPLATE, BENTO_SERVICE_DOCKERFILE_CPU_TEMPLATE, INIT_PY_TEMPLATE
+    MANIFEST_IN_TEMPLATE, BENTO_SERVICE_DOCKERFILE_CPU_TEMPLATE, \
+    BENTO_SERVICE_DOCKERFILE_SAGEMAKER_TEMPLATE, INIT_PY_TEMPLATE
 from bentoml.archive.config import BentoArchiveConfig
 
 DEFAULT_BENTO_ARCHIVE_DESCRIPTION = """\
@@ -146,6 +147,8 @@ def _save(bento_service, dst, version=None):
     # write Dockerfile
     with open(os.path.join(path, 'Dockerfile'), 'w') as f:
         f.write(BENTO_SERVICE_DOCKERFILE_CPU_TEMPLATE)
+    with open(os.path.join(path, 'Dockerfile-sagemaker'), 'w') as f:
+        f.write(BENTO_SERVICE_DOCKERFILE_SAGEMAKER_TEMPLATE)
 
     # write bentoml.yml
     config = BentoArchiveConfig()

--- a/bentoml/archive/templates.py
+++ b/bentoml/archive/templates.py
@@ -106,13 +106,14 @@ EXPOSE 8080
 
 RUN set -x \
      && apt-get update \
-     && apt-get install --no-install-recommends --no-install-suggests -y libpq-dev build-essential \
+     && apt-get install --no-install-recommends --no-install-suggests -y libpq-dev build-essential\
+     && apt-get install -y nginx \
      && rm -rf /var/lib/apt/lists/*
 
 # update conda and setup environment and pre-install common ML libraries to speed up docker build
 RUN conda update conda -y \
       && conda install pip numpy scipy \
-      && pip install gunicorn six
+      && pip install gunicorn six gevent
 
 # copy over model files
 COPY . /bento
@@ -124,9 +125,6 @@ RUN pip install -r /bento/requirements.txt
 
 # run user defined setup script
 RUN if [ -f /bento/setup.sh ]; then /bin/bash -c /bento/setup.sh; fi
-
-# Run Gunicorn server with path to module.
-CMD ["bentoml serve-sagemaker /bento"]
 """
 
 INIT_PY_TEMPLATE = """\

--- a/bentoml/archive/templates.py
+++ b/bentoml/archive/templates.py
@@ -125,6 +125,8 @@ RUN pip install -r /opt/program/requirements.txt
 
 # run user defined setup script
 RUN if [ -f /opt/program/setup.sh ]; then /bin/bash -c /opt/program/setup.sh; fi
+
+ENV PATH="/opt/program:${PATH}"
 """
 
 INIT_PY_TEMPLATE = """\

--- a/bentoml/archive/templates.py
+++ b/bentoml/archive/templates.py
@@ -99,6 +99,36 @@ RUN if [ -f /bento/setup.sh ]; then /bin/bash -c /bento/setup.sh; fi
 CMD ["bentoml serve-gunicorn /bento"]
 """
 
+BENTO_SERVICE_DOCKERFILE_SAGEMAKER_TEMPLATE = """\
+FROM continuumio/miniconda3
+
+EXPOSE 8080
+
+RUN set -x \
+     && apt-get update \
+     && apt-get install --no-install-recommends --no-install-suggests -y libpq-dev build-essential \
+     && rm -rf /var/lib/apt/lists/*
+
+# update conda and setup environment and pre-install common ML libraries to speed up docker build
+RUN conda update conda -y \
+      && conda install pip numpy scipy \
+      && pip install gunicorn six
+
+# copy over model files
+COPY . /bento
+WORKDIR /bento
+
+# update conda base env
+RUN conda env update -n base -f /bento/environment.yml
+RUN pip install -r /bento/requirements.txt
+
+# run user defined setup script
+RUN if [ -f /bento/setup.sh ]; then /bin/bash -c /bento/setup.sh; fi
+
+# Run Gunicorn server with path to module.
+CMD ["bentoml serve-sagemaker /bento"]
+"""
+
 INIT_PY_TEMPLATE = """\
 import os
 import sys

--- a/bentoml/archive/templates.py
+++ b/bentoml/archive/templates.py
@@ -116,15 +116,15 @@ RUN conda update conda -y \
       && pip install gunicorn six gevent
 
 # copy over model files
-COPY . /bento
-WORKDIR /bento
+COPY . /opt/program
+WORKDIR /opt/program
 
 # update conda base env
-RUN conda env update -n base -f /bento/environment.yml
-RUN pip install -r /bento/requirements.txt
+RUN conda env update -n base -f /opt/program/environment.yml
+RUN pip install -r /opt/program/requirements.txt
 
 # run user defined setup script
-RUN if [ -f /bento/setup.sh ]; then /bin/bash -c /bento/setup.sh; fi
+RUN if [ -f /opt/program/setup.sh ]; then /bin/bash -c /opt/program/setup.sh; fi
 """
 
 INIT_PY_TEMPLATE = """\

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -183,7 +183,7 @@ def cli():
             raise BentoMLException('Remove deployment with --platform=%s' % platform +
                                    'is not supported in the current version of BentoML')
         result = deployment.delete()
-        if result is True:
+        if result:
             display_bentoml_cli_message(
                 'Delete {platform} deployment successful'.format(platform=platform))
         else:

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -34,9 +34,11 @@ from bentoml.utils.exceptions import BentoMLException
 
 SERVERLESS_PLATFORMS = ['aws-lambda', 'aws-lambda-py2', 'gcp-function']
 
+
 class CLI_MESSAGE_TYPE(Enum):
     SUCCESS = 1
     ERROR = 2
+
 
 def display_bentoml_cli_message(message, message_type=CLI_MESSAGE_TYPE.SUCCESS):
     if message_type == CLI_MESSAGE_TYPE.SUCCESS:
@@ -188,7 +190,8 @@ def cli():
                 'Delete {platform} deployment successful'.format(platform=platform))
         else:
             display_bentoml_cli_message(
-                'Delete {platform} deployment unsuccessful'.format(platform=platform), CLI_MESSAGE_TYPE.ERROR)
+                'Delete {platform} deployment unsuccessful'.format(platform=platform),
+                CLI_MESSAGE_TYPE.ERROR)
         return
 
     # Example usage: bentoml check-deployment-status ARCHIVE_PATH --platform=aws-lambda

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -21,10 +21,6 @@ from __future__ import print_function
 import json
 import click
 
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-
 from bentoml.archive import load
 from bentoml.server import BentoAPIServer
 from bentoml.server.bento_sagemaker_server import BentoSagemakerServer

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -21,6 +21,8 @@ from __future__ import print_function
 import json
 import click
 
+from enum import Enum
+
 from bentoml.archive import load
 from bentoml.server import BentoAPIServer
 from bentoml.server.bento_sagemaker_server import BentoSagemakerServer
@@ -32,11 +34,14 @@ from bentoml.utils.exceptions import BentoMLException
 
 SERVERLESS_PLATFORMS = ['aws-lambda', 'aws-lambda-py2', 'gcp-function']
 
+class CLI_MESSAGE_TYPE(Enum):
+    SUCCESS = 1
+    ERROR = 2
 
-def display_bentoml_cli_message(message, message_type='success'):
-    if message_type == 'success':
+def display_bentoml_cli_message(message, message_type=CLI_MESSAGE_TYPE.SUCCESS):
+    if message_type == CLI_MESSAGE_TYPE.SUCCESS:
         color = 'green'
-    elif message_type == 'error':
+    elif message_type == CLI_MESSAGE_TYPE.ERROR:
         color = 'red'
     else:
         color = 'green'
@@ -155,11 +160,9 @@ def cli():
                                    'in the current version of BentoML')
         output_path = deployment.deploy()
 
-        display_bentoml_cli_message('Deploy to {platform} complete!'.format(platform=platform),
-                                    'success')
+        display_bentoml_cli_message('Deploy to {platform} complete!'.format(platform=platform))
         display_bentoml_cli_message(
-            'Deployment archive is saved at {output_path}'.format(output_path=output_path),
-            'success')
+            'Deployment archive is saved at {output_path}'.format(output_path=output_path))
         return
 
     # Example usage: bentoml delete-deployment ARCHIVE_PATH --platform=aws-lambda
@@ -182,10 +185,10 @@ def cli():
         result = deployment.delete()
         if result is True:
             display_bentoml_cli_message(
-                'Delete {platform} deployment successful'.format(platform=platform), 'success')
+                'Delete {platform} deployment successful'.format(platform=platform))
         else:
             display_bentoml_cli_message(
-                'Delete {platform} deployment unsuccessful'.format(platform=platform), 'error')
+                'Delete {platform} deployment unsuccessful'.format(platform=platform), CLI_MESSAGE_TYPE.ERROR)
         return
 
     # Example usage: bentoml check-deployment-status ARCHIVE_PATH --platform=aws-lambda

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -36,6 +36,16 @@ from bentoml.utils.exceptions import BentoMLException
 
 SERVERLESS_PLATFORMS = ['aws-lambda', 'aws-lambda-py2', 'gcp-function']
 
+def display_bentoml_cli_message(message, message_type='success'):
+    if message_type == 'success':
+        color = 'green'
+    elif message_type == 'error':
+        color = 'red'
+    else:
+        color = 'green'
+    click.echo('BentoML: ', nl=False)
+    click.secho(message, fg=color)
+
 
 def create_bentoml_cli(installed_archive_path=None):
     # pylint: disable=unused-variable
@@ -139,7 +149,7 @@ def cli():
     @click.option('--initial-instance-count', type=click.INT)
     def deploy(archive_path, platform, region, stage, api_name, instance_type, initial_instance_count):
         if platform in SERVERLESS_PLATFORMS:
-            deployment = ServerlessDeployment(platform, archive_path, region, stage)
+            deployment = ServerlessDeployment(archive_path, platform, region, stage)
         elif platform == 'aws-sagemaker':
             deployment = SagemakerDeployment(archive_path, api_name, region, initial_instance_count, instance_type)
         else:
@@ -147,12 +157,12 @@ def cli():
                 'Deploying with "--platform=%s" is not supported ' % platform +
                 'in the current version of BentoML'
                 )
-
         output_path = deployment.deploy()
-        click.echo('BentoML: ', nl=False)
-        click.secho('Deploy to {platform} complete!'.format(platform=platform), fg='green')
-        click.secho('Deployment archive is saved at {output_path}'.format(output_path=output_path),
-                    fg='green')
+
+        display_bentoml_cli_message(
+            'Deploy to {platform} complete!'.format(platform=platform), 'success')
+        display_bentoml_cli_message(
+            'Deployment archive is saved at {output_path}'.format(output_path=output_path), 'success')
         return
 
     # Example usage: bentoml delete-deployment ARCHIVE_PATH --platform=aws-lambda
@@ -162,16 +172,23 @@ def cli():
         'aws-lambda', 'aws-lambda-py2', 'gcp-function', 'aws-sagemaker', 'azure-ml', 'algorithmia'
     ]), required=True)
     @click.option('--region', type=click.STRING, required=True)
+    @click.option('--api-name', type=click.STRING)
     @click.option('--stage', type=click.STRING)
-    def delete_deployment(archive_path, platform, region, stage):
+    def delete_deployment(archive_path, platform, region, stage, api_name):
         if platform in SERVERLESS_PLATFORMS:
-            deployment = ServerlessDeployment(platform, archive_path, region, stage)
+            deployment = ServerlessDeployment(archive_path, platform, region, stage)
+        elif platform == 'aws-sagemaker':
+            deployment = SagemakerDeployment(archive_path, api_name, region)
         else:
             raise BentoMLException(
                 'Remove deployment with --platform=%s' % platform +
                 'is not supported in the current version of BentoML'
                 )
-        deployment.delete()
+        result = deployment.delete()
+        if result is True:
+            display_bentoml_cli_message('Delete {platform} deployment successful'.format(platform=platform), 'success')
+        else:
+            display_bentoml_cli_message('Delete {platform} deployment unsuccessful'.format(platform=platform), 'error')
         return
 
     # Example usage: bentoml check-deployment-status ARCHIVE_PATH --platform=aws-lambda
@@ -182,9 +199,12 @@ def cli():
     ]), required=True)
     @click.option('--region', type=click.STRING, required=True)
     @click.option('--stage', type=click.STRING)
-    def check_deployment_status(archive_path, platform, region, stage):
+    @click.option('--api-name', type=click.STRING)
+    def check_deployment_status(archive_path, platform, region, stage, api_name):
         if platform in SERVERLESS_PLATFORMS:
-            deployment = ServerlessDeployment(platform, archive_path, region, stage)
+            deployment = ServerlessDeployment(archive_path, platform, region, stage)
+        elif platform == 'aws-sagemaker':
+            deployment = SagemakerDeployment(archive_path, api_name, region)
         else:
             raise BentoMLException(
                 'check deployment status with --platform=%s' % platform +

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -31,7 +31,7 @@ from bentoml.server.bento_sagemaker_server import BentoSagemakerServer
 from bentoml.server.gunicorn_server import GunicornApplication, get_gunicorn_worker_count
 from bentoml.cli.click_utils import DefaultCommandGroup, conditional_argument
 from bentoml.deployment.serverless import ServerlessDeployment
-from bentoml.deployment.sagemaker import deploy_with_sagemaker
+from bentoml.deployment.sagemaker import SagemakerDeployment
 from bentoml.utils.exceptions import BentoMLException
 
 SERVERLESS_PLATFORMS = ['aws-lambda', 'aws-lambda-py2', 'gcp-function']
@@ -135,14 +135,13 @@ def cli():
     @click.option('--region', type=click.STRING)
     @click.option('--stage', type=click.STRING)
     @click.option('--api-name', type=click.STRING)
-    def deploy(archive_path, platform, region, stage, api_name):
+    @click.option('--instance-type', type=click.STRING)
+    @click.option('--initial-instance-count', type=click.INT)
+    def deploy(archive_path, platform, region, stage, api_name, instance_type, initial_instance_count):
         if platform in SERVERLESS_PLATFORMS:
             deployment = ServerlessDeployment(platform, archive_path, region, stage)
         elif platform == 'aws-sagemaker':
-            deploy_with_sagemaker(archive_path, {'region': region, 'api_name': api_name})
-            click.echo('BentoML: ', nl=False)
-            click.secho('Deploy to {platform} complete!'.format(platform=platform), fg='green')
-            return
+            deployment = SagemakerDeployment(archive_path, api_name, region, initial_instance_count, instance_type)
         else:
             raise BentoMLException(
                 'Deploying with "--platform=%s" is not supported ' % platform +

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -21,10 +21,6 @@ from __future__ import print_function
 import json
 import click
 
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-
 from bentoml.archive import load
 from bentoml.server import BentoAPIServer
 from bentoml.server.bento_sagemaker_server import BentoSagemakerServer
@@ -35,6 +31,7 @@ from bentoml.deployment.sagemaker import SagemakerDeployment
 from bentoml.utils.exceptions import BentoMLException
 
 SERVERLESS_PLATFORMS = ['aws-lambda', 'aws-lambda-py2', 'gcp-function']
+
 
 def display_bentoml_cli_message(message, message_type='success'):
     if message_type == 'success':
@@ -146,23 +143,23 @@ def cli():
     @click.option('--stage', type=click.STRING)
     @click.option('--api-name', type=click.STRING)
     @click.option('--instance-type', type=click.STRING)
-    @click.option('--initial-instance-count', type=click.INT)
-    def deploy(archive_path, platform, region, stage, api_name, instance_type, initial_instance_count):
+    @click.option('--instance-count', type=click.INT)
+    def deploy(archive_path, platform, region, stage, api_name, instance_type, instance_count):
         if platform in SERVERLESS_PLATFORMS:
             deployment = ServerlessDeployment(archive_path, platform, region, stage)
         elif platform == 'aws-sagemaker':
-            deployment = SagemakerDeployment(archive_path, api_name, region, initial_instance_count, instance_type)
+            deployment = SagemakerDeployment(archive_path, api_name, region, instance_count,
+                                             instance_type)
         else:
-            raise BentoMLException(
-                'Deploying with "--platform=%s" is not supported ' % platform +
-                'in the current version of BentoML'
-                )
+            raise BentoMLException('Deploying with "--platform=%s" is not supported ' % platform +
+                                   'in the current version of BentoML')
         output_path = deployment.deploy()
 
+        display_bentoml_cli_message('Deploy to {platform} complete!'.format(platform=platform),
+                                    'success')
         display_bentoml_cli_message(
-            'Deploy to {platform} complete!'.format(platform=platform), 'success')
-        display_bentoml_cli_message(
-            'Deployment archive is saved at {output_path}'.format(output_path=output_path), 'success')
+            'Deployment archive is saved at {output_path}'.format(output_path=output_path),
+            'success')
         return
 
     # Example usage: bentoml delete-deployment ARCHIVE_PATH --platform=aws-lambda
@@ -180,15 +177,15 @@ def cli():
         elif platform == 'aws-sagemaker':
             deployment = SagemakerDeployment(archive_path, api_name, region)
         else:
-            raise BentoMLException(
-                'Remove deployment with --platform=%s' % platform +
-                'is not supported in the current version of BentoML'
-                )
+            raise BentoMLException('Remove deployment with --platform=%s' % platform +
+                                   'is not supported in the current version of BentoML')
         result = deployment.delete()
         if result is True:
-            display_bentoml_cli_message('Delete {platform} deployment successful'.format(platform=platform), 'success')
+            display_bentoml_cli_message(
+                'Delete {platform} deployment successful'.format(platform=platform), 'success')
         else:
-            display_bentoml_cli_message('Delete {platform} deployment unsuccessful'.format(platform=platform), 'error')
+            display_bentoml_cli_message(
+                'Delete {platform} deployment unsuccessful'.format(platform=platform), 'error')
         return
 
     # Example usage: bentoml check-deployment-status ARCHIVE_PATH --platform=aws-lambda
@@ -206,10 +203,8 @@ def cli():
         elif platform == 'aws-sagemaker':
             deployment = SagemakerDeployment(archive_path, api_name, region)
         else:
-            raise BentoMLException(
-                'check deployment status with --platform=%s' % platform +
-                'is not supported in the current version of BentoML'
-                )
+            raise BentoMLException('check deployment status with --platform=%s' % platform +
+                                   'is not supported in the current version of BentoML')
 
         deployment.check_status()
         return

--- a/bentoml/deployment/base_deployment.py
+++ b/bentoml/deployment/base_deployment.py
@@ -37,12 +37,11 @@ class Deployment(object):
         """
         raise NotImplementedError
 
-    def check_status(self, display_cli_message=True):
+    def check_status(self):
         """Check deployment status
 
         :params
-        :display_cli_message: Boolean, default True
-        :return: Boolean, True if success
+        :return: Boolean, True if success Status Message String
         """
         raise NotImplementedError
 

--- a/bentoml/deployment/base_deployment.py
+++ b/bentoml/deployment/base_deployment.py
@@ -1,0 +1,52 @@
+# BentoML - Machine Learning Toolkit for packaging and deploying models
+# Copyright (C) 2019 Atalaya Tech, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from bentoml.archive import load
+
+class Deployment(object):
+    """Deployment is spec for describing what actions deployment should have
+    to interact with BentoML cli and BentoML service archive.
+    """
+
+    def __init__(self, archive_path):
+        self.bento_service = load(archive_path)
+        self.archive_path = archive_path
+
+    def deploy(self):
+        """Deploy bentoml service.
+
+        :return: Boolean, True if success
+        """
+        raise NotImplementedError
+
+    def check_status(self, display_cli_message=True):  
+        """Check deployment status
+
+        :params
+        :display_cli_message: Boolean, default True
+        :return: Boolean, True if success
+        """
+        raise NotImplementedError
+
+    def delete(self):
+        """Delete deployment, if deployment is active
+        :return: Boolean, True if success
+        """
+        raise NotImplementedError

--- a/bentoml/deployment/base_deployment.py
+++ b/bentoml/deployment/base_deployment.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 from bentoml.archive import load
 
+
 class Deployment(object):
     """Deployment is spec for describing what actions deployment should have
     to interact with BentoML cli and BentoML service archive.
@@ -36,7 +37,7 @@ class Deployment(object):
         """
         raise NotImplementedError
 
-    def check_status(self, display_cli_message=True):  
+    def check_status(self, display_cli_message=True):
         """Check deployment status
 
         :params

--- a/bentoml/deployment/sagemaker.py
+++ b/bentoml/deployment/sagemaker.py
@@ -1,0 +1,181 @@
+# BentoML - Machine Learning Toolkit for packaging and deploying models
+# Copyright (C) 2019 Atalaya Tech, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import shutil
+import base64
+import subprocess
+import logging
+import re
+from six.moves.urllib.parse import urlparse
+
+import boto3
+import docker
+
+from bentoml.archive import load
+from bentoml.deployment.utils import generate_bentoml_deployment_snapshot_path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REGION = 'us-west-2'
+DEFAULT_INSTANCE_TYPE = 'ml.m4.xlarge'
+DEFAULT_INITIAL_INSTANCE_COUNT = 1
+
+
+def strip_scheme(url):
+    """ Stripe url's schema
+    e.g.   http://some.url/path -> some.url/path
+    :param url: String
+    :return: String
+    """
+    parsed = urlparse(url)
+    scheme = "%s://" % parsed.scheme
+    return parsed.geturl().replace(scheme, '', 1)
+
+
+def generate_aws_compatible_string(item):
+    pattern = re.compile('[^a-zA-Z0-9-]|_')
+    return re.sub(pattern, '-', item)
+
+
+def get_arn_role_from_current_user():
+    sts_client = boto3.client("sts")
+    identity = sts_client.get_caller_identity()
+    sts_arn = identity["Arn"]
+    sts_arn_list = sts_arn.split(':')
+    type_role = sts_arn_list[-1].split('/')
+    iam_client = boto3.client("iam")
+    if type_role[0] == 'user':
+        role_list = iam_client.list_roles()
+        arn = None
+        for role in role_list['Roles']:
+            policy_document = role['AssumeRolePolicyDocument']
+            statement = policy_document['Statement'][0]
+            if statement['Effect'] == 'Allow' and statement['Principal'][
+                    'Service'] == 'sagemaker.amazonaws.com':
+                arn = role['Arn']
+        if arn is None:
+            raise ValueError(
+                "Can't find proper Arn role for Sagemaker, please create one and try again")
+        return arn
+    elif type_role[0] == 'role':
+        role_response = iam_client.get_role(RoleName=type_role[1])
+        return role_response["Role"]["Arn"]
+
+
+def create_push_image_to_ecr(bento_service, snapshot_path):
+    """Create BentoService sagemaker image and push to AWS ECR
+
+    :param bento_service: Bento Service
+    :param snapshot_path: Path
+    :return: ecr_tag: String
+    """
+
+    # Example:
+    # https://github.com/awslabs/amazon-sagemaker-examples/blob/master/advanced_functionality/scikit_bring_your_own/container/build_and_push.sh
+    # 1. get aws account info and login ecr
+    # 2. create ecr repository, if not exist
+    # 3. build tag and push docker image
+
+    ecr_client = boto3.client('ecr')
+    token = ecr_client.get_authorization_token()
+    logger.info('Getting docker login info from AWS')
+    username, password = base64.b64decode(
+        token['authorizationData'][0]['authorizationToken']).decode('utf-8').split(":")
+    registry_url = token['authorizationData'][0]['proxyEndpoint']
+
+    # https://github.com/docker/docker-py/issues/2256
+    subprocess.call(['docker', 'login', '-u', username, '-p', password, registry_url])
+    docker_client = docker.from_env()
+    docker_client.login(username, password, email='', registry=registry_url)
+
+    image_name = bento_service.name.lower() + '-sagemaker'
+    ecr_tag = strip_scheme('{registry_url}/{image_name}:{version}'.format(
+        registry_url=registry_url, image_name=image_name, version=bento_service.version))
+
+    try:
+        ecr_client.describe_repositories(repositoryNames=[image_name])['repositories']
+    except ecr_client.exceptions.RepositoryNotFoundException:
+        ecr_client.create_repository(repositoryName=image_name)
+
+    print('Building docker image: {}'.format(image_name))
+    built_image = docker_client.images.build(path=snapshot_path, tag=image_name)
+    built_image[0].tag(ecr_tag)
+    print('Pushing image to AWS ECR at {}'.format(ecr_tag))
+    docker_client.api.push(repository=ecr_tag)
+    print('Finished pushing image: {}'.format(ecr_tag))
+    return ecr_tag
+
+
+def deploy_with_sagemaker(archive_path, additional_info):
+    """Deploy BentoML service to AWS Sagemaker.
+    Your AWS credential must have the correct permissions for sagemaker and ECR
+
+    :param archive_path: Path
+    :param additional_info: Dict
+    :return:
+    """
+
+    # 1. Create docker image and push to ECR
+    # 2. Create sagemaker model base on the ECR image
+    # 2. Create sagemaker endpoint configuration base on sagemaker model
+    # 3. Create sagemaker endpoint base on sagemaker endpoint configuration
+    bento_service = load(archive_path)
+    snapshot_path = generate_bentoml_deployment_snapshot_path(bento_service.name, 'aws-sagemaker')
+    shutil.copytree(archive_path, snapshot_path)
+    region = additional_info.get('region', DEFAULT_REGION)
+    execution_role_arn = get_arn_role_from_current_user()
+    ecr_image_path = create_push_image_to_ecr(bento_service, snapshot_path)
+    sagemaker_model_name = generate_aws_compatible_string('bentoml-' + bento_service.name + '-' +
+                                                          bento_service.version)
+    sagemaker_client = boto3.client('sagemaker', region_name=region)
+
+    sagemaker_model_info = {
+        "ModelName": sagemaker_model_name,
+        "PrimaryContainer": {
+            "ContainerHostname": sagemaker_model_name,
+            "Image": ecr_image_path,
+        },
+        "ExecutionRoleArn": execution_role_arn,
+    }
+    print('Creating sagemaker model {}'.format(sagemaker_model_name))
+    model_response = sagemaker_client.create_model(**sagemaker_model_info)
+    logger.info(model_response)
+
+    endpoint_config_name = generate_aws_compatible_string(bento_service.name + '-' +
+                                                          bento_service.version + '-configuration')
+    production_variants = [{
+        "VariantName": bento_service.name,
+        "ModelName": sagemaker_model_name,
+        "InitialInstanceCount": DEFAULT_INITIAL_INSTANCE_COUNT,
+        "InstanceType": DEFAULT_INSTANCE_TYPE,
+    }]
+    print('Creating sagemaker endpoint {} configuration'.format(endpoint_config_name))
+    create_endpoint_config_response = sagemaker_client.create_endpoint_config(
+        EndpointConfigName=endpoint_config_name, ProductionVariants=production_variants)
+    logger.info(create_endpoint_config_response)
+    print('Creating sagemaker endpoint {}'.format(bento_service.name))
+    create_endpoint_response = sagemaker_client.create_endpoint(
+        EndpointName=bento_service.name, EndpointConfigName=endpoint_config_name)
+    logger.info(create_endpoint_response)
+
+    endpoint_status = sagemaker_client.describe_endpoint(EndpointName=bento_service.name)
+    logger.info(endpoint_status)
+    print(endpoint_status)
+    return

--- a/bentoml/deployment/sagemaker/templates.py
+++ b/bentoml/deployment/sagemaker/templates.py
@@ -64,7 +64,7 @@ from bentoml.archive import load
 from bentoml.server.bento_sagemaker_server import BentoSagemakerServer
 
 api_name = os.environ.get('API_NAME', None)
-model_service = load('/bento')
+model_service = load('/opt/program')
 server = BentoSagemakerServer(model_service, api_name)
 app = server.app
 """

--- a/bentoml/deployment/sagemaker/templates.py
+++ b/bentoml/deployment/sagemaker/templates.py
@@ -112,7 +112,7 @@ def _serve():
     subprocess.check_call(['ln', '-sf', '/dev/stdout', '/var/log/nginx/access.log'])
     subprocess.check_call(['ln', '-sf', '/dev/stderr', '/var/log/nginx/error.log'])
 
-    nginx = subprocess.Popen(['nginx', '-c', '/bento/nginx.conf'])
+    nginx = subprocess.Popen(['nginx', '-c', '/opt/program/nginx.conf'])
     gunicorn_app = subprocess.Popen(['gunicorn',
                                      '--timeout', str(model_server_timeout),
                                      '-k', 'gevent',

--- a/bentoml/deployment/sagemaker/templates.py
+++ b/bentoml/deployment/sagemaker/templates.py
@@ -1,0 +1,135 @@
+# BentoML - Machine Learning Toolkit for packaging and deploying models
+# Copyright (C) 2019 Atalaya Tech, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DEFAULT_NGINX_CONFIG = """\
+worker_processes 1;
+daemon off; # Prevent forking
+
+pid /tmp/nginx.pid;
+error_log /var/log/nginx/error.log;
+
+events {
+  # defaults
+}
+
+http {
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+  access_log /var/log/nginx/access.log combined;
+  
+  upstream gunicorn {
+    server unix:/tmp/gunicorn.sock;
+  }
+
+  server {
+    listen 8080 deferred;
+    client_max_body_size 500m;
+
+    keepalive_timeout 5;
+    proxy_read_timeout 1200s;
+
+    location ~ ^/(ping|invocations) {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+      proxy_pass http://gunicorn;
+    }
+
+    location / {
+      return 404 "{}";
+    }
+  }
+}
+"""
+
+
+DEFAULT_WSGI_PY = """\
+import os
+
+from bentoml.archive import load
+from bentoml.server.bento_sagemaker_server import BentoSagemakerServer
+
+api_name = os.environ.get('API_NAME', None)
+model_service = load('/bento')
+server = BentoSagemakerServer(model_service, api_name)
+app = server.app
+"""
+
+
+DEFAULT_SERVE_SCRIPT = """\
+#!/usr/bin/env python
+
+# This implement the sagemaker serving service shell.  It starts nginx and gunicorn.
+# 
+# Parameter                    Env Var                          Default Value
+# number of workers            MODEL_SERVER_TIMEOUT             60s
+# timeout                      MODEL_SERVER_WORKERS             number of cpu cores / 2 + 1
+# api name                     API_NAME                         None
+
+import subprocess
+import os
+import signal
+import sys
+
+from bentoml.archive import load
+from bentoml.server.bento_sagemaker_server import BentoSagemakerServer
+from bentoml.server.gunicorn_server import GunicornApplication, get_gunicorn_worker_count
+
+
+model_server_timeout = os.environ.get('MODEL_SERVER_TIMEOUT', 60)
+model_server_workers = int(os.environ.get('MODEL_SERVER_WORKERS', get_gunicorn_worker_count()))
+
+
+def sigterm_handler(nginx_pid, gunicorn_pid):
+    try:
+        os.kill(nginx_pid, signal.SIGQUIT)
+    except OSError:
+        pass
+    try:
+        os.kill(gunicorn_pid, signal.SIGTERM)
+    except OSError:
+        pass
+    
+    sys.exit(0)
+
+
+def _serve():
+    # link the log streams to stdout/err so they will be logged to the container logs
+    subprocess.check_call(['ln', '-sf', '/dev/stdout', '/var/log/nginx/access.log'])
+    subprocess.check_call(['ln', '-sf', '/dev/stderr', '/var/log/nginx/error.log'])
+
+    nginx = subprocess.Popen(['nginx', '-c', '/bento/nginx.conf'])
+    gunicorn_app = subprocess.Popen(['gunicorn',
+                                     '--timeout', str(model_server_timeout),
+                                     '-k', 'gevent',
+                                     '-b', 'unix:/tmp/gunicorn.sock',
+                                     '-w', str(model_server_workers),
+                                     'wsgi:app'])
+    signal.signal(signal.SIGTERM, lambda a, b: sigterm_handler(nginx.pid, gunicorn_app.pid))
+
+    pids = set([nginx.pid, gunicorn_app.pid])
+    while True:
+        pid, _ = os.wait()
+        if pid in pids:
+            break
+    sigterm_handler(nginx.pid, gunicorn_app.pid)
+    print('Inference server exiting')
+
+
+if __name__ == '__main__':
+  _serve()
+"""

--- a/bentoml/deployment/sagemaker/templates.py
+++ b/bentoml/deployment/sagemaker/templates.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
 DEFAULT_NGINX_CONFIG = """\
 worker_processes 1;
 daemon off; # Prevent forking
@@ -30,7 +29,7 @@ http {
   include /etc/nginx/mime.types;
   default_type application/octet-stream;
   access_log /var/log/nginx/access.log combined;
-  
+
   upstream gunicorn {
     server unix:/tmp/gunicorn.sock;
   }
@@ -56,7 +55,6 @@ http {
 }
 """
 
-
 DEFAULT_WSGI_PY = """\
 import os
 
@@ -69,12 +67,10 @@ server = BentoSagemakerServer(model_service, api_name)
 app = server.app
 """
 
-
 DEFAULT_SERVE_SCRIPT = """\
 #!/usr/bin/env python
 
 # This implement the sagemaker serving service shell.  It starts nginx and gunicorn.
-# 
 # Parameter                    Env Var                          Default Value
 # number of workers            MODEL_SERVER_TIMEOUT             60s
 # timeout                      MODEL_SERVER_WORKERS             number of cpu cores / 2 + 1
@@ -103,7 +99,7 @@ def sigterm_handler(nginx_pid, gunicorn_pid):
         os.kill(gunicorn_pid, signal.SIGTERM)
     except OSError:
         pass
-    
+
     sys.exit(0)
 
 

--- a/bentoml/deployment/serverless/__init__.py
+++ b/bentoml/deployment/serverless/__init__.py
@@ -203,8 +203,8 @@ class ServerlessDeployment(Deployment):
                     return True, '\n'.join(response)
 
     def delete(self):
-        active_status, _ = self.check_status()
-        if not active_status:
+        is_active, _ = self.check_status()
+        if not is_active:
             raise BentoMLException('No active deployment for service %s' % self.bento_service.name)
 
         if self.platform == 'google-python':

--- a/bentoml/deployment/serverless/__init__.py
+++ b/bentoml/deployment/serverless/__init__.py
@@ -32,6 +32,7 @@ from bentoml.utils import Path
 from bentoml.utils.tempdir import TempDirectory
 from bentoml.utils.whichcraft import which
 from bentoml.utils.exceptions import BentoMLException
+from bentoml.deployment.base_deployment import Deployment
 from bentoml.deployment.serverless.aws_lambda_template import create_aws_lambda_bundle, \
     DEFAULT_AWS_DEPLOY_STAGE, DEFAULT_AWS_REGION
 from bentoml.deployment.serverless.gcp_function_template import create_gcp_function_bundle, \
@@ -77,17 +78,16 @@ def parse_serverless_response(serverless_response):
     return str_list
 
 
-class ServerlessDeployment(object):
+class ServerlessDeployment(Deployment):
     """Managing deployment operations for serverless
     """
 
-    def __init__(self, platform, archive_path, region, stage):
+    def __init__(self, archive_path, platform, region, stage):
         check_serverless_compatiable_version()
+        super(ServerlessDeployment, self).__init__(archive_path)
 
         self.platform = platform
         self.provider = SERVERLESS_PROVIDER[platform]
-        self.archive_path = archive_path
-        self.bento_service = load(archive_path)
         if platform == 'google-python':
             self.region = DEFAULT_GCP_REGION if region is None else region
             self.stage = DEFAULT_GCP_DEPLOY_STAGE if stage is None else stage
@@ -151,7 +151,7 @@ class ServerlessDeployment(object):
             logger.info('BentoML: %s', '\n'.join(service_info))
             return output_path
 
-    def check_status(self, display_info=True):
+    def check_status(self, display_cli_message=True):
         """Check deployment status for the bentoml service.
         return True, if it is active else return false
         """
@@ -200,12 +200,12 @@ class ServerlessDeployment(object):
                 if error:
                     return False
                 else:
-                    if display_info:
+                    if display_cli_message:
                         logger.info('BentoML: %s', '\n'.join(response))
                     return True
 
     def delete(self):
-        if not self.check_status(display_info=False):
+        if not self.check_status(display_cli_message=False):
             raise BentoMLException('No active deployment for service %s' % self.bento_service.name)
 
         if self.platform == 'google-python':

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -27,5 +27,5 @@ from bentoml.utils import Path
 
 def generate_bentoml_deployment_snapshot_path(service_name, platform):
     return os.path.join(
-        str(Path.home()), '.bentoml', 'deployment-snapshot', service_name, platform,
+        str(Path.home()), '.bentoml', 'deployment-snapshots', service_name, platform,
         datetime.now().isoformat())

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -20,12 +20,10 @@ from __future__ import print_function
 
 import os
 
-from datetime import datetime
-
 from bentoml.utils import Path
 
 
-def generate_bentoml_deployment_snapshot_path(service_name, platform):
+def generate_bentoml_deployment_snapshot_path(service_name, service_version, platform):
     return os.path.join(
-        str(Path.home()), '.bentoml', 'deployment-snapshots', service_name, platform,
-        datetime.now().isoformat())
+        str(Path.home()), '.bentoml', 'deployment-snapshots', platform, service_name,
+        service_version)

--- a/bentoml/server/__init__.py
+++ b/bentoml/server/__init__.py
@@ -21,7 +21,4 @@ from __future__ import print_function
 from bentoml.server.bento_api_server import BentoAPIServer
 from bentoml.server import metrics
 
-__all__ = [
-    'BentoAPIServer',
-    'metrics'
-]
+__all__ = ['BentoAPIServer', 'metrics']

--- a/bentoml/server/__init__.py
+++ b/bentoml/server/__init__.py
@@ -23,5 +23,5 @@ from bentoml.server import metrics
 
 __all__ = [
     'BentoAPIServer',
-    'metrics',
+    'metrics'
 ]

--- a/bentoml/server/bento_sagemaker_server.py
+++ b/bentoml/server/bento_sagemaker_server.py
@@ -22,9 +22,11 @@ from flask import Flask, Response, request
 
 
 def bento_sagemaker_api_wrapper(api):
+
     def wrapper():
         response = api.handle_request(request)
         return response
+
     return wrapper
 
 

--- a/bentoml/server/bento_sagemaker_server.py
+++ b/bentoml/server/bento_sagemaker_server.py
@@ -1,0 +1,67 @@
+# BentoML - Machine Learning Toolkit for packaging and deploying models
+# Copyright (C) 2019 Atalaya Tech, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from flask import Flask, Response, request
+
+
+def bento_sagemaker_api_wrapper(api):
+    def wrapper():
+        response = api.handle_request(request)
+        return response
+    return wrapper
+
+
+def setup_bento_service_api_route(app, api):
+    route_function = bento_sagemaker_api_wrapper(api)
+    app.add_url_rule(rule='/invocations/{}'.format(api.name), endpoint=api.name,
+                     view_func=route_function, methods=['POST'])
+
+
+def ping_view_func():
+    return Response(response='\n', status=200, mimetype='application/json')
+
+
+def setup_routes(app, bento_service):
+    """
+    Setup routes required for AWS sagemaker
+    /ping
+    /invocation
+    """
+    app.add_url_rule('/ping', 'ping', ping_view_func)
+    for api in bento_service.get_service_apis():
+        setup_bento_service_api_route(app, api)
+
+
+class BentoSagemakerServer():
+    """
+    BentoSagemakerServer create an AWS sagemaker compatibility reset server.
+    """
+
+    _DEFAULT_PORT = 8080
+
+    def __init__(self, bento_service, app_name=None):
+        app_name = bento_service.name if app_name is None else app_name
+
+        self.bento_service = bento_service
+        self.app = Flask(app_name)
+        setup_routes(self.app, self.bento_service)
+
+    def start(self):
+        self.app.run(port=BentoSagemakerServer._DEFAULT_PORT)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ install_requires = [
     'Werkzeug',
     'pathlib2',
     'requests',
-    'packaging'
+    'packaging',
+    'docker'
 ]
 
 dev_requires = [


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
Add Sagemaker as a new platform target for BentoML deployment.
```bash
bentoml deploy /ARCHIVE_PATH --platform=aws-sagemaker
```

Does this close any currently open issues?
------------------------------------------
https://github.com/bentoml/BentoML/issues/52

How was this patch tested?
--------------------------
