### PR TITLE
Imporve BentoML module loading time

### DIFF
--- a/bentoml/__init__.py
+++ b/bentoml/__init__.py
@@ -56,5 +56,5 @@ __all__ = [
     "save",
     "save_to_dir",
     "handlers",
-    "artifact"
+    "artifact",
 ]

--- a/bentoml/__init__.py
+++ b/bentoml/__init__.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+
 from ._version import get_versions
 
 __version__ = get_versions()['version']
@@ -28,7 +29,6 @@ from bentoml.utils.log import configure_logging
 configure_logging()
 
 from bentoml.archive import load, save_to_dir
-from bentoml import handlers
 from bentoml.service import (
     BentoService,
     api_decorator as api,
@@ -52,8 +52,9 @@ __all__ = [
     "ver",
     "metrics",
     "BentoService",
-    "handlers",
     "load",
     "save",
     "save_to_dir",
+    "handlers",
+    "artifact"
 ]

--- a/bentoml/configuration/configparser.py
+++ b/bentoml/configuration/configparser.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 import os
 import logging
 from collections import OrderedDict
-
 from configparser import ConfigParser
 
 from bentoml.exceptions import BentoMLConfigException

--- a/bentoml/handlers/fastai_image_handler.py
+++ b/bentoml/handlers/fastai_image_handler.py
@@ -37,7 +37,7 @@ def _import_fastai_vision():
     try:
         from fastai import vision
     except ImportError:
-        raise ImportError("fastai.vision package is required to use ImageHandler")
+        raise ImportError("fastai.vision package is required to use FastaiImageHandler")
 
     return vision
 
@@ -46,7 +46,7 @@ def _import_imageio_imread():
     try:
         from imageio import imread
     except ImportError:
-        raise ImportError("imageio package is required to use ImageHandler")
+        raise ImportError("imageio package is required to use FastaiImageHandler")
 
     return imread
 

--- a/bentoml/handlers/fastai_image_handler.py
+++ b/bentoml/handlers/fastai_image_handler.py
@@ -32,6 +32,7 @@ from bentoml.handlers.image_handler import (
     get_default_accept_image_formats,
 )
 
+
 def _import_fastai_vision():
     try:
         from fastai import vision

--- a/bentoml/handlers/fastai_image_handler.py
+++ b/bentoml/handlers/fastai_image_handler.py
@@ -32,16 +32,22 @@ from bentoml.handlers.image_handler import (
     get_default_accept_image_formats,
 )
 
-try:
-    from fastai.vision import Image, pil2tensor, open_image
-except ImportError:
-    Image = None
-    pil2tensor = None
+def _import_fastai_vision():
+    try:
+        from fastai import vision
+    except ImportError:
+        raise ImportError("fastai.vision package is required to use ImageHandler")
 
-try:
-    from imageio import imread
-except ImportError:
-    imread = None
+    return vision
+
+
+def _import_imageio_imread():
+    try:
+        from imageio import imread
+    except ImportError:
+        raise ImportError("imageio package is required to use ImageHandler")
+
+    return imread
 
 
 class FastaiImageHandler(BentoHandler):
@@ -82,15 +88,8 @@ class FastaiImageHandler(BentoHandler):
         cls=None,
         after_open=None,
     ):
-        if imread is None:
-            raise ImportError(
-                "imageio package is required to use bentoml.handlers.FastaiImageHandler"
-            )
-
-        if Image is None or pil2tensor is None or open_image is None:
-            raise ImportError(
-                "fastai package is required to use bentoml.handlers.FastaiImageHandler"
-            )
+        self.imread = _import_imageio_imread()
+        self.fastai_vision = _import_fastai_vision()
 
         self.input_names = input_names
         self.convert_mode = convert_mode
@@ -143,12 +142,12 @@ class FastaiImageHandler(BentoHandler):
 
         input_data = []
         for input_stream in input_streams:
-            data = imread(input_stream, pilmode=self.convert_mode)
+            data = self.imread(input_stream, pilmode=self.convert_mode)
 
             if self.after_open:
                 data = self.after_open(data)
 
-            data = pil2tensor(data, np.float32)
+            data = self.fastai_vision.pil2tensor(data, np.float32)
 
             if self.div:
                 data = data.div_(255)
@@ -156,7 +155,7 @@ class FastaiImageHandler(BentoHandler):
             if self.cls:
                 data = self.cls(data)
             else:
-                data = Image(data)
+                data = self.fastai_vision.Image(data)
             input_data.append(data)
 
         result = func(*input_data)
@@ -177,12 +176,12 @@ class FastaiImageHandler(BentoHandler):
         if not os.path.isabs(file_path):
             file_path = os.path.abspath(file_path)
 
-        image_array = open_image(
+        image_array = self.fastai_vision.open_image(
             fn=file_path,
             convert_mode=self.convert_mode,
             div=self.div,
             after_open=self.after_open,
-            cls=self.cls or Image,
+            cls=self.cls or self.fastai_vision.Image,
         )
 
         result = func(image_array)
@@ -193,11 +192,11 @@ class FastaiImageHandler(BentoHandler):
         if event["headers"].get("Content-Type", "").startswith("images/"):
             # decodebytes introduced at python3.1
             try:
-                image_data = imread(
+                image_data = self.imread(
                     base64.decodebytes(event["body"]), pilmode=self.pilmode
                 )
             except AttributeError:
-                image_data = imread(
+                image_data = self.imread(
                     base64.decodestring(event["body"]),  # pylint: disable=W1505
                     pilmode=self.convert_mode,
                 )
@@ -210,13 +209,13 @@ class FastaiImageHandler(BentoHandler):
         if self.after_open:
             image_data = self.after_open(image_data)
 
-        image_data = pil2tensor(image_data, np.float32)
+        image_data = self.fastai_vision.pil2tensor(image_data, np.float32)
         if self.div:
             image_data = image_data.div_(255)
         if self.cls:
             image_data = self.cls(image_data)
         else:
-            image_data = Image(image_data)
+            image_data = self.fastai_vision.Image(image_data)
 
         result = func(image_data)
         result = get_output_str(result, event["headers"].get("output", "json"))
@@ -234,7 +233,7 @@ class FastaiImageHandler(BentoHandler):
             image_data = cv2.imdecode(input_bytes, cv2.IMREAD_COLOR)
             if self.after_open:
                 image_data = self.after_open(image_data)
-            image_data = pil2tensor(image_data, np.float32)
+            image_data = self.fastai_vision.pil2tensor(image_data, np.float32)
 
             if self.div:
                 image_data = image_data.div_(255)
@@ -242,7 +241,7 @@ class FastaiImageHandler(BentoHandler):
             if self.cls:
                 image_data = self.cls(image_data)
             else:
-                image_data = Image(image_data)
+                image_data = self.fastai_vision.Image(image_data)
 
             return func(image_data)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 import tempfile
 
 import bentoml
+import bentoml.handlers
 from bentoml import config
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,12 @@ import pytest
 import tempfile
 
 import bentoml
-from bentoml.handlers import DataframeHandler, ImageHandler, JsonHandler, \
-        FastaiImageHandler
+from bentoml.handlers import (
+    DataframeHandler,
+    ImageHandler,
+    JsonHandler,
+    FastaiImageHandler,
+)
 from bentoml.artifact import PickleArtifact
 from bentoml import config
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,8 @@ import pytest
 import tempfile
 
 import bentoml
-from bentoml.handlers import *
+from bentoml.handlers import DataframeHandler, ImageHandler, JsonHandler, \
+        FastaiImageHandler
 from bentoml.artifact import PickleArtifact
 from bentoml import config
 
@@ -53,14 +54,6 @@ class TestBentoService(bentoml.BentoService):
     @bentoml.api(JsonHandler)
     def predictJson(self, input_data):
         return self.artifacts.model.predictJson(input_data)
-
-    @bentoml.api(TensorflowTensorHandler)
-    def predictTF(self, input_data):
-        return self.artifacts.model.predictTF(input_data)
-
-    @bentoml.api(PytorchTensorHandler)
-    def predictTorch(self, input_data):
-        return self.artifacts.model.predictTorch(input_data)
 
     if sys.version_info >= (3, 6):
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,8 @@ import pytest
 import tempfile
 
 import bentoml
-import bentoml.handlers
+from bentoml.handlers import *
+from bentoml.artifact import PickleArtifact
 from bentoml import config
 
 
@@ -29,47 +30,45 @@ class TestModel(object):
         return {"ok": True}
 
 
-@bentoml.artifacts([bentoml.artifact.PickleArtifact("model")])
+@bentoml.artifacts([PickleArtifact("model")])
 @bentoml.env()
 class TestBentoService(bentoml.BentoService):
     """My RestServiceTestModel packaging with BentoML
     """
 
-    @bentoml.api(bentoml.handlers.DataframeHandler, input_dtypes={"age": "int"})
+    @bentoml.api(DataframeHandler, input_dtypes={"age": "int"})
     def predict(self, df):
         """predict expects dataframe as input
         """
         return self.artifacts.model.predict(df)
 
-    @bentoml.api(bentoml.handlers.ImageHandler)
+    @bentoml.api(ImageHandler)
     def predictImage(self, input_data):
         return self.artifacts.model.predictImage(input_data)
 
-    @bentoml.api(bentoml.handlers.ImageHandler, input_names=('original', 'compared'))
+    @bentoml.api(ImageHandler, input_names=('original', 'compared'))
     def predictImages(self, original, compared):
         return original[0, 0] == compared[0, 0]
 
-    @bentoml.api(bentoml.handlers.JsonHandler)
+    @bentoml.api(JsonHandler)
     def predictJson(self, input_data):
         return self.artifacts.model.predictJson(input_data)
 
-    @bentoml.api(bentoml.handlers.TensorflowTensorHandler)
+    @bentoml.api(TensorflowTensorHandler)
     def predictTF(self, input_data):
         return self.artifacts.model.predictTF(input_data)
 
-    @bentoml.api(bentoml.handlers.PytorchTensorHandler)
+    @bentoml.api(PytorchTensorHandler)
     def predictTorch(self, input_data):
         return self.artifacts.model.predictTorch(input_data)
 
     if sys.version_info >= (3, 6):
 
-        @bentoml.api(bentoml.handlers.FastaiImageHandler)
+        @bentoml.api(FastaiImageHandler)
         def predictFastaiImage(self, input_data):
             return self.artifacts.model.predictImage(input_data)
 
-        @bentoml.api(
-            bentoml.handlers.FastaiImageHandler, input_names=('original', 'compared')
-        )
+        @bentoml.api(FastaiImageHandler, input_names=('original', 'compared'))
         def predictFastaiImages(self, original, compared):
             return all(original.data[0, 0] == compared.data[0, 0])
 

--- a/tests/handlers/test_dataframe_handler.py
+++ b/tests/handlers/test_dataframe_handler.py
@@ -2,10 +2,9 @@ import pytest
 import pandas as pd
 import numpy as np
 
-from bentoml.handlers.dataframe_handler import (
-    DataframeHandler,
-    check_dataframe_column_contains,
-)
+from bentoml.handlers import DataframeHandler
+from bentoml.handlers.dataframe_handler import check_dataframe_column_contains
+
 
 try:
     from unittest.mock import Mock

--- a/tests/test_pip_install_bento_archive.py
+++ b/tests/test_pip_install_bento_archive.py
@@ -12,7 +12,7 @@ def test_pip_install_bento_archive(bento_archive_path, tmpdir):
     bentoml_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
     output = subprocess.check_output(
-        ["pip", "install", "--target={}".format(install_path), bento_archive_path]
+        ["pip", "install", "-U", "--target={}".format(install_path), bento_archive_path]
     ).decode()
     assert "Successfully installed TestBentoService" in output
 

--- a/tests/test_save_and_load.py
+++ b/tests/test_save_and_load.py
@@ -2,6 +2,7 @@ import os
 import uuid
 
 import bentoml
+from bentoml.handlers import DataframeHandler
 from bentoml.artifact import PickleArtifact
 
 
@@ -14,7 +15,7 @@ class MyTestModel(object):
 @bentoml.env(conda_pip_dependencies=["scikit-learn"])
 @bentoml.artifacts([PickleArtifact("model")])
 class MyTestBentoService(bentoml.BentoService):
-    @bentoml.api(bentoml.handlers.DataframeHandler)
+    @bentoml.api(DataframeHandler)
     def predict(self, df):
         """
         An API for testing simple bento model service
@@ -41,7 +42,7 @@ def test_save_and_load_model(tmpdir):
     assert len(model_service.get_service_apis()) == 1
     api = model_service.get_service_apis()[0]
     assert api.name == "predict"
-    assert isinstance(api.handler, bentoml.handlers.DataframeHandler)
+    assert isinstance(api.handler, DataframeHandler)
     assert api.func(1) == 2
 
     # Check api methods are available
@@ -50,7 +51,7 @@ def test_save_and_load_model(tmpdir):
 
 
 class TestBentoWithOutArtifact(bentoml.BentoService):
-    @bentoml.api(bentoml.handlers.DataframeHandler)
+    @bentoml.api(DataframeHandler)
     def test(self, df):
         return df
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2,34 +2,27 @@ import sys
 import pytest
 
 import bentoml
+from bentoml.handlers import *
 from bentoml.service import _validate_version_str
 
 
 def test_custom_api_name():
     # these names should work:
-    bentoml.api(bentoml.handlers.DataframeHandler, api_name="a_valid_name")(lambda x: x)
-    bentoml.api(bentoml.handlers.DataframeHandler, api_name="AValidName")(lambda x: x)
-    bentoml.api(bentoml.handlers.DataframeHandler, api_name="_AValidName")(lambda x: x)
-    bentoml.api(bentoml.handlers.DataframeHandler, api_name="a_valid_name_123")(
-        lambda x: x
-    )
+    bentoml.api(DataframeHandler, api_name="a_valid_name")(lambda x: x)
+    bentoml.api(DataframeHandler, api_name="AValidName")(lambda x: x)
+    bentoml.api(DataframeHandler, api_name="_AValidName")(lambda x: x)
+    bentoml.api(DataframeHandler, api_name="a_valid_name_123")(lambda x: x)
 
     with pytest.raises(ValueError) as e:
-        bentoml.api(bentoml.handlers.DataframeHandler, api_name="a invalid name")(
-            lambda x: x
-        )
+        bentoml.api(DataframeHandler, api_name="a invalid name")(lambda x: x)
     assert str(e.value).startswith("Invalid API name")
 
     with pytest.raises(ValueError) as e:
-        bentoml.api(bentoml.handlers.DataframeHandler, api_name="123_a_invalid_name")(
-            lambda x: x
-        )
+        bentoml.api(DataframeHandler, api_name="123_a_invalid_name")(lambda x: x)
     assert str(e.value).startswith("Invalid API name")
 
     with pytest.raises(ValueError) as e:
-        bentoml.api(bentoml.handlers.DataframeHandler, api_name="a-invalid-name")(
-            lambda x: x
-        )
+        bentoml.api(DataframeHandler, api_name="a-invalid-name")(lambda x: x)
     assert str(e.value).startswith("Invalid API name")
 
 
@@ -40,7 +33,7 @@ def test_fastai_image_handler_pip_dependencies():
     else:
 
         class TestFastAiImageService(bentoml.BentoService):
-            @bentoml.api(bentoml.handlers.FastaiImageHandler)
+            @bentoml.api(FastaiImageHandler)
             def test(self, image):
                 return image
 
@@ -52,7 +45,7 @@ def test_fastai_image_handler_pip_dependencies():
 
 def test_image_handler_pip_dependencies():
     class TestImageService(bentoml.BentoService):
-        @bentoml.api(bentoml.handlers.ImageHandler)
+        @bentoml.api(ImageHandler)
         def test(self, image):
             return image
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2,7 +2,7 @@ import sys
 import pytest
 
 import bentoml
-from bentoml.handlers import *
+from bentoml.handlers import DataframeHandler, FastaiImageHandler, ImageHandler
 from bentoml.service import _validate_version_str
 
 

--- a/tests/test_service_env.py
+++ b/tests/test_service_env.py
@@ -1,6 +1,7 @@
 import os
 
 import bentoml
+from bentoml.handlers import DataframeHandler
 
 
 def test_requirement_txt_env(tmpdir):
@@ -10,7 +11,7 @@ def test_requirement_txt_env(tmpdir):
 
     @bentoml.env(requirements_txt=str(req_txt_file))
     class ServiceWithFile(bentoml.BentoService):
-        @bentoml.api(bentoml.handlers.DataframeHandler)
+        @bentoml.api(DataframeHandler)
         def predict(self, df):
             return df
 
@@ -30,7 +31,7 @@ def test_requirement_txt_env(tmpdir):
 def test_pip_dependencies_env():
     @bentoml.env(pip_dependencies="numpy")
     class ServiceWithString(bentoml.BentoService):
-        @bentoml.api(bentoml.handlers.DataframeHandler)
+        @bentoml.api(DataframeHandler)
         def predict(self, df):
             return df
 
@@ -39,7 +40,7 @@ def test_pip_dependencies_env():
 
     @bentoml.env(pip_dependencies=['numpy', 'pandas', 'torch'])
     class ServiceWithList(bentoml.BentoService):
-        @bentoml.api(bentoml.handlers.DataframeHandler)
+        @bentoml.api(DataframeHandler)
         def predict(self, df):
             return df
 
@@ -52,7 +53,7 @@ def test_pip_dependencies_env():
 def test_pip_dependencies_with_archive(tmpdir):
     @bentoml.env(pip_dependencies=['numpy', 'pandas', 'torch'])
     class ServiceWithList(bentoml.BentoService):
-        @bentoml.api(bentoml.handlers.DataframeHandler)
+        @bentoml.api(DataframeHandler)
         def predict(self, df):
             return df
 


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
* Make `bentoml.handlers` behave the same to `bentoml.artifact` submodule, to reduce initial loading time and avoid unnecessarily imports
* This may break users that are accessing handler class directly e.g.:
```
import bentoml
bentoml.handlers.DataframeHandler # this will no longer work

# instead:
from bentoml.handlers import DataframeHandler
DataframeHandler # this will work
# or
import bentoml.hanlders
bentoml.handlers.DataframeHandler # this will work
```
* Tested locally, improves `import bentoml` loading time by about 3-4x
