### PR TITLE
fix templates for serverless platform

### DIFF
--- a/bentoml/deployment/serverless/aws_lambda_template.py
+++ b/bentoml/deployment/serverless/aws_lambda_template.py
@@ -32,20 +32,22 @@ logger = logging.getLogger(__name__)
 
 AWS_HANDLER_PY_TEMPLATE_HEADER = """\
 try:
-    import unzip_requirements:
+    import unzip_requirements
 except ImportError:
     pass
 
-import {class_name}
+from {class_name} import {class_name}
 
 bento_service = {class_name}.load()
+apis = bento_service.get_service_apis()
 
 """
 
-AWS_FUNCTION_TEMPLATE = """
+AWS_FUNCTION_TEMPLATE = """\
 def {api_name}(event, context):
-    result = bento_service.{api_name}.handle_aws_lambda_event(event)
+    api = next(item for item in apis if item.name == '{api_name}')
 
+    result = api.handle_aws_lambda_event(request)
     return result
 
 """

--- a/bentoml/deployment/serverless/gcp_function_template.py
+++ b/bentoml/deployment/serverless/gcp_function_template.py
@@ -31,15 +31,18 @@ DEFAULT_GCP_DEPLOY_STAGE = 'dev'
 logger = logging.getLogger(__name__)
 
 GOOGLE_MAIN_PY_TEMPLATE_HEADER = """\
-import {class_name}
+from {class_name} import {class_name}
 
 bento_service = {class_name}.load()
+apis = bento_service.get_service_apis()
 
 """
 
-GOOGLE_FUNCTION_TEMPLATE = """
+GOOGLE_FUNCTION_TEMPLATE = """\
 def {api_name}(request):
-    result = bento_service.{api_name}.handle_request(request)
+    api = next(item for item in apis if item.name == '{api_name}')
+
+    result = api.handle_request(request)
     return result
 
 """


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
* remove extra `:` at end of importing unzip_requirements for aws handler
* correctly import BentoML service

Does this close any currently open issues?
------------------------------------------


How was this patch tested?
--------------------------
