### PR TITLE
use in-development bentoml package for deployment

### DIFF
--- a/bentoml/archive/archiver.py
+++ b/bentoml/archive/archiver.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import os
 import logging
 
+from bentoml.deployment.utils import add_local_bentoml_package_to_repo
 from bentoml.exceptions import BentoMLException
 from bentoml.archive.py_module_utils import copy_used_py_modules
 from bentoml.archive.templates import (
@@ -28,6 +29,7 @@ from bentoml.archive.templates import (
     BENTO_SERVICE_DOCKERFILE_SAGEMAKER_TEMPLATE,
     INIT_PY_TEMPLATE,
 )
+from bentoml.utils import _is_bentoml_in_develop_mode
 from bentoml.utils.usage_stats import track_save
 from bentoml.archive.config import BentoArchiveConfig
 
@@ -157,6 +159,11 @@ def save_to_dir(bento_service, path, version=None):
     # Also write bentoml.yml to module base path to make it accessible
     # as package data after pip installed as a python package
     config.write_to_path(module_base_path)
+
+    # if bentoml package in editor mode(pip install -e), will include
+    # that bentoml package to bento archive
+    if _is_bentoml_in_develop_mode():
+        add_local_bentoml_package_to_repo(path)
 
     logger.info(
         "Successfully saved Bento '%s:%s' to path: %s",

--- a/bentoml/archive/archiver.py
+++ b/bentoml/archive/archiver.py
@@ -28,6 +28,7 @@ from bentoml.archive.templates import (
     BENTO_SERVICE_DOCKERFILE_CPU_TEMPLATE,
     BENTO_SERVICE_DOCKERFILE_SAGEMAKER_TEMPLATE,
     INIT_PY_TEMPLATE,
+    BENTO_INIT_SH_TEMPLATE,
 )
 from bentoml.utils import _is_bentoml_in_develop_mode
 from bentoml.utils.usage_stats import track_save
@@ -140,6 +141,10 @@ def save_to_dir(bento_service, path, version=None):
         f.write(BENTO_SERVICE_DOCKERFILE_CPU_TEMPLATE)
     with open(os.path.join(path, "Dockerfile-sagemaker"), "w") as f:
         f.write(BENTO_SERVICE_DOCKERFILE_SAGEMAKER_TEMPLATE)
+
+    # write bento init sh for install targz bundles
+    with open(os.path.join(path, 'bentoml_init.sh'), 'w') as f:
+        f.write(BENTO_INIT_SH_TEMPLATE)
 
     # write bentoml.yml
     config = BentoArchiveConfig()

--- a/bentoml/archive/templates.py
+++ b/bentoml/archive/templates.py
@@ -91,8 +91,8 @@ WORKDIR /bento
 RUN conda env update -n base -f /bento/environment.yml
 RUN pip install -r /bento/requirements.txt
 
-# Install wheel files
-RUN if [ -f /bento/install_bundled_dependencies.sh ] then /bin/bash -c /bento/install_bundled_dependencies.sh; fi
+# Install additional dependencies bundle
+RUN if [ -f /bento/install_bundled_dependencies.sh ]; then /bin/bash -c /bento/install_bundled_dependencies.sh; fi
 
 # run user defined setup script
 RUN if [ -f /bento/setup.sh ]; then /bin/bash -c /bento/setup.sh; fi
@@ -125,8 +125,8 @@ WORKDIR /opt/program
 RUN conda env update -n base -f /opt/program/environment.yml
 RUN pip install -r /opt/program/requirements.txt
 
-# Install wheel files
-RUN if [ -f /bento/install_bundled_dependencies.sh ] then /bin/bash -c /bento/install_bundled_dependencies.sh; fi
+# Install additional dependencies bundle
+RUN if [ -f /bento/install_bundled_dependencies.sh ]; then /bin/bash -c /bento/install_bundled_dependencies.sh; fi
 
 # run user defined setup script
 RUN if [ -f /opt/program/setup.sh ]; then /bin/bash -c /opt/program/setup.sh; fi

--- a/bentoml/archive/templates.py
+++ b/bentoml/archive/templates.py
@@ -91,6 +91,9 @@ WORKDIR /bento
 RUN conda env update -n base -f /bento/environment.yml
 RUN pip install -r /bento/requirements.txt
 
+# Install wheel files
+RUN if [ -f /bento/install_wheels.sh ] then /bin/bash -c /bento/install_wheels.sh; fi
+
 # run user defined setup script
 RUN if [ -f /bento/setup.sh ]; then /bin/bash -c /bento/setup.sh; fi
 
@@ -121,6 +124,9 @@ WORKDIR /opt/program
 # update conda base env
 RUN conda env update -n base -f /opt/program/environment.yml
 RUN pip install -r /opt/program/requirements.txt
+
+# Install wheel files
+RUN if [ -f /bento/install_wheels.sh ] then /bin/bash -c /bento/install_wheels.sh; fi
 
 # run user defined setup script
 RUN if [ -f /opt/program/setup.sh ]; then /bin/bash -c /opt/program/setup.sh; fi

--- a/bentoml/archive/templates.py
+++ b/bentoml/archive/templates.py
@@ -92,7 +92,7 @@ RUN conda env update -n base -f /bento/environment.yml
 RUN pip install -r /bento/requirements.txt
 
 # Install wheel files
-RUN if [ -f /bento/install_wheels.sh ] then /bin/bash -c /bento/install_wheels.sh; fi
+RUN if [ -f /bento/install_wheels.sh ] then /bin/bash -c /bento/install_bundled_dependencies.sh; fi
 
 # run user defined setup script
 RUN if [ -f /bento/setup.sh ]; then /bin/bash -c /bento/setup.sh; fi

--- a/bentoml/archive/templates.py
+++ b/bentoml/archive/templates.py
@@ -125,7 +125,7 @@ WORKDIR /opt/program
 RUN conda env update -n base -f /opt/program/environment.yml
 RUN pip install -r /opt/program/requirements.txt
 
-# Install additional dependencies bundle
+# Install additional pip dependencies inside bundled_pip_dependencies dir
 RUN if [ -f /bento/bentoml_init.sh ]; then /bin/bash -c /bento/bentoml_init.sh; fi
 
 # run user defined setup script
@@ -162,7 +162,7 @@ __all__ = ['__version__', '{service_name}', 'load']
 BENTO_INIT_SH_TEMPLATE = """\
 #!/bin/bash
 
-for filename in ./bundled_dependencies/*.tar.gz; do
+for filename in ./bundled_pip_dependencies/*.tar.gz; do
     [ -e "$filename" ] || continue
     pip install "$filename" --ignore-installed
 done

--- a/bentoml/archive/templates.py
+++ b/bentoml/archive/templates.py
@@ -92,7 +92,7 @@ RUN conda env update -n base -f /bento/environment.yml
 RUN pip install -r /bento/requirements.txt
 
 # Install additional dependencies bundle
-RUN if [ -f /bento/install_bundled_dependencies.sh ]; then /bin/bash -c /bento/install_bundled_dependencies.sh; fi
+RUN if [ -f /bento/bentoml_init.sh ]; then /bin/bash -c /bento/bentoml_init.sh; fi
 
 # run user defined setup script
 RUN if [ -f /bento/setup.sh ]; then /bin/bash -c /bento/setup.sh; fi
@@ -126,7 +126,7 @@ RUN conda env update -n base -f /opt/program/environment.yml
 RUN pip install -r /opt/program/requirements.txt
 
 # Install additional dependencies bundle
-RUN if [ -f /bento/install_bundled_dependencies.sh ]; then /bin/bash -c /bento/install_bundled_dependencies.sh; fi
+RUN if [ -f /bento/bentoml_init.sh ]; then /bin/bash -c /bento/bentoml_init.sh; fi
 
 # run user defined setup script
 RUN if [ -f /opt/program/setup.sh ]; then /bin/bash -c /opt/program/setup.sh; fi
@@ -156,4 +156,14 @@ def load():
 
 
 __all__ = ['__version__', '{service_name}', 'load']
+"""
+
+
+BENTO_INIT_SH_TEMPLATE = """\
+#!/bin/bash
+
+for filename in ./bundled_dependencies/*.tar.gz; do
+    [ -e "$filename" ] || continue
+    pip install "$filename" --ignore-installed
+done
 """

--- a/bentoml/archive/templates.py
+++ b/bentoml/archive/templates.py
@@ -91,7 +91,7 @@ WORKDIR /bento
 RUN conda env update -n base -f /bento/environment.yml
 RUN pip install -r /bento/requirements.txt
 
-# Install additional dependencies bundle
+ # Install additional pip dependencies inside bundled_pip_dependencies dir
 RUN if [ -f /bento/bentoml_init.sh ]; then /bin/bash -c /bento/bentoml_init.sh; fi
 
 # run user defined setup script

--- a/bentoml/archive/templates.py
+++ b/bentoml/archive/templates.py
@@ -92,7 +92,7 @@ RUN conda env update -n base -f /bento/environment.yml
 RUN pip install -r /bento/requirements.txt
 
 # Install wheel files
-RUN if [ -f /bento/install_wheels.sh ] then /bin/bash -c /bento/install_bundled_dependencies.sh; fi
+RUN if [ -f /bento/install_bundled_dependencies.sh ] then /bin/bash -c /bento/install_bundled_dependencies.sh; fi
 
 # run user defined setup script
 RUN if [ -f /bento/setup.sh ]; then /bin/bash -c /bento/setup.sh; fi
@@ -126,7 +126,7 @@ RUN conda env update -n base -f /opt/program/environment.yml
 RUN pip install -r /opt/program/requirements.txt
 
 # Install wheel files
-RUN if [ -f /bento/install_wheels.sh ] then /bin/bash -c /bento/install_wheels.sh; fi
+RUN if [ -f /bento/install_bundled_dependencies.sh ] then /bin/bash -c /bento/install_bundled_dependencies.sh; fi
 
 # run user defined setup script
 RUN if [ -f /opt/program/setup.sh ]; then /bin/bash -c /opt/program/setup.sh; fi

--- a/bentoml/deployment/sagemaker/__init__.py
+++ b/bentoml/deployment/sagemaker/__init__.py
@@ -408,22 +408,22 @@ class SageMakerDeploymentOperator(DeploymentOperatorBase):
                     "AWS create endpoint response: %s", create_endpoint_response
                 )
         except ClientError as e:
-            cleanup_model_error = _cleanup_sagemaker_endpoint_config(
+            cleanup_endpoint_config_error = _cleanup_sagemaker_endpoint_config(
                 client=sagemaker_client,
                 name=deployment_spec.bento_name,
                 version=deployment_spec.bento_version,
             )
-            if cleanup_model_error:
-                cleanup_model_error.error_message = (
+            if cleanup_endpoint_config_error:
+                cleanup_endpoint_config_error.error_message = (
                     'Failed to clean up endpoint config after unsuccessfully '
                     'apply SageMaker deployment: %s',
-                    cleanup_model_error.error_message,
+                    cleanup_endpoint_config_error.error_message,
                 )
                 return ApplyDeploymentResponse(
-                    status=cleanup_model_error, deployment=deployment_pb
+                    status=cleanup_endpoint_config_error, deployment=deployment_pb
                 )
 
-            cleanup_model_error = _cleanup_sagemaker_endpoint_config(
+            cleanup_model_error = _cleanup_sagemaker_model(
                 client=sagemaker_client,
                 name=deployment_spec.bento_name,
                 version=deployment_spec.bento_version,
@@ -473,7 +473,7 @@ class SageMakerDeploymentOperator(DeploymentOperatorBase):
             )
             return DeleteDeploymentResponse(status=status)
 
-        delete_config_error = _cleanup_sagemaker_model(
+        delete_config_error = _cleanup_sagemaker_endpoint_config(
             client=sagemaker_client,
             name=deployment_spec.bento_name,
             version=deployment_spec.bento_version,

--- a/bentoml/deployment/serverless/serverless_utils.py
+++ b/bentoml/deployment/serverless/serverless_utils.py
@@ -131,14 +131,14 @@ class TemporaryServerlessContent(object):
         )
         requirement_txt_path = os.path.join(self.archive_path, 'requirements.txt')
         shutil.copy(requirement_txt_path, tempdir)
-        model_service_archive_path = os.path.join(tempdir, self.bento_name)
+        bento_archive_path = os.path.join(tempdir, self.bento_name)
         model_path = os.path.join(self.archive_path, self.bento_name)
-        shutil.copytree(model_path, model_service_archive_path)
+        shutil.copytree(model_path, bento_archive_path)
 
         bundled_dependencies_path = os.path.join(
             self.archive_path, 'bundled_pip_dependencies'
         )
-        # If bundled_dependencies directory exists, we copy over and update
+        # If bundled_pip_dependencies directory exists, we copy over and update
         # requirements.txt
         if os.path.isdir(bundled_dependencies_path):
             dest_bundle_path = os.path.join(tempdir, 'bundled_pip_dependencies')

--- a/bentoml/deployment/serverless/serverless_utils.py
+++ b/bentoml/deployment/serverless/serverless_utils.py
@@ -26,7 +26,7 @@ from subprocess import PIPE
 from ruamel.yaml import YAML
 from packaging import version
 
-from bentoml.utils import Path, _is_bentoml_in_develop_mode
+from bentoml.utils import Path
 from bentoml.utils.tempdir import TempDirectory
 from bentoml.utils.whichcraft import which
 from bentoml.exceptions import BentoMLException

--- a/bentoml/deployment/serverless/serverless_utils.py
+++ b/bentoml/deployment/serverless/serverless_utils.py
@@ -26,7 +26,7 @@ from subprocess import PIPE
 from ruamel.yaml import YAML
 from packaging import version
 
-from bentoml.utils import Path, _is_bentoml_in_editor_mode
+from bentoml.utils import Path, _is_bentoml_in_development_mode
 from bentoml.utils.tempdir import TempDirectory
 from bentoml.utils.whichcraft import which
 from bentoml.exceptions import BentoMLException
@@ -135,7 +135,7 @@ class TemporaryServerlessContent(object):
         model_path = os.path.join(self.archive_path, self.bento_name)
         shutil.copytree(model_path, model_serivce_archive_path)
 
-        if _is_bentoml_in_editor_mode():
+        if _is_bentoml_in_development_mode():
             dest_bundle_path = os.path.join(tempdir, 'bundle_dependencies')
             bundle_dependencies_path = os.path.join(
                 self.archive_path, 'bundle_dependencies'

--- a/bentoml/deployment/serverless/serverless_utils.py
+++ b/bentoml/deployment/serverless/serverless_utils.py
@@ -26,7 +26,7 @@ from subprocess import PIPE
 from ruamel.yaml import YAML
 from packaging import version
 
-from bentoml.utils import Path, _is_bentoml_in_development_mode
+from bentoml.utils import Path, _is_bentoml_in_develop_mode
 from bentoml.utils.tempdir import TempDirectory
 from bentoml.utils.whichcraft import which
 from bentoml.exceptions import BentoMLException
@@ -135,7 +135,7 @@ class TemporaryServerlessContent(object):
         model_path = os.path.join(self.archive_path, self.bento_name)
         shutil.copytree(model_path, model_serivce_archive_path)
 
-        if _is_bentoml_in_development_mode():
+        if _is_bentoml_in_develop_mode():
             dest_bundle_path = os.path.join(tempdir, 'bundle_dependencies')
             bundle_dependencies_path = os.path.join(
                 self.archive_path, 'bundle_dependencies'

--- a/bentoml/deployment/serverless/serverless_utils.py
+++ b/bentoml/deployment/serverless/serverless_utils.py
@@ -26,8 +26,7 @@ from subprocess import PIPE
 from ruamel.yaml import YAML
 from packaging import version
 
-from bentoml.utils import Path
-from bentoml.utils.usage_stats import _is_pypi_release
+from bentoml.utils import Path, _is_bentoml_in_editor_mode
 from bentoml.utils.tempdir import TempDirectory
 from bentoml.utils.whichcraft import which
 from bentoml.exceptions import BentoMLException
@@ -136,11 +135,10 @@ class TemporaryServerlessContent(object):
         model_path = os.path.join(self.archive_path, self.bento_name)
         shutil.copytree(model_path, model_serivce_archive_path)
 
-        if not _is_pypi_release():
+        if _is_bentoml_in_editor_mode():
             dest_bundle_path = os.path.join(tempdir, 'bundle_dependencies')
             bundle_dependencies_path = os.path.join(
-                self.archive_path,
-                'bundle_dependencies'
+                self.archive_path, 'bundle_dependencies'
             )
             shutil.copytree(bundle_dependencies_path, dest_bundle_path)
             requirement_txt_path = os.path.join(tempdir, 'requirements.txt')

--- a/bentoml/deployment/serverless/serverless_utils.py
+++ b/bentoml/deployment/serverless/serverless_utils.py
@@ -138,7 +138,10 @@ class TemporaryServerlessContent(object):
 
         if not _is_pypi_release():
             dest_bundle_path = os.path.join(tempdir, 'bundle_dependencies')
-            bundle_dependencies_path = os.path.join(self.archive_path, 'bundle_dependencies')
+            bundle_dependencies_path = os.path.join(
+                self.archive_path,
+                'bundle_dependencies'
+            )
             shutil.copytree(bundle_dependencies_path, dest_bundle_path)
             requirement_txt_path = os.path.join(tempdir, 'requirements.txt')
 

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -73,7 +73,11 @@ def add_local_bentoml_package_to_repo(archive_path):
         _, module_location, _ = imp.find_module('bentoml')
     bentoml_location = Path(module_location)
 
-    bentoml_setup_py = os.path.abspath(os.path.join(bentoml_location, '..', 'setup.py'))
+    try:
+        bentoml_setup_py = os.path.abspath(os.path.join(bentoml_location, '..', 'setup.py'))
+    except AttributeError:
+        # python 2.7 'PosixPath' object has no attribute 'endswith'
+        bentoml_setup_py = os.path.join(bentoml_location.parent, 'setup.py')
     if not os.path.isfile(bentoml_setup_py):
         raise KeyError('"setup.py" for Bentoml module not found')
 

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -79,9 +79,8 @@ def add_local_bentoml_package_to_repo(archive_path):
     bundle_dir_name = '__bento_dev_{}'.format(date_string)
     Path(bundle_dir_name).mkdir(exist_ok=True, parents=True)
 
-    setup_py = os.path.join(bentoml_location, 'setup.py')
     sandbox.run_setup(
-        setup_py, ['sdist', '--format', 'gztar', '--dist-dir', bundle_dir_name]
+        bentoml_setup_py, ['sdist', '--format', 'gztar', '--dist-dir', bundle_dir_name]
     )
 
     # copy the generated targz to archive directory and remove it from

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -27,7 +27,6 @@ from datetime import datetime
 from setuptools import sandbox
 from ruamel.yaml import YAML
 
-from bentoml import config
 from bentoml.utils import Path
 
 logger = logging.getLogger(__name__)

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -71,13 +71,8 @@ def add_local_bentoml_package_to_repo(archive_path):
         # python 2.7 doesn't have importlib.util, will fall back to imp instead
         import imp
         _, module_location, _ = imp.find_module('bentoml')
-    bentoml_location = Path(module_location)
+    bentoml_setup_py = os.path.abspath(os.path.join(module_location, '..', 'setup.py'))
 
-    try:
-        bentoml_setup_py = os.path.abspath(os.path.join(bentoml_location, '..', 'setup.py'))
-    except AttributeError:
-        # python 2.7 'PosixPath' object has no attribute 'endswith'
-        bentoml_setup_py = os.path.join(bentoml_location.parent, 'setup.py')
     if not os.path.isfile(bentoml_setup_py):
         raise KeyError('"setup.py" for Bentoml module not found')
 
@@ -93,7 +88,7 @@ def add_local_bentoml_package_to_repo(archive_path):
 
     # copy the generated targz to archive directory and remove it from
     # bentoml module directory
-    source_dir = os.path.join(bentoml_location, bundle_dir_name)
+    source_dir = os.path.abspath(os.path.join(module_location, '..', bundle_dir_name))
     dest_dir = os.path.join(archive_path, 'bundled_dependencies')
     if os.path.isdir(source_dir):
         shutil.copytree(source_dir, dest_dir)

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -74,7 +74,9 @@ def add_local_bentoml_package_to_repo(deployment_pb, repo):
     Path(bundle_dir_name).mkdir(exist_ok=True, parents=True)
 
     setup_py = os.path.join(bentoml_location.parent, 'setup.py')
-    sandbox.run_setup(setup_py, ['sdist', '--format', 'gztar', '--dist-dir', bundle_dir_name])
+    sandbox.run_setup(
+        setup_py, ['sdist', '--format', 'gztar', '--dist-dir', bundle_dir_name]
+    )
 
     source_dir = os.path.join(bentoml_location.parent, bundle_dir_name)
     dist_dir = os.path.join(archive_path, 'bundle_dependencies')

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 import json
 import os
 import logging
-import imp
+import importlib
 import shutil
 
 from distutils.dir_util import copy_tree
@@ -65,12 +65,11 @@ done
 """
 
 
-def add_local_bentoml_package_to_repo(deployment_pb, repo):
-    deployment_spec = deployment_pb.spec
-    archive_path = repo.get(deployment_spec.bento_name, deployment_spec.bento_version)
-    bentoml_location = Path(imp.find_module('bentoml')[1]).parent
+def add_local_bentoml_package_to_repo(archive_path):
+    module_location, = importlib.util.find_spec('bentoml').submodule_search_locations
+    bentoml_location = Path(module_location)
 
-    bentoml_setup_py = os.path.join(bentoml_location, 'setup.py')
+    bentoml_setup_py = os.path.abspath(os.path.join(bentoml_location, '..', 'setup.py'))
     if not os.path.isfile(bentoml_setup_py):
         raise KeyError('"setup.py" for Bentoml module not found')
 

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -22,9 +22,7 @@ import logging
 import importlib
 import shutil
 
-from datetime import datetime
 from setuptools import sandbox
-from ruamel.yaml import YAML
 
 from bentoml.utils import Path
 
@@ -54,16 +52,6 @@ def process_docker_api_line(payload):
                     logger.info(line_payload['stream'])
 
 
-INSTALL_TARGZ_TEMPLATE = """\
-#!/bin/bash
-
-for filename in ./bundled_dependencies/*.tar.gz; do
-    [ -e "$filename" ] || continue
-    pip install "$filename" --ignore-installed
-done
-"""
-
-
 def add_local_bentoml_package_to_repo(archive_path):
     try:
         module_location, = importlib.util.find_spec('bentoml').submodule_search_locations
@@ -73,13 +61,11 @@ def add_local_bentoml_package_to_repo(archive_path):
         _, module_location, _ = imp.find_module('bentoml')
     bentoml_setup_py = os.path.abspath(os.path.join(module_location, '..', 'setup.py'))
 
-    if not os.path.isfile(bentoml_setup_py):
-        raise KeyError('"setup.py" for Bentoml module not found')
+    assert os.path.isfile(bentoml_setup_py), '"setup.py" for Bentoml module not found'
 
     # Create random directory inside bentoml module for storing the bundled
     # targz file. Since dist-dir can only be inside of the module directory
-    date_string = datetime.now().strftime("%Y_%m_%d")
-    bundle_dir_name = '__bento_dev_{}'.format(date_string)
+    bundle_dir_name = '__bento_dev_tmp'
     Path(bundle_dir_name).mkdir(exist_ok=True, parents=True)
 
     sandbox.run_setup(
@@ -90,39 +76,12 @@ def add_local_bentoml_package_to_repo(archive_path):
     # bentoml module directory
     source_dir = os.path.abspath(os.path.join(module_location, '..', bundle_dir_name))
     dest_dir = os.path.join(archive_path, 'bundled_dependencies')
-    if os.path.isdir(source_dir):
-        shutil.copytree(source_dir, dest_dir)
-        shutil.rmtree(source_dir)
+    shutil.copytree(source_dir, dest_dir)
+    shutil.rmtree(source_dir)
 
     # Include script for install targz file in archive directory
     install_script_path = os.path.join(archive_path, 'install_bundled_dependencies.sh')
     with open(install_script_path, 'w') as f:
         f.write(INSTALL_TARGZ_TEMPLATE)
-    permission = "755"
-    octal_permission = int(permission, 8)
-    os.chmod(install_script_path, octal_permission)
-
-    # remove the 'dirty' and 'hash' tags for bentoml in the environment.yml
-    # and requirements.txt in archive
-    with open(os.path.join(archive_path, 'requirements.txt'), 'r+') as file:
-        content = file.read()
-        req_list = content.split('\n')
-        bento_string = [s for s in req_list if 'bentoml==' in s][0]
-        if bento_string:
-            req_list[req_list.index(bento_string)] = bento_string.split('+')[0]
-        else:
-            logger.error('no bentoml in requirements.txt')
-        file.seek(0)
-        file.write('\n'.join(req_list))
-        file.truncate()
-
-    with open(os.path.join(archive_path, 'environment.yml'), 'rb') as file:
-        content = file.read()
-    yaml = YAML()
-    yaml_content = yaml.load(content)
-    pip_list_index = yaml_content['dependencies'].index('pip') + 1
-    pip_list = yaml_content['dependencies'][pip_list_index].get('pip')
-    pip_list[0] = pip_list[0].split('+')[0]
-    yaml.dump(yaml_content, Path(os.path.join(archive_path, 'environment.yml')))
 
     return

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -54,10 +54,13 @@ def process_docker_api_line(payload):
 
 def add_local_bentoml_package_to_repo(archive_path):
     try:
-        module_location, = importlib.util.find_spec('bentoml').submodule_search_locations
+        module_location, = importlib.util.find_spec(
+            'bentoml'
+        ).submodule_search_locations
     except AttributeError:
         # python 2.7 doesn't have importlib.util, will fall back to imp instead
         import imp
+
         _, module_location, _ = imp.find_module('bentoml')
     bentoml_setup_py = os.path.abspath(os.path.join(module_location, '..', 'setup.py'))
 
@@ -78,10 +81,5 @@ def add_local_bentoml_package_to_repo(archive_path):
     dest_dir = os.path.join(archive_path, 'bundled_dependencies')
     shutil.copytree(source_dir, dest_dir)
     shutil.rmtree(source_dir)
-
-    # Include script for install targz file in archive directory
-    install_script_path = os.path.join(archive_path, 'install_bundled_dependencies.sh')
-    with open(install_script_path, 'w') as f:
-        f.write(INSTALL_TARGZ_TEMPLATE)
 
     return

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -79,8 +79,8 @@ def add_local_bentoml_package_to_repo(deployment_pb, repo):
     )
 
     source_dir = os.path.join(bentoml_location.parent, bundle_dir_name)
-    dist_dir = os.path.join(archive_path, 'bundle_dependencies')
-    copy_tree(source_dir, dist_dir)
+    dest_dir = os.path.join(archive_path, 'bundle_dependencies')
+    copy_tree(source_dir, dest_dir)
 
     install_script_path = os.path.join(archive_path, 'install_bundled_dependencies.sh')
     with open(install_script_path, 'w') as f:

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -22,7 +22,6 @@ import logging
 import importlib
 import shutil
 
-from distutils.dir_util import copy_tree
 from datetime import datetime
 from setuptools import sandbox
 from ruamel.yaml import YAML
@@ -87,7 +86,7 @@ def add_local_bentoml_package_to_repo(archive_path):
     # bentoml module directory
     source_dir = os.path.join(bentoml_location, bundle_dir_name)
     dest_dir = os.path.join(archive_path, 'bundled_dependencies')
-    copy_tree(source_dir, dest_dir)
+    shutil.copytree(source_dir, dest_dir)
     shutil.rmtree(source_dir)
 
     # Include script for install targz file in archive directory

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -65,7 +65,12 @@ done
 
 
 def add_local_bentoml_package_to_repo(archive_path):
-    module_location, = importlib.util.find_spec('bentoml').submodule_search_locations
+    try:
+        module_location, = importlib.util.find_spec('bentoml').submodule_search_locations
+    except AttributeError:
+        # python 2.7 doesn't have importlib.util, will fall back to imp instead
+        import imp
+        _, module_location, _ = imp.find_module('bentoml')
     bentoml_location = Path(module_location)
 
     bentoml_setup_py = os.path.abspath(os.path.join(bentoml_location, '..', 'setup.py'))

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -24,7 +24,6 @@ import shutil
 
 from setuptools import sandbox
 
-from bentoml.utils import Path
 
 logger = logging.getLogger(__name__)
 

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -66,10 +66,13 @@ def add_local_bentoml_package_to_repo(archive_path):
 
     assert os.path.isfile(bentoml_setup_py), '"setup.py" for Bentoml module not found'
 
-    # Create random directory inside bentoml module for storing the bundled
+    # Create tmp directory inside bentoml module for storing the bundled
     # targz file. Since dist-dir can only be inside of the module directory
     bundle_dir_name = '__bento_dev_tmp'
-    Path(bundle_dir_name).mkdir(exist_ok=True, parents=True)
+    source_dir = os.path.abspath(os.path.join(module_location, '..', bundle_dir_name))
+    if os.path.isdir(source_dir):
+        shutil.rmtree(source_dir, ignore_errors=True)
+    os.mkdir(source_dir)
 
     sandbox.run_setup(
         bentoml_setup_py, ['sdist', '--format', 'gztar', '--dist-dir', bundle_dir_name]
@@ -77,9 +80,6 @@ def add_local_bentoml_package_to_repo(archive_path):
 
     # copy the generated targz to archive directory and remove it from
     # bentoml module directory
-    source_dir = os.path.abspath(os.path.join(module_location, '..', bundle_dir_name))
-    dest_dir = os.path.join(archive_path, 'bundled_dependencies')
+    dest_dir = os.path.join(archive_path, 'bundled_pip_dependencies')
     shutil.copytree(source_dir, dest_dir)
     shutil.rmtree(source_dir)
-
-    return

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -86,8 +86,9 @@ def add_local_bentoml_package_to_repo(archive_path):
     # bentoml module directory
     source_dir = os.path.join(bentoml_location, bundle_dir_name)
     dest_dir = os.path.join(archive_path, 'bundled_dependencies')
-    shutil.copytree(source_dir, dest_dir)
-    shutil.rmtree(source_dir)
+    if os.path.isdir(source_dir):
+        shutil.copytree(source_dir, dest_dir)
+        shutil.rmtree(source_dir)
 
     # Include script for install targz file in archive directory
     install_script_path = os.path.join(archive_path, 'install_bundled_dependencies.sh')

--- a/bentoml/deployment/utils.py
+++ b/bentoml/deployment/utils.py
@@ -59,7 +59,7 @@ INSTALL_TARGZ_TEMPLATE = """\
 
 for filename in ./bundled_dependencies/*.tar.gz; do
     [ -e "$filename" ] || continue
-    # pip install "$filename" --ignore-installed
+    pip install "$filename" --ignore-installed
 done
 """
 

--- a/bentoml/service_env.py
+++ b/bentoml/service_env.py
@@ -35,7 +35,7 @@ dependencies:
   - python={python_version}
   - pip
   - pip:
-    - bentoml[api_server]=={bentoml_version}
+    - {bentoml_package}
 """
 
 CONDA_ENV_DEFAULT_NAME = "bentoml-custom-conda-env"
@@ -56,11 +56,14 @@ class CondaEnv(object):
     ):
         self._yaml = YAML()
         self._yaml.default_flow_style = False
+        bentoml_package = 'bentoml[api_server]=={}'.format(bentoml_version)
+        if os.environ['BENTOML_DEVELOPMENT_PACKAGE']:
+            bentoml_package = os.environ['BENTOML_DEVELOPMENT_PACKAGE']
         self._conda_env = self._yaml.load(
             CONDA_ENV_BASE_YAML.format(
                 name=name,
                 python_version=python_version,
-                bentoml_version=bentoml_version,
+                bentoml_package=bentoml_package,
             )
         )
 
@@ -119,7 +122,10 @@ class BentoServiceEnv(object):
     def __init__(self, bentoml_version=LOCAL_BENTOML_VERSION):
         self._setup_sh = None
         self._conda_env = CondaEnv()
-        self._pip_dependencies = ["bentoml=={}".format(bentoml_version)]
+        bentoml_dependency = "bentoml=={}".format(bentoml_version)
+        if os.environ['BENTOML_DEVELOPMENT_PACKAGE']:
+            bentoml_dependency = os.environ['BENTOML_DEVELOPMENT_PACKAGE']
+        self._pip_dependencies = [bentoml_dependency]
 
     def get_conda_env_name(self):
         return self._conda_env.get_name()

--- a/bentoml/service_env.py
+++ b/bentoml/service_env.py
@@ -20,6 +20,7 @@ import os
 from sys import version_info
 from ruamel.yaml import YAML
 
+from bentoml.exceptions import BentoMLConfigException
 from bentoml.utils import Path, StringIO
 from bentoml import __version__ as LOCAL_BENTOML_VERSION
 from bentoml import config
@@ -60,8 +61,10 @@ class CondaEnv(object):
 
         # If bentoml deploy version is set in config,
         # will use that as bentoml version for the archive
-        if config('core').get('bentoml_deploy_version'):
-            bentoml_version = config('core').get('bentoml_deploy_version')
+        try:
+            bentoml_version = config().get('bentoml_deploy_version')
+        except BentoMLConfigException:
+            pass
 
         self._conda_env = self._yaml.load(
             CONDA_ENV_BASE_YAML.format(
@@ -126,11 +129,13 @@ class BentoServiceEnv(object):
     def __init__(self, bentoml_version=LOCAL_BENTOML_VERSION):
         self._setup_sh = None
         self._conda_env = CondaEnv()
-        
+
         # If bentoml deploy version is set in config,
         # will use that as bentoml version for the archive
-        if config('core').get('bentoml_deploy_version'):
-            bentoml_version = config('core').get('bentoml_deploy_version')
+        try:
+            bentoml_version = config().get('bentoml_deploy_version')
+        except BentoMLConfigException:
+            pass
         self._pip_dependencies = ["bentoml=={}".format(bentoml_version)]
 
     def get_conda_env_name(self):

--- a/bentoml/service_env.py
+++ b/bentoml/service_env.py
@@ -35,7 +35,7 @@ dependencies:
   - python={python_version}
   - pip
   - pip:
-    - {bentoml_package}
+    - bentoml[api_server]=={bentoml_version}
 """
 
 CONDA_ENV_DEFAULT_NAME = "bentoml-custom-conda-env"
@@ -56,14 +56,11 @@ class CondaEnv(object):
     ):
         self._yaml = YAML()
         self._yaml.default_flow_style = False
-        bentoml_package = 'bentoml[api_server]=={}'.format(bentoml_version)
-        if os.environ['BENTOML_DEVELOPMENT_PACKAGE']:
-            bentoml_package = os.environ['BENTOML_DEVELOPMENT_PACKAGE']
         self._conda_env = self._yaml.load(
             CONDA_ENV_BASE_YAML.format(
                 name=name,
                 python_version=python_version,
-                bentoml_package=bentoml_package,
+                bentoml_version=bentoml_version,
             )
         )
 
@@ -122,10 +119,7 @@ class BentoServiceEnv(object):
     def __init__(self, bentoml_version=LOCAL_BENTOML_VERSION):
         self._setup_sh = None
         self._conda_env = CondaEnv()
-        bentoml_dependency = "bentoml=={}".format(bentoml_version)
-        if os.environ['BENTOML_DEVELOPMENT_PACKAGE']:
-            bentoml_dependency = os.environ['BENTOML_DEVELOPMENT_PACKAGE']
-        self._pip_dependencies = [bentoml_dependency]
+        self._pip_dependencies = ["bentoml=={}".format(bentoml_version)]
 
     def get_conda_env_name(self):
         return self._conda_env.get_name()

--- a/bentoml/service_env.py
+++ b/bentoml/service_env.py
@@ -22,6 +22,7 @@ from ruamel.yaml import YAML
 
 from bentoml.utils import Path, StringIO
 from bentoml import __version__ as LOCAL_BENTOML_VERSION
+from bentoml import config
 
 PYTHON_VERSION = "{major}.{minor}.{micro}".format(
     major=version_info.major, minor=version_info.minor, micro=version_info.micro
@@ -56,6 +57,12 @@ class CondaEnv(object):
     ):
         self._yaml = YAML()
         self._yaml.default_flow_style = False
+
+        # If bentoml deploy version is set in config,
+        # will use that as bentoml version for the archive
+        if config('core').get('bentoml_deploy_version'):
+            bentoml_version = config('core').get('bentoml_deploy_version')
+
         self._conda_env = self._yaml.load(
             CONDA_ENV_BASE_YAML.format(
                 name=name,
@@ -119,6 +126,11 @@ class BentoServiceEnv(object):
     def __init__(self, bentoml_version=LOCAL_BENTOML_VERSION):
         self._setup_sh = None
         self._conda_env = CondaEnv()
+        
+        # If bentoml deploy version is set in config,
+        # will use that as bentoml version for the archive
+        if config('core').get('bentoml_deploy_version'):
+            bentoml_version = config('core').get('bentoml_deploy_version')
         self._pip_dependencies = ["bentoml=={}".format(bentoml_version)]
 
     def get_conda_env_name(self):

--- a/bentoml/service_env.py
+++ b/bentoml/service_env.py
@@ -59,13 +59,6 @@ class CondaEnv(object):
         self._yaml = YAML()
         self._yaml.default_flow_style = False
 
-        # If bentoml deploy version is set in config,
-        # will use that as bentoml version for the archive
-        try:
-            bentoml_version = config().get('bentoml_deploy_version')
-        except BentoMLConfigException:
-            pass
-
         self._conda_env = self._yaml.load(
             CONDA_ENV_BASE_YAML.format(
                 name=name,
@@ -130,12 +123,6 @@ class BentoServiceEnv(object):
         self._setup_sh = None
         self._conda_env = CondaEnv()
 
-        # If bentoml deploy version is set in config,
-        # will use that as bentoml version for the archive
-        try:
-            bentoml_version = config().get('bentoml_deploy_version')
-        except BentoMLConfigException:
-            pass
         self._pip_dependencies = ["bentoml=={}".format(bentoml_version)]
 
     def get_conda_env_name(self):

--- a/bentoml/service_env.py
+++ b/bentoml/service_env.py
@@ -20,7 +20,6 @@ import os
 from sys import version_info
 from ruamel.yaml import YAML
 
-from bentoml.exceptions import BentoMLConfigException
 from bentoml.utils import Path, StringIO
 from bentoml import __version__ as LOCAL_BENTOML_VERSION
 from bentoml import config

--- a/bentoml/service_env.py
+++ b/bentoml/service_env.py
@@ -22,7 +22,6 @@ from ruamel.yaml import YAML
 
 from bentoml.utils import Path, StringIO
 from bentoml import __version__ as LOCAL_BENTOML_VERSION
-from bentoml import config
 
 PYTHON_VERSION = "{major}.{minor}.{micro}".format(
     major=version_info.major, minor=version_info.minor, micro=version_info.micro

--- a/bentoml/utils/__init__.py
+++ b/bentoml/utils/__init__.py
@@ -17,10 +17,14 @@ from __future__ import division
 from __future__ import print_function
 
 import re
+import os
+import imp
 
 from six.moves.urllib.parse import urlparse, uses_netloc, uses_params, uses_relative
 from google.protobuf.json_format import MessageToJson, MessageToDict
 from ruamel.yaml import YAML
+
+from bentoml import __version__ as BENTOML_VERSION, _version as version_mod
 
 try:
     from pathlib import Path
@@ -75,3 +79,21 @@ def ProtoMessageToDict(protobuf_msg, **kwargs):
         kwargs['preserving_proto_field_name'] = True
 
     return MessageToDict(protobuf_msg, **kwargs)
+
+
+def _is_pypi_release():
+    is_installed_package = hasattr(version_mod, 'version_json')
+    is_tagged = not BENTOML_VERSION.startswith('0+untagged')
+    is_clean = not version_mod.get_versions()['dirty']
+    return is_installed_package and is_tagged and is_clean
+
+
+def _is_bentoml_in_editor_mode():
+    is_editor = False
+    bentoml_location = Path(imp.find_module('bentoml')[1])
+
+    setup_py_path = os.path.join(bentoml_location, 'setup.py')
+    if not _is_pypi_release() and os.path.isfile(setup_py_path):
+        is_editor = True
+
+    return is_editor

--- a/bentoml/utils/__init__.py
+++ b/bentoml/utils/__init__.py
@@ -92,7 +92,12 @@ def _is_pypi_release():
 # branches of BentoML library, it gets triggered when BentoML module is installed
 # via "pip install --editable ."
 def _is_bentoml_in_develop_mode():
-    module_location, = importlib.util.find_spec('bentoml').submodule_search_locations
+    try:
+        module_location, = importlib.util.find_spec('bentoml').submodule_search_locations
+    except AttributeError:
+        # python 2.7 doesn't have importlib.util, will fall back to imp instead
+        import imp
+        _, module_location, _ = imp.find_module('bentoml')
     bentoml_location = Path(module_location)
 
     setup_py_path = os.path.abspath(os.path.join(bentoml_location, '..', 'setup.py'))

--- a/bentoml/utils/__init__.py
+++ b/bentoml/utils/__init__.py
@@ -25,7 +25,6 @@ from google.protobuf.json_format import MessageToJson, MessageToDict
 from ruamel.yaml import YAML
 
 from bentoml import __version__ as BENTOML_VERSION, _version as version_mod
-from bentoml import config
 
 try:
     from pathlib import Path

--- a/bentoml/utils/__init__.py
+++ b/bentoml/utils/__init__.py
@@ -88,7 +88,7 @@ def _is_pypi_release():
     return is_installed_package and is_tagged and is_clean
 
 
-def _is_bentoml_in_editor_mode():
+def _is_bentoml_in_development_mode():
     is_editor = False
     bentoml_location = Path(imp.find_module('bentoml')[1]).parent
 

--- a/bentoml/utils/__init__.py
+++ b/bentoml/utils/__init__.py
@@ -98,13 +98,8 @@ def _is_bentoml_in_develop_mode():
         # python 2.7 doesn't have importlib.util, will fall back to imp instead
         import imp
         _, module_location, _ = imp.find_module('bentoml')
-    bentoml_location = Path(module_location)
 
-    try:
-        setup_py_path = os.path.abspath(os.path.join(bentoml_location, '..', 'setup.py'))
-    except AttributeError:
-        # python 2.7 'PosixPath' object has no attribute 'endswith'
-        setup_py_path = os.path.join(bentoml_location.parent, 'setup.py')
+    setup_py_path = os.path.abspath(os.path.join(module_location, '..', 'setup.py'))
     if not _is_pypi_release() and os.path.isfile(setup_py_path):
         return True
 

--- a/bentoml/utils/__init__.py
+++ b/bentoml/utils/__init__.py
@@ -90,7 +90,7 @@ def _is_pypi_release():
 
 def _is_bentoml_in_editor_mode():
     is_editor = False
-    bentoml_location = Path(imp.find_module('bentoml')[1])
+    bentoml_location = Path(imp.find_module('bentoml')[1]).parent
 
     setup_py_path = os.path.join(bentoml_location, 'setup.py')
     if not _is_pypi_release() and os.path.isfile(setup_py_path):

--- a/bentoml/utils/__init__.py
+++ b/bentoml/utils/__init__.py
@@ -100,7 +100,11 @@ def _is_bentoml_in_develop_mode():
         _, module_location, _ = imp.find_module('bentoml')
     bentoml_location = Path(module_location)
 
-    setup_py_path = os.path.abspath(os.path.join(bentoml_location, '..', 'setup.py'))
+    try:
+        setup_py_path = os.path.abspath(os.path.join(bentoml_location, '..', 'setup.py'))
+    except AttributeError:
+        # python 2.7 'PosixPath' object has no attribute 'endswith'
+        setup_py_path = os.path.join(bentoml_location.parent, 'setup.py')
     if not _is_pypi_release() and os.path.isfile(setup_py_path):
         return True
 

--- a/bentoml/utils/__init__.py
+++ b/bentoml/utils/__init__.py
@@ -100,7 +100,4 @@ def _is_bentoml_in_develop_mode():
         _, module_location, _ = imp.find_module('bentoml')
 
     setup_py_path = os.path.abspath(os.path.join(module_location, '..', 'setup.py'))
-    if not _is_pypi_release() and os.path.isfile(setup_py_path):
-        return True
-
-    return False
+    return not _is_pypi_release() and os.path.isfile(setup_py_path)

--- a/bentoml/utils/__init__.py
+++ b/bentoml/utils/__init__.py
@@ -93,10 +93,13 @@ def _is_pypi_release():
 # via "pip install --editable ."
 def _is_bentoml_in_develop_mode():
     try:
-        module_location, = importlib.util.find_spec('bentoml').submodule_search_locations
+        module_location, = importlib.util.find_spec(
+            'bentoml'
+        ).submodule_search_locations
     except AttributeError:
         # python 2.7 doesn't have importlib.util, will fall back to imp instead
         import imp
+
         _, module_location, _ = imp.find_module('bentoml')
 
     setup_py_path = os.path.abspath(os.path.join(module_location, '..', 'setup.py'))

--- a/bentoml/utils/__init__.py
+++ b/bentoml/utils/__init__.py
@@ -18,13 +18,14 @@ from __future__ import print_function
 
 import re
 import os
-import imp
+import importlib
 
 from six.moves.urllib.parse import urlparse, uses_netloc, uses_params, uses_relative
 from google.protobuf.json_format import MessageToJson, MessageToDict
 from ruamel.yaml import YAML
 
 from bentoml import __version__ as BENTOML_VERSION, _version as version_mod
+from bentoml import config
 
 try:
     from pathlib import Path
@@ -88,12 +89,15 @@ def _is_pypi_release():
     return is_installed_package and is_tagged and is_clean
 
 
-def _is_bentoml_in_development_mode():
-    is_editor = False
-    bentoml_location = Path(imp.find_module('bentoml')[1]).parent
+# this is for BentoML developer to create BentoService containing custom develop
+# branches of BentoML library, it gets triggered when BentoML module is installed
+# via "pip install --editable ."
+def _is_bentoml_in_develop_mode():
+    module_location, = importlib.util.find_spec('bentoml').submodule_search_locations
+    bentoml_location = Path(module_location)
 
-    setup_py_path = os.path.join(bentoml_location, 'setup.py')
+    setup_py_path = os.path.abspath(os.path.join(bentoml_location, '..', 'setup.py'))
     if not _is_pypi_release() and os.path.isfile(setup_py_path):
-        is_editor = True
+        return True
 
-    return is_editor
+    return False

--- a/bentoml/utils/usage_stats.py
+++ b/bentoml/utils/usage_stats.py
@@ -27,7 +27,8 @@ import atexit
 import uuid
 import requests
 
-from bentoml import config, __version__ as BENTOML_VERSION, _version as version_mod
+from bentoml.utils import _is_pypi_release
+from bentoml import config
 
 
 logger = logging.getLogger(__name__)
@@ -40,13 +41,6 @@ PY_VERSION = "{major}.{minor}.{micro}".format(
     micro=sys.version_info.micro,
 )
 SESSION_ID = str(uuid.uuid4())  # uuid that marks current python session
-
-
-def _is_pypi_release():
-    is_installed_package = hasattr(version_mod, 'version_json')
-    is_tagged = not BENTOML_VERSION.startswith('0+untagged')
-    is_clean = not version_mod.get_versions()['dirty']
-    return is_installed_package and is_tagged and is_clean
 
 
 # Use dev amplitude key

--- a/bentoml/utils/usage_stats.py
+++ b/bentoml/utils/usage_stats.py
@@ -29,6 +29,7 @@ import requests
 
 from bentoml.utils import _is_pypi_release
 from bentoml import config
+from bentoml import __version__ as BENTOML_VERSION
 
 
 logger = logging.getLogger(__name__)

--- a/bentoml/yatai/yatai_service_impl.py
+++ b/bentoml/yatai/yatai_service_impl.py
@@ -115,7 +115,7 @@ class YataiService(YataiServicer):
             # find deployment operator based on deployment spec
             operator = get_deployment_operator(request.deployment)
 
-            # Generate BentoML whl file to repository
+            # Generate BentoML bundle to repository
             if not _is_pypi_release():
                 add_local_bentoml_package_to_repo(request.deployment, self.repo)
 

--- a/bentoml/yatai/yatai_service_impl.py
+++ b/bentoml/yatai/yatai_service_impl.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 import logging
 
-
+from bentoml.deployment.utils import add_local_bentoml_package_to_repo
 from bentoml.proto.deployment_pb2 import (
     GetDeploymentResponse,
     DescribeDeploymentResponse,
@@ -46,6 +46,7 @@ from bentoml.exceptions import BentoMLException
 from bentoml.repository import BentoRepository
 from bentoml.repository.metadata_store import BentoMetadataStore
 from bentoml.db import init_db
+from bentoml.utils.usage_stats import _is_pypi_release
 from bentoml.yatai.status import Status
 from bentoml.proto import status_pb2
 from bentoml.utils import ProtoMessageToDict
@@ -113,6 +114,10 @@ class YataiService(YataiServicer):
             self.deployment_store.insert_or_update(request.deployment)
             # find deployment operator based on deployment spec
             operator = get_deployment_operator(request.deployment)
+
+            # Generate BentoML whl file to repository
+            if not _is_pypi_release():
+                add_local_bentoml_package_to_repo(request.deployment, self.repo)
 
             # deploying to target platform
             response = operator.apply(

--- a/bentoml/yatai/yatai_service_impl.py
+++ b/bentoml/yatai/yatai_service_impl.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 
 import logging
 
-from bentoml.deployment.utils import add_local_bentoml_package_to_repo
 from bentoml.proto.deployment_pb2 import (
     GetDeploymentResponse,
     DescribeDeploymentResponse,
@@ -48,7 +47,7 @@ from bentoml.repository.metadata_store import BentoMetadataStore
 from bentoml.db import init_db
 from bentoml.yatai.status import Status
 from bentoml.proto import status_pb2
-from bentoml.utils import ProtoMessageToDict, _is_bentoml_in_development_mode
+from bentoml.utils import ProtoMessageToDict
 from bentoml.utils.validator import validate_deployment_pb_schema
 from bentoml import __version__ as BENTOML_VERSION
 
@@ -113,11 +112,6 @@ class YataiService(YataiServicer):
             self.deployment_store.insert_or_update(request.deployment)
             # find deployment operator based on deployment spec
             operator = get_deployment_operator(request.deployment)
-
-            # if bentoml package in editor mode(pip install -e), will include
-            # that bentoml package to bento archive
-            if _is_bentoml_in_development_mode():
-                add_local_bentoml_package_to_repo(request.deployment, self.repo)
 
             # deploying to target platform
             response = operator.apply(

--- a/bentoml/yatai/yatai_service_impl.py
+++ b/bentoml/yatai/yatai_service_impl.py
@@ -48,7 +48,7 @@ from bentoml.repository.metadata_store import BentoMetadataStore
 from bentoml.db import init_db
 from bentoml.yatai.status import Status
 from bentoml.proto import status_pb2
-from bentoml.utils import ProtoMessageToDict, _is_bentoml_in_editor_mode
+from bentoml.utils import ProtoMessageToDict, _is_bentoml_in_development_mode
 from bentoml.utils.validator import validate_deployment_pb_schema
 from bentoml import __version__ as BENTOML_VERSION
 
@@ -116,7 +116,7 @@ class YataiService(YataiServicer):
 
             # if bentoml package in editor mode(pip install -e), will include
             # that bentoml package to bento archive
-            if _is_bentoml_in_editor_mode():
+            if _is_bentoml_in_development_mode():
                 add_local_bentoml_package_to_repo(request.deployment, self.repo)
 
             # deploying to target platform

--- a/bentoml/yatai/yatai_service_impl.py
+++ b/bentoml/yatai/yatai_service_impl.py
@@ -46,10 +46,9 @@ from bentoml.exceptions import BentoMLException
 from bentoml.repository import BentoRepository
 from bentoml.repository.metadata_store import BentoMetadataStore
 from bentoml.db import init_db
-from bentoml.utils.usage_stats import _is_pypi_release
 from bentoml.yatai.status import Status
 from bentoml.proto import status_pb2
-from bentoml.utils import ProtoMessageToDict
+from bentoml.utils import ProtoMessageToDict, _is_bentoml_in_editor_mode
 from bentoml.utils.validator import validate_deployment_pb_schema
 from bentoml import __version__ as BENTOML_VERSION
 
@@ -115,8 +114,9 @@ class YataiService(YataiServicer):
             # find deployment operator based on deployment spec
             operator = get_deployment_operator(request.deployment)
 
-            # Generate BentoML bundle to repository
-            if not _is_pypi_release():
+            # if bentoml package in editor mode(pip install -e), will include
+            # that bentoml package to bento archive
+            if _is_bentoml_in_editor_mode():
                 add_local_bentoml_package_to_repo(request.deployment, self.repo)
 
             # deploying to target platform


### PR DESCRIPTION
If `bentoml_deploy_version` is set in bentoml.cfg. When archiving service, it will use that version instead of the installed bentoml version.

When deploying to the cloud, if Bentoml is in editor mode(BentoML module is installed with `pip install -e`), we will generate tar.gz file of the BentoML module and placed it in the archive directory for deploying.  Deployed service will have the targz file's BentoML installed