### PR TITLE
Fixed setup_sh feature in service_env

### DIFF
--- a/bentoml/bundler/templates.py
+++ b/bentoml/bundler/templates.py
@@ -78,15 +78,15 @@ RUN conda install pip numpy scipy \\
 COPY . /bento
 WORKDIR /bento
 
+# run user defined setup script
+RUN if [ -f /bento/setup.sh ]; then /bin/bash -c /bento/setup.sh; fi
+
 # update conda base env
 RUN conda env update -n base -f /bento/environment.yml
 RUN pip install -r /bento/requirements.txt
 
- # Install additional pip dependencies inside bundled_pip_dependencies dir
+# Install additional pip dependencies inside bundled_pip_dependencies dir
 RUN if [ -f /bento/bentoml_init.sh ]; then /bin/bash -c /bento/bentoml_init.sh; fi
-
-# run user defined setup script
-RUN if [ -f /bento/setup.sh ]; then /bin/bash -c /bento/setup.sh; fi
 
 # Run Gunicorn server with path to module.
 CMD ["bentoml serve-gunicorn /bento"]

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -483,7 +483,7 @@ class BentoService(BentoServiceBase):
             and self._bento_service_version != version_str
         ):
             logger.warning(
-                "Reseting BentoServive '%s' version from %s to %s",
+                "Resetting BentoService '%s' version from %s to %s",
                 self.name,
                 self._bento_service_version,
                 version_str,

--- a/tests/test_service_env.py
+++ b/tests/test_service_env.py
@@ -1,4 +1,5 @@
 import os
+import stat
 
 import bentoml
 from bentoml.handlers import DataframeHandler
@@ -43,3 +44,47 @@ def test_service_env_pip_dependencies(tmpdir):
         assert 'numpy' in module_list
         assert 'pandas' in module_list
         assert 'torch' in module_list
+
+
+def test_can_instantiate_setup_sh_from_file(tmpdir):
+    script_path = os.path.join(tmpdir, 'script.sh')
+    with open(script_path, 'w') as f:
+        f.write('ls')
+
+    @bentoml.env(setup_sh=script_path)
+    class ServiceWithSetup(bentoml.BentoService):
+        @bentoml.api(DataframeHandler)
+        def predict(self, df):
+            return df
+
+    service_with_setup = ServiceWithSetup()
+    saved_path = service_with_setup.save(str(tmpdir))
+
+    setup_sh_path = os.path.join(saved_path, 'setup.sh')
+    assert os.path.isfile(setup_sh_path)
+
+    st = os.stat(setup_sh_path)
+    assert st.st_mode & stat.S_IEXEC
+
+    with open(setup_sh_path, 'r') as f:
+        assert f.read() == 'ls'
+
+
+def test_can_instantiate_setup_sh_from_txt(tmpdir):
+    @bentoml.env(setup_sh='ls')
+    class ServiceWithSetup(bentoml.BentoService):
+        @bentoml.api(DataframeHandler)
+        def predict(self, df):
+            return df
+
+    service_with_setup = ServiceWithSetup()
+    saved_path = service_with_setup.save(str(tmpdir))
+
+    setup_sh_path = os.path.join(saved_path, 'setup.sh')
+    assert os.path.isfile(setup_sh_path)
+
+    st = os.stat(setup_sh_path)
+    assert st.st_mode & stat.S_IEXEC
+
+    with open(setup_sh_path, 'r') as f:
+        assert f.read() == 'ls'


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
It appears that the setup_sh feature of the `env` decorator was broken.
We (@seantur and myself) implemented the functionality as described in the documentation
and added the tests seen below.

Additionally, we moved the setup.sh execution higher in the generated Dockerfile.
The reason for this was to allow the setup.sh script to add our private PyPI repository
to the image, which is required for the `pip install -r /bento/requirements.txt` line to
succeed for private packages. We would certainly welcome feedback on this solution
and discuss alternatives.

Does this close any currently open issues?
------------------------------------------
No.

How was this patch tested?
--------------------------
We used a Python 3.7.5 virtualenv and ran the following commands:
```
./scripts/lint.sh
./scripts/format.sh
pytest
```