### PR TITLE
fix include bundle requirement for serverless deployment

### DIFF
--- a/bentoml/deployment/serverless/serverless_utils.py
+++ b/bentoml/deployment/serverless/serverless_utils.py
@@ -168,7 +168,7 @@ class TemporaryServerlessContent(object):
             bundled_files = os.listdir(dest_bundle_path)
             has_bentoml_bundle = False
             for index, bundled_file_name in enumerate(bundled_files):
-                bundled_files[index] = './bundled_pip_dependencies/{}\n'.format(
+                bundled_files[index] = '\n./bundled_pip_dependencies/{}'.format(
                     bundled_file_name
                 )
                 # If file name start with `BentoML-`, assuming it is a


### PR DESCRIPTION
Move '\n' to the front, so the first entry won't be on the same line as the last required module in requirements.txt
