### PR TITLE
Add pack method for BentoService instance

### DIFF
--- a/bentoml/archive/archiver.py
+++ b/bentoml/archive/archiver.py
@@ -90,6 +90,14 @@ def save_to_dir(bento_service, path, version=None):
     if not os.path.exists(path):
         raise BentoMLException("Directory '{}' not found".format(path))
 
+    for spec in bento_service._artifacts_spec:
+        if spec.name not in bento_service.artifacts:
+            logger.warning(
+                "Missing declared artifact '%s' for BentoService '%s'",
+                spec.name,
+                bento_service.name,
+            )
+
     module_base_path = os.path.join(path, bento_service.name)
     os.mkdir(module_base_path)
 

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -513,9 +513,9 @@ class BentoService(BentoServiceBase):
         return self
 
     @pack.classmethod
-    def pack(cls, *args, **kwargs):
+    def pack(cls, *args, **kwargs):  # pylint: disable=E0213
         if args and isinstance(args[0], ArtifactCollection):
-            return cls(args[0])
+            return cls(args[0])  # pylint: disable=E1102
 
         artifacts = ArtifactCollection()
 
@@ -524,7 +524,7 @@ class BentoService(BentoServiceBase):
                 artifact_instance = artifact_spec.pack(kwargs[artifact_spec.name])
                 artifacts.add(artifact_instance)
 
-        return cls(artifacts)
+        return cls(artifacts)  # pylint: disable=E1102
 
     @classmethod
     def load_from_dir(cls, path):

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -31,7 +31,8 @@ from bentoml.archive import save_to_dir
 from bentoml.exceptions import BentoMLException
 from bentoml.service_env import BentoServiceEnv
 from bentoml.artifact import ArtifactCollection, BentoServiceArtifact
-from bentoml.utils import isidentifier, hybridmethod
+from bentoml.utils import isidentifier
+from bentoml.utils.hybirdmethod import hybridmethod
 from bentoml.proto.repository_pb2 import BentoServiceMetadata
 
 logger = logging.getLogger(__name__)
@@ -497,20 +498,6 @@ class BentoService(BentoServiceBase):
         return save_to_dir(self, path, version)
 
     @hybridmethod
-    def pack(cls, *args, **kwargs):
-        if args and isinstance(args[0], ArtifactCollection):
-            return cls(args[0])
-
-        artifacts = ArtifactCollection()
-
-        for artifact_spec in cls._artifacts_spec:
-            if artifact_spec.name in kwargs:
-                artifact_instance = artifact_spec.pack(kwargs[artifact_spec.name])
-                artifacts.add(artifact_instance)
-
-        return cls(artifacts)
-
-    @pack.instancemethod
     def pack(self, name, *args, **kwargs):
         if name in self.artifacts:
             logger.warning(
@@ -524,6 +511,20 @@ class BentoService(BentoServiceBase):
         artifact_instance = artifact_spec.pack(*args, **kwargs)
         self.artifacts.add(artifact_instance)
         return self
+
+    @pack.classmethod
+    def pack(cls, *args, **kwargs):
+        if args and isinstance(args[0], ArtifactCollection):
+            return cls(args[0])
+
+        artifacts = ArtifactCollection()
+
+        for artifact_spec in cls._artifacts_spec:
+            if artifact_spec.name in kwargs:
+                artifact_instance = artifact_spec.pack(kwargs[artifact_spec.name])
+                artifacts.add(artifact_instance)
+
+        return cls(artifacts)
 
     @classmethod
     def load_from_dir(cls, path):

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -30,8 +30,8 @@ from abc import abstractmethod, ABCMeta
 from bentoml.archive import save_to_dir
 from bentoml.exceptions import BentoMLException
 from bentoml.service_env import BentoServiceEnv
-from bentoml.artifact import ArtifactCollection
-from bentoml.utils import isidentifier
+from bentoml.artifact import ArtifactCollection, BentoServiceArtifact
+from bentoml.utils import isidentifier, hybridmethod
 from bentoml.proto.repository_pb2 import BentoServiceMetadata
 
 logger = logging.getLogger(__name__)
@@ -310,7 +310,8 @@ def ver_decorator(major, minor):
     >>>  class MyMLService(BentoService):
     >>>     pass
     >>>
-    >>>  svc = MyMLService.pack(model="my ML model object")
+    >>>  svc = MyMLService()
+    >>>  svc.pack("model", trained_classifier)
     >>>  svc.set_version("2019-08.iteration20")
     >>>  svc.save('/path_to_archive')
     >>>  # The final produced BentoArchive version will be "1.4.2019-08.iteration20"
@@ -392,26 +393,26 @@ class BentoService(BentoServiceBase):
         self.name = self.__class__.name()
 
     def _init_artifacts(self, artifacts):
-        if len(self._artifacts_spec) > 0:
-            if artifacts is None:
-                if self._bento_archive_path:
-                    artifacts = ArtifactCollection.load(
-                        self._bento_archive_path, self.__class__._artifacts_spec
-                    )
-                else:
-                    raise BentoMLException(
-                        "Must provide required artifacts before instantiating a "
-                        "custom BentoService class"
-                    )
-
-            if isinstance(artifacts, ArtifactCollection):
-                self._artifacts = artifacts
-            else:
-                self._artifacts = ArtifactCollection()
-                for artifact in artifacts:
-                    self._artifacts[artifact.name] = artifact
-        else:
+        type_error_msg = (
+            "BentoService can only be initialized with list of BentoArtifacts, instead "
+            "got %s"
+        )
+        artifacts = artifacts or []
+        if not artifacts and self._bento_archive_path:
+            self._artifacts = ArtifactCollection.load(
+                self._bento_archive_path, self.__class__._artifacts_spec
+            )
+        elif isinstance(artifacts, ArtifactCollection):
+            self._artifacts = artifacts
+        elif isinstance(artifacts, list):
             self._artifacts = ArtifactCollection()
+            for artifact in artifacts:
+                assert isinstance(
+                    artifact, BentoServiceArtifact
+                ), type_error_msg % type(artifacts)
+                self._artifacts[artifact.name] = artifact
+        else:
+            raise BentoMLException(type_error_msg % type(artifacts))
 
     def _init_env(self, env=None):
         if env is None:
@@ -495,7 +496,7 @@ class BentoService(BentoServiceBase):
     def save_to_dir(self, path, version=None):
         return save_to_dir(self, path, version)
 
-    @classmethod
+    @hybridmethod
     def pack(cls, *args, **kwargs):
         if args and isinstance(args[0], ArtifactCollection):
             return cls(args[0])
@@ -508,6 +509,21 @@ class BentoService(BentoServiceBase):
                 artifacts.add(artifact_instance)
 
         return cls(artifacts)
+
+    @pack.instancemethod
+    def pack(self, name, *args, **kwargs):
+        if name in self.artifacts:
+            logger.warning(
+                "BentoService '%s'#pack overriding existing artifact '%s'",
+                self.name,
+                name,
+            )
+            del self.artifacts[name]
+
+        artifact_spec = next(spec for spec in self._artifacts_spec if spec.name == name)
+        artifact_instance = artifact_spec.pack(*args, **kwargs)
+        self.artifacts.add(artifact_instance)
+        return self
 
     @classmethod
     def load_from_dir(cls, path):

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -246,17 +246,17 @@ def api_decorator(handler_cls, *args, **kwargs):
     return decorator
 
 
-def artifacts_decorator(artifact_specs):
+def artifacts_decorator(artifacts_spec):
     """Define artifact spec for BentoService
 
     Args:
-        artifact_specs (list(bentoml.artifact.BentoServiceArtifact)): A list of desired
+        artifacts_spec (list(bentoml.artifact.BentoServiceArtifact)): A list of desired
             artifacts for initializing this BentoService
         for initializing this BentoService being decorated
     """
 
     def decorator(bento_service_cls):
-        bento_service_cls._artifacts_spec = artifact_specs
+        bento_service_cls._artifacts_spec = artifacts_spec
         return bento_service_cls
 
     return decorator
@@ -531,7 +531,7 @@ class BentoService(BentoServiceBase):
 
         if cls._bento_archive_path is not None and cls._bento_archive_path != path:
             logger.warning(
-                "Loaded BentoArchive from '%s' can't be loaded again from a different"
+                "Loaded BentoArchive from '%s' being loaded again from a different"
                 "path %s",
                 cls._bento_archive_path,
                 path,

--- a/bentoml/utils/__init__.py
+++ b/bentoml/utils/__init__.py
@@ -25,7 +25,6 @@ from google.protobuf.json_format import MessageToJson, MessageToDict
 from ruamel.yaml import YAML
 
 from bentoml import __version__ as BENTOML_VERSION, _version as version_mod
-from bentoml.utils.hybirdmethod import hybridmethod
 
 try:
     from pathlib import Path

--- a/bentoml/utils/__init__.py
+++ b/bentoml/utils/__init__.py
@@ -25,6 +25,7 @@ from google.protobuf.json_format import MessageToJson, MessageToDict
 from ruamel.yaml import YAML
 
 from bentoml import __version__ as BENTOML_VERSION, _version as version_mod
+from bentoml.utils.hybirdmethod import hybridmethod
 
 try:
     from pathlib import Path

--- a/bentoml/utils/hybirdmethod.py
+++ b/bentoml/utils/hybirdmethod.py
@@ -1,0 +1,34 @@
+# Copyright 2019 Atalaya Tech, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class hybridmethod:
+    def __init__(self, fclass, finstance=None, doc=None):
+        self.fclass = fclass
+        self.finstance = finstance
+        self.__doc__ = doc or fclass.__doc__
+        # support use on abstract base classes
+        self.__isabstractmethod__ = bool(getattr(fclass, '__isabstractmethod__', False))
+
+    def classmethod(self, fclass):
+        return type(self)(fclass, self.finstance, None)
+
+    def instancemethod(self, finstance):
+        return type(self)(self.fclass, finstance, self.__doc__)
+
+    def __get__(self, instance, cls):
+        if instance is None or self.finstance is None:
+            # either bound to the class, or no instance method available
+            return self.fclass.__get__(cls, None)
+        return self.finstance.__get__(instance, cls)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,10 @@ def bento_service():
     """Create a new TestBentoService
     """
     test_model = TestModel()
-    return TestBentoService.pack(model=test_model)
+    TestBentoService._bento_archive_path = None
+    test_svc = TestBentoService()
+    test_svc.pack('model', test_model)
+    return test_svc
 
 
 @pytest.fixture()

--- a/tests/test_save_and_load.py
+++ b/tests/test_save_and_load.py
@@ -1,5 +1,8 @@
 import os
 import uuid
+import mock
+import pytest
+
 
 import bentoml
 from bentoml.handlers import DataframeHandler
@@ -12,7 +15,6 @@ class MyTestModel(object):
 
 
 @bentoml.ver(major=2, minor=10)
-@bentoml.env(conda_pip_dependencies=["scikit-learn"])
 @bentoml.artifacts([PickleArtifact("model")])
 class MyTestBentoService(bentoml.BentoService):
     @bentoml.api(DataframeHandler)
@@ -23,13 +25,58 @@ class MyTestBentoService(bentoml.BentoService):
         return self.artifacts.model.predict(df)
 
 
-def test_save_and_load_model(tmpdir):
+@pytest.fixture()
+def test_bento_service_class():
+    MyTestBentoService._bento_archive_path = None
+    return MyTestBentoService
+
+
+def test_save_and_load_model(tmpdir, test_bento_service_class):
     test_model = MyTestModel()
-    ms = MyTestBentoService.pack(model=test_model)
+    ms = test_bento_service_class.pack(model=test_model)
 
     assert ms.predict(1000) == 2000
     version = "test_" + uuid.uuid4().hex
     saved_path = ms.save(str(tmpdir), version=version)
+
+    expected_version = "2.10.{}".format(version)
+    assert saved_path == os.path.join(
+        str(tmpdir), "MyTestBentoService", expected_version
+    )
+    assert os.path.exists(saved_path)
+
+    model_service = bentoml.load(saved_path)
+
+    assert len(model_service.get_service_apis()) == 1
+    api = model_service.get_service_apis()[0]
+    assert api.name == "predict"
+    assert isinstance(api.handler, DataframeHandler)
+    assert api.func(1) == 2
+
+    # Check api methods are available
+    assert model_service.predict(1) == 2
+    assert model_service.version == expected_version
+
+
+def test_pack_on_bento_service_instance(tmpdir, test_bento_service_class):
+    test_model = MyTestModel()
+    ms = test_bento_service_class()
+
+    with mock.patch('bentoml.archive.archiver.logger') as log_mock:
+        ms.save()
+        log_mock.warning.assert_called_once_with(
+            "Missing declared artifact '%s' for BentoService '%s'",
+            'model',
+            'MyTestBentoService',
+        )
+
+    ms.pack("model", test_model)
+    assert ms.predict(1000) == 2000
+
+    version = "test_" + uuid.uuid4().hex
+    ms.set_version(version)
+
+    saved_path = ms.save(str(tmpdir))
 
     expected_version = "2.10.{}".format(version)
     assert saved_path == os.path.join(

--- a/tests/test_save_and_load.py
+++ b/tests/test_save_and_load.py
@@ -24,7 +24,7 @@ class MyTestBentoService(bentoml.BentoService):
         """
         return self.artifacts.model.predict(df)
 
-
+# pylint: disable=redefined-outer-name
 @pytest.fixture()
 def test_bento_service_class():
     MyTestBentoService._bento_archive_path = None


### PR DESCRIPTION
Added support for the follow syntax, which makes creating services with multiple models easier

```
bento_service = MyBentoService()
bento_service.pack('model1', ...)
bento_service.pack('model2', ...)
bento_service.save()
```