### PR TITLE
ImageHandler update

### DIFF
--- a/bentoml/handlers/image_handler.py
+++ b/bentoml/handlers/image_handler.py
@@ -105,11 +105,15 @@ class ImageHandler(BentoHandler):
             return Response(response="Only accept POST request", status=400)
 
         if not self.accept_multiple_files:
-            input_file = request.files.get(self.input_names)
-            file_name = secure_filename(input_file.filename)
-            check_file_format(file_name, self.accept_file_extensions)
+            input_file = request.files.get("image")
 
-            input_stream = BytesIO(input_file.read())
+            if input_file:
+                file_name = secure_filename(input_file.filename)
+                check_file_format(file_name, self.accept_file_extensions)
+                input_stream = BytesIO(input_file.read())
+            else:
+                input_stream = BytesIO(request.data)
+
             input_data = imread(input_stream, pilmode=self.pilmode)
         else:
             return Response(response="Only support single file input", status=400)

--- a/bentoml/handlers/image_handler.py
+++ b/bentoml/handlers/image_handler.py
@@ -66,13 +66,13 @@ class ImageHandler(BentoHandler):
 
     def __init__(
         self,
-        input_names=None,
+        input_name="image",
         accept_file_extensions=None,
         accept_multiple_files=False,
-        pilmode=None,
+        pilmode="RGB",
     ):
-        self.input_names = input_names or "image"
-        self.pilmode = pilmode or "RGB"
+        self.input_name = input_name
+        self.pilmode = pilmode
         self.accept_file_extensions = accept_file_extensions or [
             ".jpg",
             ".png",


### PR DESCRIPTION
* allow post image directly with '--data-binary', for example:
```
curl -X POST "http://127.0.0.1:5000/predict" -H "Content-Type: image/png" --data-binary @Sample_Image.png
```
* 👆 also fixed posting image with the OpenAPI debugging web UI, user can upload image from the web UI for testing API endpoint now:
![image](https://user-images.githubusercontent.com/489344/61349573-7ad5ee00-a819-11e9-980c-e7ba0f200b1f.png)


* fix ImageHandler request_schema for OpenAPI docs

* add request_schema for FastaiImageHandler