### PR TITLE
Specify api_server deps separately

### DIFF
--- a/bentoml/service_env.py
+++ b/bentoml/service_env.py
@@ -35,7 +35,7 @@ dependencies:
   - python={python_version}
   - pip
   - pip:
-    - bentoml=={bentoml_version}
+    - bentoml[api_server]=={bentoml_version}
 """
 
 CONDA_ENV_DEFAULT_NAME = 'bentoml-custom-conda-env'

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ install_requires = [
     "click",
     "pandas",
     "dill",
+    "prometheus_client",
     "python-json-logger",
     "boto3",
     "pathlib2",

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ tests_require += cv2
 
 extras_require = {
     "all": dev_all,
+    "api_server": api_server,
     "dev": dev_requires,
     "pytorch": pytorch,
     "tensorflow": tensorflow,

--- a/setup.py
+++ b/setup.py
@@ -12,67 +12,73 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import os
 import sys
 import imp
 import setuptools
 
 __version__ = imp.load_source(
-        'bentoml.version', os.path.join('bentoml', 'version.py')).__version__
+    "bentoml.version", os.path.join("bentoml", "version.py")
+).__version__
 
 with open("README.md", "r") as f:
     long_description = f.read()
 
 install_requires = [
-    'prometheus_client',
-    'ruamel.yaml>=0.15.0',
-    'numpy',
-    'flask',
-    'gunicorn',
-    'six',
-    'click',
-    'pandas',
-    'dill',
-    'python-json-logger',
-    'boto3',
-    'Werkzeug',
-    'pathlib2',
-    'requests',
-    'packaging',
-    'docker'
+    "ruamel.yaml>=0.15.0",
+    "numpy",
+    "flask",
+    "gunicorn",
+    "six",
+    "click",
+    "pandas",
+    "dill",
+    "python-json-logger",
+    "boto3",
+    "pathlib2",
+    "requests",
+    "packaging",
+    "docker",
 ]
 
 dev_requires = [
-    'tox==3.8.4',
-    'yapf==0.26.0',
-    'pylint==2.3.1',
-    'pytest==4.4.0',
-    'tox-conda==0.2.0',
-    'twine',
-    'setuptools',
-    'pycodestyle',
-    'gitpython>=2.0.2'
+    "yapf==0.26.0",
+    "pylint==2.3.1",
+    "pytest==4.4.0",
+    "tox-conda==0.2.0",
+    "twine",
+    "setuptools",
+    "pycodestyle",
+    "gitpython>=2.0.2",
 ]
 
-cv2 = [ 'opencv-python' ]
-pytorch  = [ 'torch', 'torchvision' ]
-tensorflow = [ 'tensorflow' ]
-gunicorn = [ 'gunicorn' ]
+cv2 = ["opencv-python"]
+pytorch = ["torch", "torchvision"]
+tensorflow = ["tensorflow"]
+api_server = ["gunicorn", "prometheus_client", "Werkzeug"]
 
-optional_requires = cv2 + pytorch + tensorflow + gunicorn
+optional_requires = api_server + cv2 + pytorch + tensorflow
 dev_all = install_requires + dev_requires + optional_requires
 
 tests_require = [
-    'pytest==4.4.0',
-    'snapshottest==0.5.0',
-    'mock==2.0.0',
-    'tox==3.8.4',
-    'pytest-cov',
-    'coverage',
-    'codecov'
+    "pytest==4.4.0",
+    "snapshottest==0.5.0",
+    "mock==2.0.0",
+    "tox==3.8.4",
+    "pytest-cov",
+    "coverage",
+    "codecov",
 ]
 tests_require += cv2
+
+extras_require = {
+    "all": dev_all,
+    "dev": dev_requires,
+    "pytorch": pytorch,
+    "tensorflow": tensorflow,
+    "cv2": cv2,
+    "test": tests_require,
+}
 
 setuptools.setup(
     name="BentoML",
@@ -83,35 +89,29 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=install_requires,
-    extras_require={
-        'all': dev_all,
-        'dev': dev_requires,
-        'pytorch': pytorch,
-        'tensorflow': tensorflow,
-        'cv2': cv2,
-        'test': tests_require,
-    },
+    extras_require=extras_require,
     url="https://github.com/bentoml/BentoML",
-    packages=setuptools.find_packages(exclude=['tests*']),
+    packages=setuptools.find_packages(exclude=["tests*"]),
     classifiers=[
         "Programming Language :: Python :: 2.7",
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
         "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent"
+        "Operating System :: OS Independent",
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     entry_points={
-        'console_scripts': [
-            'bentoml=bentoml.cli:cli',
-        ],
+        "console_scripts": [
+            "bentoml=bentoml.cli:cli"
+        ]
     },
     project_urls={
-        'Bug Reports': 'https://github.com/bentoml/BentoML/issues',
-        'Source Code': 'https://github.com/bentoml/BentoML'
-    }
+        "Bug Reports": "https://github.com/bentoml/BentoML/issues",
+        "Source Code": "https://github.com/bentoml/BentoML",
+        "Gitter Chat Room": "https://gitter.im/bentoml/BentoML",
+    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,5 @@ deps =
   pytest
   mock
   opencv-python
+  docker
 commands = pytest


### PR DESCRIPTION
Use  ```pip install bentoml[api_server]``` when building API server image, which will install extra deps including gunicorn