### PR TITLE
Fix Bento loading error in dev environment caused by versioneer version str

### DIFF
--- a/bentoml/archive/config.py
+++ b/bentoml/archive/config.py
@@ -68,8 +68,11 @@ class BentoArchiveConfig(object):
 
             # If major version is different, then there could be incompatible API
             # changes. Raise error in this case.
-            if int(conf["version"].split(".")[0]) != int(BENTOML_VERSION.split(".")[0]):
-                raise ValueError(msg)
+            if conf["version"].split(".")[0] != BENTOML_VERSION.split(".")[0]:
+                if not BENTOML_VERSION.startswith('0+untagged'):
+                    raise ValueError(msg)
+                else:
+                    LOG.warning(msg)
             else:  # Otherwise just show a warning.
                 LOG.warning(msg)
 


### PR DESCRIPTION
Avoid the following exception when loading from a dev version of local bentoml:
```
ValueError: invalid literal for int() with base 10: '0+untagged'
```