### PR TITLE
Update clipper/python36-closure-container's version from 0.3 to 0.4.1

### DIFF
--- a/bentoml/deployment/clipper/templates.py
+++ b/bentoml/deployment/clipper/templates.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
 """
 
 DOCKERFILE_CLIPPER = """\
-FROM clipper/python36-closure-container:0.3
+FROM clipper/python36-closure-container:0.4.1
 
 # Install miniconda3 for python. Copied from
 # https://github.com/ContinuumIO/docker-images/blob/master/miniconda3/debian/Dockerfile


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below.)

What changes were proposed in this pull request?
------------------------------------------------
Hi, I'm the maintainer of Clipper. `Clipper` was updated from 0.3 to 0.4.1 recently. See [this](https://github.com/ucbrise/clipper/releases/tag/v0.4.1).

Does this close any currently open issues?
------------------------------------------
No.

How was this patch tested?
--------------------------
No. You don't have any unit-tests about Clipper.