### PR TITLE
[ISSUE-336] Support both keras and tf.keras in KerasModelArtifact

### DIFF
--- a/bentoml/artifact/keras_model_artifact.py
+++ b/bentoml/artifact/keras_model_artifact.py
@@ -17,17 +17,16 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import importlib
 
 from bentoml.utils import cloudpickle
 from bentoml.artifact import BentoServiceArtifact, BentoServiceArtifactWrapper
+from bentoml.exceptions import BentoMLArtifactLoadingException
 
 try:
     import tensorflow as tf
-    import keras
 except ImportError:
     tf = None
-    keras = None
-
 
 class KerasModelArtifact(BentoServiceArtifact):
     """
@@ -48,12 +47,25 @@ class KerasModelArtifact(BentoServiceArtifact):
         store_as_json_and_weights=False,
     ):
         super(KerasModelArtifact, self).__init__(name)
+
+        if tf is None:
+            raise ImportError(
+                "Tensorflow package is required to use KerasModelArtifact."
+            )
+
         self._model_extension = model_extension
         self._store_as_json_and_weights = store_as_json_and_weights
+
+        # By default assume using tf.python.keras module
+        self._keras_module_name = tf.python.keras.__name__
 
         self.custom_objects = custom_objects
         self.graph = None
         self.sess = None
+
+    def _keras_module_name_path(self, base_path):
+        # The name of the keras module used, can be 'keras' or 'tensorflow.python.keras'
+        return os.path.join(base_path, self.name + '_keras_module_name.txt')
 
     def _custom_objects_path(self, base_path):
         return os.path.join(base_path, self.name + '_custom_objects.pkl')
@@ -70,7 +82,8 @@ class KerasModelArtifact(BentoServiceArtifact):
     def bind_keras_backend_session(self):
         if tf is None:
             raise ImportError(
-                "Tensorflow package is required to use KerasModelArtifact."
+                "Tensorflow package is required to use KerasModelArtifact. BentoML "
+                "currently only support using Keras with Tensorflow backend."
             )
 
         self.sess = tf.compat.v1.keras.backend.get_session()
@@ -79,7 +92,8 @@ class KerasModelArtifact(BentoServiceArtifact):
     def creat_session(self):
         if tf is None:
             raise ImportError(
-                "Tensorflow package is required to use KerasModelArtifact."
+                "Tensorflow package is required to use KerasModelArtifact. BentoML "
+                "currently only support using Keras with Tensorflow backend."
             )
 
         self.graph = tf.compat.v1.get_default_graph()
@@ -89,17 +103,11 @@ class KerasModelArtifact(BentoServiceArtifact):
     def pack(self, data):  # pylint:disable=arguments-differ
         if tf is None:
             raise ImportError(
-                "Tensorflow package is required to use KerasModelArtifact."
+                "Tensorflow package is required to use KerasModelArtifact. BentoML "
+                "currently only support using Keras with Tensorflow backend."
             )
 
-        if isinstance(data, keras.engine.training.Model):
-            model = data
-            custom_objects = self.custom_objects
-        elif (
-            isinstance(data, dict)
-            and 'model' in data
-            and isinstance(data['model'], keras.engine.training.Model)
-        ):
+        if isinstance(data, dict):
             model = data['model']
             custom_objects = (
                 data['custom_objects']
@@ -107,9 +115,25 @@ class KerasModelArtifact(BentoServiceArtifact):
                 else self.custom_objects
             )
         else:
-            raise ValueError(
-                "KerasModelArtifact#pack expects type: keras.engine.training.Model"
+            model = data
+            custom_objects = self.custom_objects
+
+        if not isinstance(data, tf.python.keras.engine.training.Model):
+            error_msg = (
+                "KerasModelArtifact#pack expects model argument to be type: "
+                "keras.engine.training.Model or "
+                "tf.python.keras.engine.training.Model, instead got: "
+                "{}".format(type(model))
             )
+            try:
+                import keras
+
+                if not isinstance(data, keras.engine.training.Model):
+                    raise ValueError(error_msg)
+                else:
+                    self._keras_module_name = keras.__name__
+            except ImportError:
+                raise ValueError(error_msg)
 
         self.bind_keras_backend_session()
         model._make_predict_function()
@@ -118,8 +142,20 @@ class KerasModelArtifact(BentoServiceArtifact):
     def load(self, path):
         if tf is None:
             raise ImportError(
-                "Tensorflow package is required to use KerasModelArtifact."
+                "Tensorflow package is required to use KerasModelArtifact. BentoML "
+                "currently only support using Keras with Tensorflow backend."
             )
+
+        if os.isfile(self._keras_module_name_path(path)):
+            with open(self._keras_module_name_path(path), "rb") as text_file:
+                keras_module_name = text_file.read().decode("utf-8")
+                try:
+                    keras_module = importlib.import_module(keras_module_name)
+                except ImportError:
+                    raise BentoMLArtifactLoadingException(
+                        "Failed to import '{}' module when loading saved "
+                        "KerasModelArtifact".format(keras_module_name)
+                    )
 
         self.creat_session()
 
@@ -136,13 +172,13 @@ class KerasModelArtifact(BentoServiceArtifact):
                 if self._store_as_json_and_weights:
                     with open(self._model_json_path(path), 'r') as json_file:
                         model_json = json_file.read()
-                    model = keras.models.model_from_json(
+                    model = keras_module.models.model_from_json(
                         model_json, custom_objects=self.custom_objects
                     )
                     model.load_weights(self._model_weights_path(path))
                 # otherwise, load keras model via standard load_model
                 else:
-                    model = keras.models.load_model(
+                    model = keras_module.models.load_model(
                         self._model_file_path(path), custom_objects=self.custom_objects
                     )
         return self.pack(model)
@@ -152,17 +188,6 @@ class _KerasModelArtifactWrapper(BentoServiceArtifactWrapper):
     def __init__(self, spec, model, custom_objects):
         super(_KerasModelArtifactWrapper, self).__init__(spec)
 
-        if tf is None:
-            raise ImportError(
-                "Tensorflow package is required to use KerasModelArtifact."
-            )
-
-        if not isinstance(model, keras.engine.training.Model):
-            raise ValueError(
-                "Expected `model` argument to be a "
-                "`keras.engine.training.Model` instance"
-            )
-
         self.graph = spec.graph
         self.sess = spec.sess
         self._model = model
@@ -171,6 +196,10 @@ class _KerasModelArtifactWrapper(BentoServiceArtifactWrapper):
         self._model_wrapper = _KerasModelWrapper(self._model, self.graph, self.sess)
 
     def save(self, dst):
+        # save the keras module name to be used when loading
+        with open(self.spec._keras_module_name_path(dst), "wb") as text_file:
+            text_file.write(self.spec._keras_module_name.encode("utf-8"))
+
         # save custom_objects for model
         cloudpickle.dump(
             self._custom_objects, open(self.spec._custom_objects_path(dst), "wb")

--- a/bentoml/artifact/keras_model_artifact.py
+++ b/bentoml/artifact/keras_model_artifact.py
@@ -23,6 +23,11 @@ from bentoml.utils import cloudpickle
 from bentoml.artifact import BentoServiceArtifact, BentoServiceArtifactWrapper
 from bentoml.exceptions import BentoMLArtifactLoadingException
 
+import keras
+keras.engine.network.Network
+
+keras.engine.Model
+
 try:
     import tensorflow as tf
 except ImportError:
@@ -57,15 +62,15 @@ class KerasModelArtifact(BentoServiceArtifact):
         self._model_extension = model_extension
         self._store_as_json_and_weights = store_as_json_and_weights
 
-        # By default assume using tf.python.keras module
-        self._keras_module_name = tf.python.keras.__name__
+        # By default assume using tf.keras module
+        self._keras_module_name = tf.keras.__name__
 
         self.custom_objects = custom_objects
         self.graph = None
         self.sess = None
 
     def _keras_module_name_path(self, base_path):
-        # The name of the keras module used, can be 'keras' or 'tensorflow.python.keras'
+        # The name of the keras module used, can be 'keras' or 'tensorflow.keras'
         return os.path.join(base_path, self.name + '_keras_module_name.txt')
 
     def _custom_objects_path(self, base_path):
@@ -98,8 +103,8 @@ class KerasModelArtifact(BentoServiceArtifact):
             )
 
         self.graph = tf.compat.v1.get_default_graph()
-        self.sess = tf.Session(graph=self.graph)
-        tf.keras.backend.set_session(self.sess)
+        self.sess = tf.compat.v1.Session(graph=self.graph)
+        tf.compat.v1.keras.backend.set_session(self.sess)
 
     def pack(self, data):  # pylint:disable=arguments-differ
         if tf is None:
@@ -119,17 +124,17 @@ class KerasModelArtifact(BentoServiceArtifact):
             model = data
             custom_objects = self.custom_objects
 
-        if not isinstance(data, tf.python.keras.engine.training.Model):
+        if not isinstance(data, tf.keras.models.Model):
             error_msg = (
                 "KerasModelArtifact#pack expects model argument to be type: "
                 "keras.engine.training.Model or "
-                "tf.python.keras.engine.training.Model, instead got: "
+                "tf.keras.engine.training.Model, instead got: "
                 "{}".format(type(model))
             )
             try:
                 import keras
 
-                if not isinstance(data, keras.engine.training.Model):
+                if not isinstance(data, keras.engine.network.Network):
                     raise ValueError(error_msg)
                 else:
                     self._keras_module_name = keras.__name__
@@ -147,7 +152,7 @@ class KerasModelArtifact(BentoServiceArtifact):
                 "currently only support using Keras with Tensorflow backend."
             )
 
-        if os.isfile(self._keras_module_name_path(path)):
+        if os.path.isfile(self._keras_module_name_path(path)):
             with open(self._keras_module_name_path(path), "rb") as text_file:
                 keras_module_name = text_file.read().decode("utf-8")
                 try:

--- a/bentoml/artifact/keras_model_artifact.py
+++ b/bentoml/artifact/keras_model_artifact.py
@@ -145,13 +145,6 @@ class KerasModelArtifact(BentoServiceArtifact):
         return _KerasModelArtifactWrapper(self, model, custom_objects)
 
     def load(self, path):
-        try:
-            import tensorflow as tf
-        except ImportError:
-            raise ImportError(
-                "Tensorflow package is required to use KerasModelArtifact. BentoML "
-                "currently only support using Keras with Tensorflow backend."
-            )
         if os.path.isfile(self._keras_module_name_path(path)):
             with open(self._keras_module_name_path(path), "rb") as text_file:
                 keras_module_name = text_file.read().decode("utf-8")

--- a/bentoml/artifact/keras_model_artifact.py
+++ b/bentoml/artifact/keras_model_artifact.py
@@ -23,16 +23,6 @@ from bentoml.utils import cloudpickle
 from bentoml.artifact import BentoServiceArtifact, BentoServiceArtifactWrapper
 from bentoml.exceptions import BentoMLArtifactLoadingException
 
-import keras
-keras.engine.network.Network
-
-keras.engine.Model
-
-try:
-    import tensorflow as tf
-except ImportError:
-    tf = None
-
 
 class KerasModelArtifact(BentoServiceArtifact):
     """
@@ -54,9 +44,12 @@ class KerasModelArtifact(BentoServiceArtifact):
     ):
         super(KerasModelArtifact, self).__init__(name)
 
-        if tf is None:
+        try:
+            import tensorflow as tf
+        except ImportError:
             raise ImportError(
-                "Tensorflow package is required to use KerasModelArtifact."
+                "Tensorflow package is required to use KerasModelArtifact. BentoML "
+                "currently only support using Keras with Tensorflow backend."
             )
 
         self._model_extension = model_extension
@@ -86,7 +79,9 @@ class KerasModelArtifact(BentoServiceArtifact):
         return os.path.join(base_path, self.name + '_json.json')
 
     def bind_keras_backend_session(self):
-        if tf is None:
+        try:
+            import tensorflow as tf
+        except ImportError:
             raise ImportError(
                 "Tensorflow package is required to use KerasModelArtifact. BentoML "
                 "currently only support using Keras with Tensorflow backend."
@@ -96,7 +91,9 @@ class KerasModelArtifact(BentoServiceArtifact):
         self.graph = self.sess.graph
 
     def creat_session(self):
-        if tf is None:
+        try:
+            import tensorflow as tf
+        except ImportError:
             raise ImportError(
                 "Tensorflow package is required to use KerasModelArtifact. BentoML "
                 "currently only support using Keras with Tensorflow backend."
@@ -107,7 +104,9 @@ class KerasModelArtifact(BentoServiceArtifact):
         tf.compat.v1.keras.backend.set_session(self.sess)
 
     def pack(self, data):  # pylint:disable=arguments-differ
-        if tf is None:
+        try:
+            import tensorflow as tf
+        except ImportError:
             raise ImportError(
                 "Tensorflow package is required to use KerasModelArtifact. BentoML "
                 "currently only support using Keras with Tensorflow backend."
@@ -146,12 +145,13 @@ class KerasModelArtifact(BentoServiceArtifact):
         return _KerasModelArtifactWrapper(self, model, custom_objects)
 
     def load(self, path):
-        if tf is None:
+        try:
+            import tensorflow as tf
+        except ImportError:
             raise ImportError(
                 "Tensorflow package is required to use KerasModelArtifact. BentoML "
                 "currently only support using Keras with Tensorflow backend."
             )
-
         if os.path.isfile(self._keras_module_name_path(path)):
             with open(self._keras_module_name_path(path), "rb") as text_file:
                 keras_module_name = text_file.read().decode("utf-8")

--- a/bentoml/artifact/keras_model_artifact.py
+++ b/bentoml/artifact/keras_model_artifact.py
@@ -28,6 +28,7 @@ try:
 except ImportError:
     tf = None
 
+
 class KerasModelArtifact(BentoServiceArtifact):
     """
     Abstraction for saving/loading Keras model

--- a/bentoml/artifact/keras_model_artifact.py
+++ b/bentoml/artifact/keras_model_artifact.py
@@ -113,7 +113,7 @@ class KerasModelArtifact(BentoServiceArtifact):
 
         self.bind_keras_backend_session()
         model._make_predict_function()
-        return _TfKerasModelArtifactWrapper(self, model, custom_objects)
+        return _KerasModelArtifactWrapper(self, model, custom_objects)
 
     def load(self, path):
         if tf is None:
@@ -148,9 +148,9 @@ class KerasModelArtifact(BentoServiceArtifact):
         return self.pack(model)
 
 
-class _TfKerasModelArtifactWrapper(BentoServiceArtifactWrapper):
+class _KerasModelArtifactWrapper(BentoServiceArtifactWrapper):
     def __init__(self, spec, model, custom_objects):
-        super(_TfKerasModelArtifactWrapper, self).__init__(spec)
+        super(_KerasModelArtifactWrapper, self).__init__(spec)
 
         if tf is None:
             raise ImportError(
@@ -168,7 +168,7 @@ class _TfKerasModelArtifactWrapper(BentoServiceArtifactWrapper):
         self._model = model
         self._custom_objects = custom_objects
         self._store_as_json_and_weights = spec._store_as_json_and_weights
-        self._model_wrapper = _TfKerasModelWrapper(self._model, self.graph, self.sess)
+        self._model_wrapper = _KerasModelWrapper(self._model, self.graph, self.sess)
 
     def save(self, dst):
         # save custom_objects for model
@@ -190,7 +190,7 @@ class _TfKerasModelArtifactWrapper(BentoServiceArtifactWrapper):
         return self._model_wrapper
 
 
-class _TfKerasModelWrapper:
+class _KerasModelWrapper:
     def __init__(self, keras_model, graph, sess):
         self.keras_model = keras_model
         self.graph = graph

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -274,6 +274,7 @@ def create_bento_service_cli(archive_path=None):
         track_cli('serve_gunicorn')
 
         from bentoml.server.gunicorn_server import GunicornBentoServer
+
         gunicorn_app = GunicornBentoServer(archive_path, port, workers, timeout)
         gunicorn_app.run()
 

--- a/bentoml/exceptions.py
+++ b/bentoml/exceptions.py
@@ -26,6 +26,10 @@ class BentoMLException(Exception):
     status_code = 500
 
 
+class BentoMLArtifactLoadingException(BentoMLException):
+    pass
+
+
 class BentoMLConfigException(BentoMLException):
     pass
 


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
* Added support for pure Keras model (instead of model created with tf.keras module), thanks @ghunkins for reporting this issue

Does this close any currently open issues?
------------------------------------------
KerasModelArtifact#pack expects type: keras.engine.training.Model #336

How was this patch tested?
--------------------------
Tested locally, will follow up with more unit tests