### PR TITLE
ImageHandler - handling multiple images

### DIFF
--- a/bentoml/handlers/image_handler.py
+++ b/bentoml/handlers/image_handler.py
@@ -138,12 +138,18 @@ class ImageHandler(BentoHandler):
                 file_names = [secure_filename(file.filename) for file in input_files]
                 for file_name in file_names:
                     check_file_format(file_name, self.accept_file_extensions)
-                input_streams = [BytesIO(input_file.read()) for input_file in input_files]
+                input_streams = [
+                    BytesIO(input_file.read()) for
+                    input_file in input_files
+                ]
             else:
                 raise ValueError(
                     "BentoML#ImageHandler unexpected HTTP request: %s" % request
                 )
-            input_data = tuple(imread(input_stream, pilmode=self.pilmode) for input_stream in input_streams)
+            input_data = tuple(
+                imread(input_stream, pilmode=self.pilmode)
+                for input_stream in input_streams
+            )
 
         result = func(input_data)
         result = get_output_str(result, request.headers.get("output", "json"))

--- a/bentoml/handlers/image_handler.py
+++ b/bentoml/handlers/image_handler.py
@@ -71,7 +71,7 @@ class ImageHandler(BentoHandler):
         accept_multiple_files=False,
         pilmode="RGB",
     ):
-        self.input_name = input_name
+        self.input_name = input_name if type(input_name) is tuple else (input_name,)
         self.pilmode = pilmode
         self.accept_file_extensions = accept_file_extensions or [
             ".jpg",
@@ -88,7 +88,8 @@ class ImageHandler(BentoHandler):
                 "schema": {
                     "type": "object",
                     "properties": {
-                        self.input_name: {"type": "string", "format": "binary"}
+                        filename: {"type": "string", "format": "binary"}
+                        for filename in self.input_name
                     },
                 }
             },
@@ -132,8 +133,9 @@ class ImageHandler(BentoHandler):
                 )
 
             input_data = imread(input_stream, pilmode=self.pilmode)
+            result = func(input_data)
         else:
-            input_files = request.files.getlist(self.input_name)
+            input_files = [request.files.get(filename) for filename in self.input_name]
             if input_files:
                 file_names = [secure_filename(file.filename) for file in input_files]
                 for file_name in file_names:
@@ -150,8 +152,8 @@ class ImageHandler(BentoHandler):
                 imread(input_stream, pilmode=self.pilmode)
                 for input_stream in input_streams
             )
+            result = func(*input_data)
 
-        result = func(input_data)
         result = get_output_str(result, request.headers.get("output", "json"))
         return Response(response=result, status=200, mimetype="application/json")
 


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
Handling multiple images in ImageHandler

Does this close any currently open issues?
------------------------------------------
#264

How was this patch tested?
--------------------------
Since `handle_request` isn't covered in tests, I've tested simple service using curl:

```
@ver(major=1, minor=0)
class ImageSimilarityScorer(BentoService):

    @api(ImageHandler, input_name='image', accept_multiple_files=True)
    def predict(self, images):
        original = images[0]
        compared = images[1]
        return int(original[0, 0, 0] == compared[0,0, 0])
```

It returns expected value for two different random images I've got from the web