### PR TITLE
Removing Python2.7 form test environments list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: xenial
 cache: pip
 
 python:
-  - 2.7
   - 3.6
   - 3.7
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37
+envlist = py36,py37
 
 [testenv]
 deps =
@@ -8,7 +8,7 @@ deps =
   docker
   pip
   imageio
-  !py27: fastai
+  fastai
 commands = pytest
 
 [pytest]


### PR DESCRIPTION
* As part of our plans to deprecate support of python 2.7, this PR stops the default Travis test runs for python 2.7 environment
