### PR TITLE
KerasModelArtifact Feature: Save As Weights & JSON

### DIFF
--- a/bentoml/artifact/keras_model_artifact.py
+++ b/bentoml/artifact/keras_model_artifact.py
@@ -39,7 +39,13 @@ class KerasModelArtifact(BentoServiceArtifact):
         store_as_json_and_weights (bool): flag allowing storage of the Keras model as JSON and weights
     """
 
-    def __init__(self, name, custom_objects=None, model_extension=".h5", store_as_json_and_weights=False):
+    def __init__(
+        self,
+        name,
+        custom_objects=None,
+        model_extension=".h5",
+        store_as_json_and_weights=False,
+    ):
         super(KerasModelArtifact, self).__init__(name)
         self._model_extension = model_extension
         self._store_as_json_and_weights = store_as_json_and_weights
@@ -129,7 +135,7 @@ class KerasModelArtifact(BentoServiceArtifact):
                 if self._store_as_json_and_weights:
                     with open(self._model_json_path(path), 'r') as json_file:
                         model_json = json_file.read()
-                    model = keras.models.model_from_json(loaded_model_json)
+                    model = keras.models.model_from_json(model_json)
                     model.load_weights(self._model_weights_path(path))
                 # otherwise, load keras model via standard load_model
                 else:

--- a/bentoml/artifact/keras_model_artifact.py
+++ b/bentoml/artifact/keras_model_artifact.py
@@ -135,7 +135,9 @@ class KerasModelArtifact(BentoServiceArtifact):
                 if self._store_as_json_and_weights:
                     with open(self._model_json_path(path), 'r') as json_file:
                         model_json = json_file.read()
-                    model = keras.models.model_from_json(model_json)
+                    model = keras.models.model_from_json(
+                        model_json, custom_objects=self.custom_objects
+                    )
                     model.load_weights(self._model_weights_path(path))
                 # otherwise, load keras model via standard load_model
                 else:

--- a/bentoml/artifact/keras_model_artifact.py
+++ b/bentoml/artifact/keras_model_artifact.py
@@ -23,7 +23,7 @@ from bentoml.artifact import BentoServiceArtifact, BentoServiceArtifactWrapper
 
 try:
     import tensorflow as tf
-    from tensorflow.python import keras
+    import keras
 except ImportError:
     tf = None
     keras = None

--- a/bentoml/artifact/keras_model_artifact.py
+++ b/bentoml/artifact/keras_model_artifact.py
@@ -36,7 +36,8 @@ class KerasModelArtifact(BentoServiceArtifact):
     Args:
         name (string): name of the artifact
         custom_objects (dict): dictionary of Keras custom objects for model
-        store_as_json_and_weights (bool): flag allowing storage of the Keras model as JSON and weights
+        store_as_json_and_weights (bool): flag allowing storage of the Keras
+            model as JSON and weights
     """
 
     def __init__(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,7 @@ class TestBentoService(bentoml.BentoService):
         return self.artifacts.model.predictTorch(input_data)
 
     if sys.version_info >= (3, 6):
+
         @bentoml.api(bentoml.handlers.FastaiImageHandler)
         def predictFastaiImage(self, input_data):
             return self.artifacts.model.predictImage(input_data)
@@ -70,6 +71,7 @@ class TestBentoService(bentoml.BentoService):
         )
         def predictFastaiImages(self, original, compared):
             return all(original.data[0, 0] == compared.data[0, 0])
+
 
 @pytest.fixture()
 def bento_service():

--- a/tests/handlers/test_fastai_image_handler.py
+++ b/tests/handlers/test_fastai_image_handler.py
@@ -9,6 +9,7 @@ def test_fastai_image_handler(capsys, tmpdir):
         # fast ai is required 3.6 or higher.
         assert True
     else:
+
         class ImageHandlerModelForFastai(bentoml.BentoService):
             @bentoml.api(FastaiImageHandler)
             def predict(self, image):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -38,6 +38,7 @@ def test_fastai_image_handler_pip_dependencies():
         # fast ai is required 3.6 or higher.
         assert True
     else:
+
         class TestFastAiImageService(bentoml.BentoService):
             @bentoml.api(bentoml.handlers.FastaiImageHandler)
             def test(self, image):


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
This PR introduces the option for users of `KerasModelArtifact` to store only what is absolutely necessary for inference. This is particularly helpful for rapid, space-conscious deployments of Keras models that may have training configuration or history bloat.

Note: For `Keras` models that have already reduced to minimal information for inference, this option is still viable but will not reduce model storage size. Other options (i.e. translation to [`Tensorlow Lite`](https://www.tensorflow.org/lite/convert)) are necessary in this case.

Does this close any currently open issues?
------------------------------------------
No.

How was this patch tested?
--------------------------
`tox` passes on all supported environments. No tests for this specific feature have been written, but a successful deployment using this feature has been made.

Additionally, all files were auto-formatted using the provided formatting script.