### PR TITLE
[ISSUE-372] fix API server docker image build: No module named 'gunicorn.six'

### DIFF
--- a/bentoml/archive/templates.py
+++ b/bentoml/archive/templates.py
@@ -67,7 +67,7 @@ graft {service_name}/artifacts
 """
 
 BENTO_SERVICE_DOCKERFILE_CPU_TEMPLATE = """\
-FROM continuumio/miniconda3
+FROM continuumio/miniconda3:4.7.12
 
 ENTRYPOINT [ "/bin/bash", "-c" ]
 
@@ -102,7 +102,7 @@ CMD ["bentoml serve-gunicorn /bento"]
 """  # noqa: E501
 
 BENTO_SERVICE_DOCKERFILE_SAGEMAKER_TEMPLATE = """\
-FROM continuumio/miniconda3
+FROM continuumio/miniconda3:4.7.12
 
 EXPOSE 8080
 

--- a/bentoml/server/gunicorn_server.py
+++ b/bentoml/server/gunicorn_server.py
@@ -16,9 +16,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-
+from six import iteritems
 from gunicorn.app.base import BaseApplication
-from gunicorn.six import iteritems
 
 from bentoml import config
 from bentoml.archive import load


### PR DESCRIPTION
Fixing issue #372
* Pinned base image version
* Remove "import gunicorn.six" whish got removed in gunicorn's latest release 20.0.0