### PR TITLE
ImageHandler accept file type check fix and unit tests

### DIFF
--- a/bentoml/handlers/image_handler.py
+++ b/bentoml/handlers/image_handler.py
@@ -44,7 +44,7 @@ def verify_image_format_or_raise(file_name, accept_format_list):
     """
     if accept_format_list:
         _, extension = os.path.splitext(file_name)
-        if extension not in accept_format_list:
+        if extension.lower() not in accept_format_list:
             raise ValueError(
                 "Input file not in supported format list: {}".format(accept_format_list)
             )

--- a/bentoml/handlers/image_handler.py
+++ b/bentoml/handlers/image_handler.py
@@ -132,7 +132,7 @@ class ImageHandler(BentoHandler):
                 response="BentoML#ImageHandler only accept POST request", status=405
             )
 
-        if len(self.input_names) == 1:
+        if len(self.input_names) == 1 and len(request.files) == 1:
             # Ignore multipart form input name when ImageHandler is intended to accept
             # only one image file at a time
             input_files = request.files.values()

--- a/bentoml/handlers/image_handler.py
+++ b/bentoml/handlers/image_handler.py
@@ -129,14 +129,20 @@ class ImageHandler(BentoHandler):
         """
         if request.method != "POST":
             return Response(
-                response="BentoML#ImageHandler only accept POST request", status=400
+                response="BentoML#ImageHandler only accept POST request", status=405
             )
 
-        input_files = [
-            request.files.get(form_input_name)
-            for form_input_name in self.input_names
-            if form_input_name in request.files
-        ]
+        if len(self.input_names) == 1:
+            # Ignore multipart form input name when ImageHandler is intended to accept
+            # only one image file at a time
+            input_files = request.files.values()
+        else:
+            input_files = [
+                request.files.get(form_input_name)
+                for form_input_name in self.input_names
+                if form_input_name in request.files
+            ]
+
         if input_files:
             file_names = [secure_filename(file.filename) for file in input_files]
             try:

--- a/bentoml/service_env.py
+++ b/bentoml/service_env.py
@@ -20,7 +20,7 @@ import os
 from sys import version_info
 from ruamel.yaml import YAML
 
-from bentoml.utils import Path, StringIO
+from bentoml.utils import Path
 from bentoml.configuration import get_bentoml_deploy_version
 
 PYTHON_VERSION = "{major}.{minor}.{micro}".format(

--- a/tests/handlers/test_image_handler.py
+++ b/tests/handlers/test_image_handler.py
@@ -92,6 +92,7 @@ def test_image_handler_http_request_multipart_form(img_file):
     assert response.status_code == 200
     assert "[10, 10, 3]" in str(response.response)
 
+
 def test_image_handler_http_request_single_image_different_name(img_file):
     test_image_handler = ImageHandler(input_names=("my_image",))
     request = mock.MagicMock(spec=flask.Request)

--- a/tests/handlers/test_image_handler.py
+++ b/tests/handlers/test_image_handler.py
@@ -55,7 +55,7 @@ def test_image_handler_http_request_wrong_request_method():
     request.method = "GET"
 
     response = test_image_handler.handle_request(request, predict)
-    assert response.status_code == 400
+    assert response.status_code == 405
     assert "only accept POST request" in str(response.response)
 
 
@@ -92,6 +92,25 @@ def test_image_handler_http_request_multipart_form(img_file):
     assert response.status_code == 200
     assert "[10, 10, 3]" in str(response.response)
 
+def test_image_handler_http_request_single_image_different_name(img_file):
+    test_image_handler = ImageHandler(input_names=("my_image",))
+    request = mock.MagicMock(spec=flask.Request)
+    file_attr = {
+        'filename': 'test_img.png',
+        'read.return_value': open(str(img_file), 'rb').read(),
+    }
+    file = mock.Mock(**file_attr)
+
+    request.method = "POST"
+    request.files = {"a_differnt_name_used": file}
+    request.headers = {}
+    request.get_data.return_value = None
+
+    response = test_image_handler.handle_request(request, predict)
+
+    assert response.status_code == 200
+    assert "[10, 10, 3]" in str(response.response)
+
 
 def test_image_handler_http_request_malformatted_input_missing_image_file():
     test_image_handler = ImageHandler(input_names=("my_image",))
@@ -109,11 +128,11 @@ def test_image_handler_http_request_malformatted_input_missing_image_file():
 
 
 def test_image_handler_http_request_malformatted_input_wrong_input_name():
-    test_image_handler = ImageHandler(input_names=("my_image",))
+    test_image_handler = ImageHandler(input_names=("my_image", "my_image2"))
     request = mock.MagicMock(spec=flask.Request)
 
     request.method = "POST"
-    request.files = {"my_image_0": None}
+    request.files = {"abc": None}
     request.headers = {}
     request.get_data.return_value = None
 

--- a/tests/handlers/test_image_handler.py
+++ b/tests/handlers/test_image_handler.py
@@ -1,39 +1,123 @@
 import base64
+import pytest
+import mock
 
-from bentoml import BentoService, api
+import flask
+import imageio
+import numpy as np
+
+
 from bentoml.handlers import ImageHandler
 
 
-class ImageHandlerModel(BentoService):
-    @api(ImageHandler)
-    def predict(self, image):
-        return image.shape
+def predict(image):
+    return image.shape
 
 
-def test_image_handler(capsys, tmpdir):
-    ms = ImageHandlerModel()
-    api = ms.get_service_apis()[0]
+@pytest.fixture()
+def img_file(tmpdir):
+    img_file = tmpdir.join("test_img.png")
+    imageio.imwrite(str(img_file), np.zeros((10, 10)))
+    return img_file
 
-    import cv2
-    import numpy as np
 
-    img_file = tmpdir.join("img.png")
-    cv2.imwrite(str(img_file), np.zeros((10, 10)))
+def test_image_handler_cli(capsys, img_file):
+    test_image_handler = ImageHandler()
 
     test_args = ["--input={}".format(img_file)]
-    api.handle_cli(test_args)
+    test_image_handler.handle_cli(test_args, predict)
     out, err = capsys.readouterr()
-
     assert out.strip().endswith("(10, 10, 3)")
 
-    with open(str(img_file), "rb") as imageFile:
-        content = imageFile.read()
-        try:
-            imageStr = base64.encodebytes(content)
-        except AttributeError:
-            imageStr = base64.encodestring(str(img_file))
-    aws_lambda_event = {"body": imageStr, "headers": {"Content-Type": "images/png"}}
 
-    aws_result = api.handle_aws_lambda_event(aws_lambda_event)
+def test_image_handler_aws_lambda_event(img_file):
+    test_image_handler = ImageHandler()
+    with open(str(img_file), "rb") as image_file:
+        content = image_file.read()
+        try:
+            image_bytes_encoded = base64.encodebytes(content)
+        except AttributeError:
+            image_bytes_encoded = base64.encodestring(str(content))
+
+    aws_lambda_event = {
+        "body": image_bytes_encoded,
+        "headers": {"Content-Type": "images/png"},
+    }
+
+    aws_result = test_image_handler.handle_aws_lambda_event(aws_lambda_event, predict)
     assert aws_result["statusCode"] == 200
     assert aws_result["body"] == "[10, 10, 3]"
+
+
+def test_image_handler_http_request_wrong_request_method(img_file):
+    test_image_handler = ImageHandler()
+    request = mock.MagicMock(spec=flask.Request)
+    request.method = "GET"
+
+    response = test_image_handler.handle_request(request, predict)
+    assert response.status_code == 400
+    assert "only accept POST request" in str(response.response)
+
+
+def test_image_handler_http_request_post_binary(img_file):
+    test_image_handler = ImageHandler()
+    request = mock.MagicMock(spec=flask.Request)
+    request.method = "POST"
+    request.files = {}
+    request.headers = {}
+    request.get_data.return_value = open(img_file, 'rb')
+
+    response = test_image_handler.handle_request(request, predict)
+
+    assert response.status_code == 200
+    assert "[10, 10, 3]" in str(response.response)
+
+
+def test_image_handler_http_request_multipart_form(img_file):
+    test_image_handler = ImageHandler(input_names=("my_image",))
+    request = mock.MagicMock(spec=flask.Request)
+    file_attr = {
+        'filename': 'test_img.png',
+        'read.return_value': open(img_file, 'rb').read(),
+    }
+    file = mock.Mock(**file_attr)
+
+    request.method = "POST"
+    request.files = {"my_image": file}
+    request.headers = {}
+    request.get_data.return_value = None
+
+    response = test_image_handler.handle_request(request, predict)
+
+    assert response.status_code == 200
+    assert "[10, 10, 3]" in str(response.response)
+
+
+def test_image_handler_http_request_malformatted_input_missing_image_file(img_file):
+    test_image_handler = ImageHandler(input_names=("my_image",))
+    request = mock.MagicMock(spec=flask.Request)
+
+    request.method = "POST"
+    request.files = {}
+    request.headers = {}
+    request.get_data.return_value = None
+
+    response = test_image_handler.handle_request(request, predict)
+
+    assert response.status_code == 400
+    assert "unexpected HTTP request format" in str(response.response)
+
+
+def test_image_handler_http_request_malformatted_input_wrong_input_name(img_file):
+    test_image_handler = ImageHandler(input_names=("my_image",))
+    request = mock.MagicMock(spec=flask.Request)
+
+    request.method = "POST"
+    request.files = {"my_image_0": None}
+    request.headers = {}
+    request.get_data.return_value = None
+
+    response = test_image_handler.handle_request(request, predict)
+
+    assert response.status_code == 400
+    assert "unexpected HTTP request format" in str(response.response)

--- a/tests/handlers/test_image_handler.py
+++ b/tests/handlers/test_image_handler.py
@@ -37,7 +37,7 @@ def test_image_handler_aws_lambda_event(img_file):
         try:
             image_bytes_encoded = base64.encodebytes(content)
         except AttributeError:
-            image_bytes_encoded = base64.encodestring(str(content))
+            image_bytes_encoded = base64.encodestring(str(img_file))
 
     aws_lambda_event = {
         "body": image_bytes_encoded,
@@ -49,7 +49,7 @@ def test_image_handler_aws_lambda_event(img_file):
     assert aws_result["body"] == "[10, 10, 3]"
 
 
-def test_image_handler_http_request_wrong_request_method(img_file):
+def test_image_handler_http_request_wrong_request_method():
     test_image_handler = ImageHandler()
     request = mock.MagicMock(spec=flask.Request)
     request.method = "GET"
@@ -65,7 +65,7 @@ def test_image_handler_http_request_post_binary(img_file):
     request.method = "POST"
     request.files = {}
     request.headers = {}
-    request.get_data.return_value = open(img_file, 'rb')
+    request.get_data.return_value = open(str(img_file), 'rb')
 
     response = test_image_handler.handle_request(request, predict)
 
@@ -78,7 +78,7 @@ def test_image_handler_http_request_multipart_form(img_file):
     request = mock.MagicMock(spec=flask.Request)
     file_attr = {
         'filename': 'test_img.png',
-        'read.return_value': open(img_file, 'rb').read(),
+        'read.return_value': open(str(img_file), 'rb').read(),
     }
     file = mock.Mock(**file_attr)
 
@@ -93,7 +93,7 @@ def test_image_handler_http_request_multipart_form(img_file):
     assert "[10, 10, 3]" in str(response.response)
 
 
-def test_image_handler_http_request_malformatted_input_missing_image_file(img_file):
+def test_image_handler_http_request_malformatted_input_missing_image_file():
     test_image_handler = ImageHandler(input_names=("my_image",))
     request = mock.MagicMock(spec=flask.Request)
 
@@ -108,7 +108,7 @@ def test_image_handler_http_request_malformatted_input_missing_image_file(img_fi
     assert "unexpected HTTP request format" in str(response.response)
 
 
-def test_image_handler_http_request_malformatted_input_wrong_input_name(img_file):
+def test_image_handler_http_request_malformatted_input_wrong_input_name():
     test_image_handler = ImageHandler(input_names=("my_image",))
     request = mock.MagicMock(spec=flask.Request)
 


### PR DESCRIPTION
* fix accept format check - previously it will fail for filename with captialized extension e.g. '.PNG'
* when prediction request is malformated, API server should return 400 error response instead of raise exception with 500 internal error
* add unit tests for ImageHandler
