### PR TITLE
Fix Fastai module import when loading artifact

### DIFF
--- a/bentoml/artifact/fastai_model_artifact.py
+++ b/bentoml/artifact/fastai_model_artifact.py
@@ -25,7 +25,7 @@ from bentoml.artifact import BentoServiceArtifact, BentoServiceArtifactWrapper
 
 def _import_fastai_module():
     try:
-        import fastai
+        import fastai.basic_train
     except ImportError:
         raise ImportError(
             "fastai package is required to use " "bentoml.artifacts.FastaiModelArtifact"


### PR DESCRIPTION
* This ensures that fastai.basic_train submodule is loaded when trying to load a FastaiModelArtifact
* Fixed bug reported at https://github.com/bentoml/BentoML/issues/358