### PR TITLE
Strip ' on db engine link

### DIFF
--- a/bentoml/db.py
+++ b/bentoml/db.py
@@ -27,7 +27,9 @@ from bentoml.exceptions import BentoMLException
 
 # sql alchemy config
 engine = create_engine(
-    config.get('db', 'engine'), echo=False, connect_args={'check_same_thread': False}
+    config.get('db', 'engine').strip("\'"),
+    echo=False,
+    connect_args={'check_same_thread': False},
 )
 Base = declarative_base()
 Session = sessionmaker(bind=engine)


### PR DESCRIPTION
Solve error `sqlalchemy.exc.ArgumentError: Could not parse rfc1738 URL from string ''sqlite:////home/travis/bentoml/storage.db''`
