### PR TITLE
Add CLI docs command to display docs.

### DIFF
--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -20,7 +20,7 @@ import json
 import click
 
 from bentoml.archive import load
-from bentoml.server import BentoAPIServer
+from bentoml.server import BentoAPIServer, get_docs
 from bentoml.server.gunicorn_server import (
     GunicornApplication,
     get_gunicorn_worker_count,
@@ -104,6 +104,15 @@ def create_bento_service_cli(archive_path=None):
             indent=2,
         )
         print(output)
+
+    # Example usage: bentoml docs /SAVED_ARCHIVE_PATH
+    @bentoml_cli.command(
+        help="Display API documents in Open API format", short_help="Display docs"
+    )
+    @conditional_argument(archive_path is None, "archive-path", type=click.STRING)
+    def docs(archive_path=archive_path):
+        model_service = load(archive_path)
+        print(json.dumps(get_docs(model_service), indent=2))
 
     # Example Usage: bentoml serve ./SAVED_ARCHIVE_PATH --port=PORT
     @bentoml_cli.command(

--- a/bentoml/server/__init__.py
+++ b/bentoml/server/__init__.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from bentoml.server.bento_api_server import BentoAPIServer
+from bentoml.server.bento_api_server import BentoAPIServer, get_docs
 from bentoml.server import metrics
 
-__all__ = ["BentoAPIServer", "metrics"]
+__all__ = ["BentoAPIServer", "metrics", "get_docs"]

--- a/bentoml/server/bento_api_server.py
+++ b/bentoml/server/bento_api_server.py
@@ -87,7 +87,7 @@ def index_view_func(bento_service):
     )
 
 
-def docs_view_func(bento_service):
+def get_docs(bento_service):
     """
     The docs for all endpoints in Open API format.
     """
@@ -149,7 +149,11 @@ def docs_view_func(bento_service):
         )
 
     docs["paths"] = paths
+    return docs
 
+
+def docs_view_func(bento_service):
+    docs = get_docs(bento_service)
     return jsonify(docs)
 
 

--- a/tests/test_pip_install_bento_archive.py
+++ b/tests/test_pip_install_bento_archive.py
@@ -37,3 +37,7 @@ def test_pip_install_bento_archive(bento_archive_path, tmpdir):
     assert output["name"] == "TestBentoService"
     assert output["version"] == svc.version
     assert "predict" in output["apis"]
+
+    output = subprocess.check_output([cli_bin_path, "docs"], env=env).decode()
+    output = json.loads(output)
+    assert output["info"]["version"] == svc.version


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below.)

What changes were proposed in this pull request?
------------------------------------------------
Add CLI

Does this close any currently open issues?
------------------------------------------
Nope

How was this patch tested?
--------------------------
Tested locally.

```
$IrisClassifier docs
{
  "openapi": "3.0.0",
  "info": {
    "version": "2019_06_29_cb4814c7",
    "title": "IrisClassifier",
    "description": "To get a client SDK, copy all content from <a href=\"/docs.json\">docs</a> and paste into <a href=\"https://editor.swagger.io\">editor.swagger.io</a> then click the tab <strong>Generate Client</strong> and choose the language."
  },
  "tags": [
    {
      "name": "infra"
    },
    {
      "name": "app"
    }
  ],
  "paths": {
    "/healthz": {
      "get": {
        "tags": [
          "infra"
        ],
        "description": "Health check endpoint. Expecting an empty response with status code 200 when the service is in health state",
        "responses": {
          "200": {
            "description": "success"
          }
        }
      }
    },
    "/metrics": {
      "get": {
        "tags": [
          "infra"
        ],
        "description": "Prometheus metrics endpoint",
        "responses": {
          "200": {
            "description": "success"
          }
        }
      }
    },
    "/feedback": {
      "get": {
        "tags": [
          "infra"
        ],
        "description": "Predictions feedback endpoint. Expecting feedback request in JSON format and must contain a `request_id` field, which can be obtained from any BentoService API response header",
        "responses": {
          "200": {
            "description": "success"
          }
        }
      },
      "post": {
        "tags": [
          "infra"
        ],
        "description": "Predictions feedback endpoint. Expecting feedback request in JSON format and must contain a `request_id` field, which can be obtained from any BentoService API response header",
        "responses": {
          "200": {
            "description": "success"
          }
        }
      }
    },
    "/predict": {
      "post": {
        "tags": [
          "app"
        ],
        "description": "BentoML generated API endpoint",
        "requestBody": {
          "required": true,
          "content": {
            "application/json": {
              "schema": {
                "type": "object"
              }
            }
          }
        },
        "responses": {
          "200": {
            "description": "success"
          }
        }
      }
    }
  }
}
```