### PR TITLE
0.2.1 Beta Release

### DIFF
--- a/bentoml/version.py
+++ b/bentoml/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,6 +4,7 @@ set -e
 GIT_ROOT=$(git rev-parse --show-toplevel)
 cd $GIT_ROOT
 
+
 # Currently only BentoML maintainer has permission to create new pypi
 # releases
 if [ ! -f $HOME/.pypirc ]; then
@@ -11,6 +12,12 @@ if [ ! -f $HOME/.pypirc ]; then
   # https://docs.python.org/3/distutils/packageindex.html#the-pypirc-file
   echo "Error: File \$HOME/.pypirc not found."
   exit
+fi
+
+
+if [ -d $GIT_ROOT/dist ]; then
+  echo "Removing existing 'dist' directory"
+  rm -rf $GIT_ROOT/dist
 fi
 
 echo "Installing dev dependencies..."


### PR DESCRIPTION
Release notes:
* Improved inline python docs and new documentation site launched https://bentoml.readthedocs.io
* Support running examples on google colab
* OpenAPI docs endpoint beta
* Configurable prediction and feedback logging in API server
* Serverless deployment improved
* Bug fixes
