### PR TITLE
BentoHandler API output format refactor

### DIFF
--- a/bentoml/configuration/default_bentoml.cfg
+++ b/bentoml/configuration/default_bentoml.cfg
@@ -40,7 +40,7 @@ dev_log_format = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %
 # the base file directory where bentoml store all its log files
 base_log_dir = {BENTOML_HOME}/logs/
 
-disable_logging_image = False
+log_request_image_files = True
 
 prediction_log_filename = prediction.log
 prediction_log_json_format = "(service_name) (service_version) (api) (request_id) (request) (response) (asctime)"

--- a/bentoml/deployment/aws_lambda/lambda_app.py
+++ b/bentoml/deployment/aws_lambda/lambda_app.py
@@ -52,7 +52,26 @@ this_module = sys.modules[__name__]
 
 
 def api_func(event, context):  # pylint: disable=unused-argument
-    return bento_service_api.handle_aws_lambda_event(event)
+    """
+    Event – AWS Lambda uses this parameter to pass in event data to the handler. This
+    parameter is usually of the Python dict type. It can also be list, str, int,
+    float, or NoneType type. Currently BentoML only handles Lambda event coming from
+    Application Load Balancer, in which case the parameter `event` must be type `dict`
+    containing the HTTP request headers and body.
+
+    see: https://docs.aws.amazon.com/lambda/latest/dg/services-alb.html
+    """
+
+    if type(event) is dict and "headers" in event and "body" in event:
+        return bento_service_api.handle_aws_lambda_event(event)
+    else:
+        error_msg = (
+            'Error: Unexpected Lambda event data received. Currently BentoML lambda '
+            'deployment can only handle event triggered by HTTP request from '
+            'Application Load Balancer.'
+        )
+        print(error_msg)
+        raise RuntimeError(error_msg)
 
 
 setattr(this_module, api_name, api_func)

--- a/bentoml/handlers/image_handler.py
+++ b/bentoml/handlers/image_handler.py
@@ -26,7 +26,7 @@ from flask import Response
 
 from bentoml import config
 from bentoml.exceptions import BadInput, MissingDependencyException
-from bentoml.handlers.base_handlers import BentoHandler, get_output_str
+from bentoml.handlers.base_handlers import BentoHandler, api_func_result_to_json
 
 
 def _import_imageio_imread():
@@ -159,15 +159,13 @@ class ImageHandler(BentoHandler):
             for input_stream in input_streams
         )
         result = func(*input_data)
-        result = get_output_str(result, request.headers.get("output", "json"))
-        return Response(response=result, status=200, mimetype="application/json")
+        json_output = api_func_result_to_json(result)
+        return Response(response=json_output, status=200, mimetype="application/json")
 
     def handle_cli(self, args, func):
         parser = argparse.ArgumentParser()
         parser.add_argument("--input", required=True)
-        parser.add_argument(
-            "-o", "--output", default="str", choices=["str", "json", "yaml"]
-        )
+        parser.add_argument("-o", "--output", default="str", choices=["str", "json"])
         parsed_args = parser.parse_args(args)
         file_path = parsed_args.input
 
@@ -178,7 +176,10 @@ class ImageHandler(BentoHandler):
         image_array = self.imread(file_path, pilmode=self.pilmode)
 
         result = func(image_array)
-        result = get_output_str(result, output_format=parsed_args.output)
+        if parsed_args.output == "json":
+            result = api_func_result_to_json(result)
+        else:
+            result = str(result)
         print(result)
 
     def handle_aws_lambda_event(self, event, func):
@@ -191,5 +192,5 @@ class ImageHandler(BentoHandler):
             )
 
         result = func(image)
-        result = get_output_str(result, event["headers"].get("output", "json"))
-        return {"statusCode": 200, "body": result}
+        json_output = api_func_result_to_json(result)
+        return {"statusCode": 200, "body": json_output}

--- a/bentoml/handlers/utils.py
+++ b/bentoml/handlers/utils.py
@@ -19,7 +19,7 @@ def bytes_2_tf_b64(obj):
         return obj
 
 
-def tf_tendor_2_serializable(obj):
+def tf_tensor_2_serializable(obj):
     '''
     To convert
         tf.Tensor -> json serializable

--- a/bentoml/server/bento_api_server.py
+++ b/bentoml/server/bento_api_server.py
@@ -269,6 +269,9 @@ class BentoAPIServer:
 
     @staticmethod
     def log_image(req, request_id):
+        if not config('logging').getboolean('log_request_image_files'):
+            return []
+
         img_prefix = 'image/'
         log_folder = config('logging').get('base_log_dir')
 
@@ -311,9 +314,8 @@ class BentoAPIServer:
         service_version = self.bento_service.version
 
         def api_func_wrapper():
-            image_paths = []
-            if not config('logging').getboolean('disable_logging_image'):
-                image_paths = self.log_image(request, request_id)
+            # Log image files in request if there is any
+            image_paths = self.log_image(request, request_id)
 
             # _request_to_json parses request as JSON; in case errors, it raises
             # a 400 exception. (consider 4xx before 5xx.)

--- a/bentoml/server/bento_api_server.py
+++ b/bentoml/server/bento_api_server.py
@@ -337,7 +337,7 @@ class BentoAPIServer:
                     )
                 else:
                     response = make_response('', e.status_code)
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 # For all unexpected error, return 500 by default. For example,
                 # if users' model raises an error of division by zero.
                 self.log_exception(sys.exc_info())
@@ -378,5 +378,5 @@ class BentoAPIServer:
         :attr:`logger`.
         """
         logger.error(
-            "Exception on %s [%s]" % (request.path, request.method), exc_info=exc_info
+            "Exception on %s [%s]", request.path, request.method, exc_info=exc_info
         )

--- a/bentoml/utils/tempdir.py
+++ b/bentoml/utils/tempdir.py
@@ -52,7 +52,9 @@ class TempDirectory(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if config('core').getboolean('debug'):
-            logger.debug(f'BentoML in debug mode, keeping temp directory "{self.path}"')
+            logger.debug(
+                'BentoML in debug mode, keeping temp directory "%s"', self.path
+            )
             return
 
         if self._cleanup:
@@ -60,12 +62,12 @@ class TempDirectory(object):
 
     def create(self):
         if self.path is not None:
-            logger.debug(f"Skipped temp direcotry creation: {self.path}")
+            logger.debug("Skipped temp direcotry creation: %s", self.path)
             return self.path
 
         tempdir = tempfile.mkdtemp(prefix="bentoml-{}-".format(self._prefix))
         self.path = os.path.realpath(tempdir)
-        logger.debug(f"Created temporary directory: {self.path}")
+        logger.debug("Created temporary directory: %s", self.path)
 
     def cleanup(self, ignore_errors=False):
         """

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -29,4 +29,4 @@ def test_run_command_with_input_file(bento_bundle_path):
     )
 
     assert result.exit_code == 0
-    assert result.output.strip() == '"3"'
+    assert result.output.strip() == '3'

--- a/tests/deployment/aws_lambda/test_aws_lambda_deployment_operator.py
+++ b/tests/deployment/aws_lambda/test_aws_lambda_deployment_operator.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 import boto3
 from mock import MagicMock, patch, Mock
 from moto import mock_s3
@@ -55,7 +56,7 @@ def generate_lambda_deployment_pb():
 
 def test_aws_lambda_app_py(monkeypatch):
     def test_predict(value):
-        return value
+        return value['body']
 
     class Mock_bento_service_class(object):
         name = "mock_bento_service"
@@ -102,7 +103,11 @@ def test_aws_lambda_app_py(monkeypatch):
         return predict
 
     predict = return_predict_func()
-    assert predict(1, None) == 1
+
+    with pytest.raises(RuntimeError):
+        predict("Invalid Input Type", None)
+
+    assert predict({"headers": [], "body": 'test'}, None) == 'test'
 
 
 @patch('shutil.rmtree', MagicMock())

--- a/tests/handlers/test_dataframe_handler.py
+++ b/tests/handlers/test_dataframe_handler.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 
 from bentoml.handlers import DataframeHandler
-from bentoml.handlers.dataframe_handler import check_dataframe_column_contains
+from bentoml.handlers.dataframe_handler import _check_dataframe_column_contains
 from bentoml.exceptions import BadInput
 
 try:
@@ -72,17 +72,17 @@ def test_check_dataframe_column_contains():
     )
 
     # this should pass
-    check_dataframe_column_contains({"a": "int", "b": "int", "c": "int"}, df)
-    check_dataframe_column_contains({"a": "int"}, df)
-    check_dataframe_column_contains({"a": "int", "c": "int"}, df)
+    _check_dataframe_column_contains({"a": "int", "b": "int", "c": "int"}, df)
+    _check_dataframe_column_contains({"a": "int"}, df)
+    _check_dataframe_column_contains({"a": "int", "c": "int"}, df)
 
     # this should raise exception
     with pytest.raises(BadInput) as e:
-        check_dataframe_column_contains({"required_column_x": "int"}, df)
+        _check_dataframe_column_contains({"required_column_x": "int"}, df)
     assert "Missing columns: required_column_x" in str(e.value)
 
     with pytest.raises(BadInput) as e:
-        check_dataframe_column_contains(
+        _check_dataframe_column_contains(
             {"a": "int", "b": "int", "d": "int", "e": "int"}, df
         )
     assert "Missing columns:" in str(e.value)

--- a/tests/handlers/test_tf_tensor_handler.py
+++ b/tests/handlers/test_tf_tensor_handler.py
@@ -67,7 +67,7 @@ def test_tf_tensor_handle_request():
     for input_data in COMMON_TEST_CASES:
         request.data = json.dumps(input_data).encode('utf-8')
         result = handler.handle_request(request, lambda i: i)
-        predictions = json.loads(result.get_data().decode('utf-8'))['predictions']
+        predictions = json.loads(result.get_data().decode('utf-8'))
         assert (
             input_data['instances'] == predictions
             or math.isnan(input_data['instances'])
@@ -78,26 +78,26 @@ def test_tf_tensor_handle_request():
     input_data = {"instances": {"b64": STR_B64}}
     request.data = json.dumps(input_data).encode("utf8")
     result = handler.handle_request(request, lambda i: i)
-    predictions = json.loads(result.get_data().decode('utf-8'))['predictions']
+    predictions = json.loads(result.get_data().decode('utf-8'))
     assert STR == predictions
 
     input_data = {"instances": [{"b64": STR_B64}]}
     request.data = json.dumps(input_data).encode("utf8")
     result = handler.handle_request(request, lambda i: i)
-    predictions = json.loads(result.get_data().decode('utf-8'))['predictions']
+    predictions = json.loads(result.get_data().decode('utf-8'))
     assert [STR] == predictions
 
     # test bin b64
     input_data = {"instances": {"b64": BIN_B64}}
     request.data = json.dumps(input_data).encode("utf8")
     result = handler.handle_request(request, lambda i: i)
-    predictions = json.loads(result.get_data().decode('utf-8'))['predictions']
+    predictions = json.loads(result.get_data().decode('utf-8'))
     assert {"b64": BIN_B64} == predictions
 
     input_data = {"instances": [{"b64": BIN_B64}]}
     request.data = json.dumps(input_data).encode("utf8")
     result = handler.handle_request(request, lambda i: i)
-    predictions = json.loads(result.get_data().decode('utf-8'))['predictions']
+    predictions = json.loads(result.get_data().decode('utf-8'))
     assert [{"b64": BIN_B64}] == predictions
 
 

--- a/tests/server/test_model_api_server.py
+++ b/tests/server/test_model_api_server.py
@@ -32,7 +32,7 @@ def test_api_function_route(bento_service, tmpdir):
     response = test_client.post(
         "/predict_dataframe", data=json.dumps(data), content_type="application/json"
     )
-    assert response.data.decode().strip() == '"30"'
+    assert response.data.decode().strip() == '30'
 
     # Test Image handlers.
     img_file = tmpdir.join("test_img.png")


### PR DESCRIPTION

* Removed the behavior of configuring API handler output type by setting HTTP request header
* Fixed issues with Numpy outputs from user API function
* Additional parameter validation for `orient` and `output_orient` in DataframeHandler
* Removed the leading "predictions" key in TensorHandler outputs
* Fixed all linter errors 