### PR TITLE
BentoML cli refactors

### DIFF
--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -94,11 +94,8 @@ def create_bento_service_cli(bundle_path=None):
 
     # Example Usage: bentoml {API_NAME} {BUNDLE_PATH} --input=...
     @bentoml_cli.command(
-        default_command=True,
-        default_command_usage="{API_NAME} {BUNDLE_PATH} --input=...",
-        default_command_display_name="<API_NAME>",
-        short_help="Run API function",
         help="Run a API defined in saved BentoService bundle from command line",
+        short_help="Run API function",
         context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
     )
     @click.argument("api-name", type=click.STRING)

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -20,7 +20,6 @@ import re
 import os
 import json
 import click
-import logging
 import tempfile
 import subprocess
 from pathlib import Path
@@ -45,7 +44,6 @@ from bentoml.cli.click_utils import (
 from bentoml.cli.deployment import get_deployment_sub_command
 from bentoml.cli.config import get_configuration_sub_command
 from bentoml.utils import ProtoMessageToDict
-from bentoml.utils.log import configure_logging
 from bentoml.utils.usage_stats import track_cli
 
 
@@ -59,38 +57,11 @@ def create_bento_service_cli(bundle_path=None):
     # pylint: disable=unused-variable
 
     @click.group(cls=BentoMLCommandGroup)
-    @click.option(
-        '-q',
-        '--quiet',
-        is_flag=True,
-        default=False,
-        help="Hide process logs and only print command results",
-    )
-    @click.option(
-        '--verbose',
-        '--debug',
-        is_flag=True,
-        default=False,
-        help="Print verbose debugging information for BentoML developer",
-    )
     @click.version_option()
-    @click.pass_context
-    def bentoml_cli(ctx, verbose, quiet):
+    def bentoml_cli():
         """
         BentoML CLI tool
         """
-        ctx.verbose = verbose
-        ctx.quiet = quiet
-
-        if verbose:
-            from bentoml import config
-
-            config().set('core', 'debug', 'true')
-            configure_logging(logging.DEBUG)
-        elif quiet:
-            configure_logging(logging.ERROR)
-        else:
-            configure_logging()  # use default setting in local bentoml.cfg
 
     # Example Usage: bentoml {API_NAME} {BUNDLE_PATH} --input=...
     @bentoml_cli.command(

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -39,8 +39,7 @@ from bentoml.server import BentoAPIServer, get_docs
 from bentoml.cli.click_utils import (
     BentoMLCommandGroup,
     conditional_argument,
-    _echo,
-    CLI_COLOR_ERROR,
+    _echo
 )
 from bentoml.cli.deployment import get_deployment_sub_command
 from bentoml.cli.config import get_configuration_sub_command
@@ -83,7 +82,6 @@ def run_with_conda_env(bundle_path, command):
         'dependencies."; }} && {cmd}'.format(
             env_name=env_name,
             env_file=env_path,
-            bundle_path=bundle_path,
             pip_req=pip_req,
             cmd=command,
         ),
@@ -129,8 +127,8 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
             return get_bento_result.bento.uri.uri
         else:
             raise BentoMLException(
-                f'BentoService "{bento}" not found - either specify the file path of the'
-                f'BentoService saved bundle, or the BentoService id in the form of '
+                f'BentoService "{bento}" not found - either specify the file path of '
+                f'the BentoService saved bundle, or the BentoService id in the form of '
                 f'"name:version"'
             )
 

--- a/bentoml/cli/aws_lambda.py
+++ b/bentoml/cli/aws_lambda.py
@@ -18,6 +18,7 @@ import click
 from bentoml.utils import status_pb_to_error_code_and_message
 from bentoml.cli.utils import Spinner
 from bentoml.cli.click_utils import (
+    BentoMLCommandGroup,
     parse_bento_tag_callback,
     CLI_COLOR_ERROR,
     _echo,
@@ -41,7 +42,9 @@ def get_aws_lambda_sub_command():
     # pylint: disable=unused-variable
 
     @click.group(
-        name='lambda', help='Commands for AWS Lambda BentoService deployments',
+        name='lambda',
+        help='Commands for AWS Lambda BentoService deployments',
+        cls=BentoMLCommandGroup,
     )
     def aws_lambda():
         pass

--- a/bentoml/cli/aws_sagemaker.py
+++ b/bentoml/cli/aws_sagemaker.py
@@ -17,6 +17,7 @@ import click
 
 from bentoml.cli.utils import Spinner
 from bentoml.cli.click_utils import (
+    BentoMLCommandGroup,
     parse_bento_tag_callback,
     CLI_COLOR_ERROR,
     _echo,
@@ -43,7 +44,9 @@ def get_aws_sagemaker_sub_command():
     # pylint: disable=unused-variable
 
     @click.group(
-        name='sagemaker', help='Commands for AWS Sagemaker BentoService deployments',
+        name='sagemaker',
+        help='Commands for AWS Sagemaker BentoService deployments',
+        cls=BentoMLCommandGroup,
     )
     def aws_sagemaker():
         pass

--- a/bentoml/cli/bento.py
+++ b/bentoml/cli/bento.py
@@ -89,7 +89,7 @@ def add_bento_sub_command(cli):
                     get_bento_result.status
                 )
                 _echo(
-                    f'Failed to get BentoService{name}:{version} '
+                    f'BentoService {name}:{version} not found - '
                     f'{error_code}:{error_message}',
                     CLI_COLOR_ERROR,
                 )

--- a/bentoml/cli/click_utils.py
+++ b/bentoml/cli/click_utils.py
@@ -57,41 +57,6 @@ class BentoMLCommandGroup(click.Group):
     command for each group defined
     """
 
-    def command(self, *args, **kwargs):
-        default_command = kwargs.pop("default_command", False)
-        default_command_usage = kwargs.pop("default_command_usage", "")
-        default_command_display_name = kwargs.pop("default_command_display_name", "<>")
-
-        if default_command and not args:
-            kwargs["name"] = kwargs.get("name", default_command_display_name)
-        decorator = super(BentoMLCommandGroup, self).command(*args, **kwargs)
-
-        if default_command:
-
-            def default_command_format_usage(ctx, formatter):
-                formatter.write_usage(ctx.parent.command_path, default_command_usage)
-
-            def new_decorator(f):
-                cmd = decorator(f)
-                cmd.format_usage = default_command_format_usage
-                # pylint:disable=attribute-defined-outside-init
-                self.default_command = cmd.name
-                # pylint:enable=attribute-defined-outside-init
-
-                return cmd
-
-            return new_decorator
-
-        return decorator
-
-    def resolve_command(self, ctx, args):
-        try:
-            return super(BentoMLCommandGroup, self).resolve_command(ctx, args)
-        except click.UsageError:
-            # command did not parse, assume it is the default command
-            args.insert(0, self.default_command)
-            return super(BentoMLCommandGroup, self).resolve_command(ctx, args)
-
 
 def conditional_argument(condition, *param_decls, **attrs):
     """

--- a/bentoml/cli/config.py
+++ b/bentoml/cli/config.py
@@ -26,7 +26,7 @@ from configparser import ConfigParser
 
 from bentoml import config as bentoml_config
 from bentoml.configuration import get_local_config_file, DEFAULT_CONFIG_FILE
-from bentoml.cli.click_utils import _echo, CLI_COLOR_ERROR
+from bentoml.cli.click_utils import BentoMLCommandGroup, _echo, CLI_COLOR_ERROR
 from bentoml.utils.usage_stats import track_cli
 
 # pylint: disable=unused-variable
@@ -52,6 +52,7 @@ def get_configuration_sub_command():
     @click.group(
         help="Configure BentoML configurations and settings",
         short_help="Config BentoML library",
+        cls=BentoMLCommandGroup,
     )
     def config():
         create_local_config_file_if_not_found()

--- a/bentoml/cli/deployment.py
+++ b/bentoml/cli/deployment.py
@@ -21,6 +21,7 @@ import logging
 from datetime import datetime
 
 from bentoml.cli.click_utils import (
+    BentoMLCommandGroup,
     _echo,
     CLI_COLOR_ERROR,
     CLI_COLOR_SUCCESS,
@@ -47,7 +48,10 @@ DEFAULT_SAGEMAKER_INSTANCE_COUNT = 1
 def get_deployment_sub_command():
     # pylint: disable=unused-variable
 
-    @click.group(help='Commands for manageing and operating BentoService deployments')
+    @click.group(
+        help='Commands for manageing and operating BentoService deployments',
+        cls=BentoMLCommandGroup,
+    )
     def deployment():
         pass
 

--- a/scripts/e2e_tests/aws_lambda/e2e_lambda_deployment.py
+++ b/scripts/e2e_tests/aws_lambda/e2e_lambda_deployment.py
@@ -55,7 +55,6 @@ if __name__ == '__main__':
         bento_name = f'{loaded_service.name}:{loaded_service.version}'
     create_deployment_command = [
         'bentoml',
-        '--verbose',
         'lambda',
         'deploy',
         deployment_name,
@@ -63,6 +62,7 @@ if __name__ == '__main__':
         bento_name,
         '--region',
         'us-west-2',
+        '--verbose',
     ]
     logger.info(
         f"Running bentoml deploy command: {' '.join(create_deployment_command)}"

--- a/scripts/e2e_tests/aws_sagemaker/e2e_sagemaker_deployment.py
+++ b/scripts/e2e_tests/aws_sagemaker/e2e_sagemaker_deployment.py
@@ -131,7 +131,6 @@ if __name__ == '__main__':
         bento_name = f'{loaded_service.name}:{loaded_service.version}'
     create_deployment_command = [
         'bentoml',
-        '--verbose',
         'sagemaker',
         'deploy',
         deployment_name,
@@ -144,6 +143,7 @@ if __name__ == '__main__':
         '--num-of-gunicorn-workers-per-instance',
         '2',
         '--wait',
+        '--verbose',
     ]
     deployment_failed, endpoint_name = run_sagemaker_create_or_update_command(
         create_deployment_command

--- a/scripts/e2e_tests/aws_sagemaker/e2e_sagemaker_update_deployment.py
+++ b/scripts/e2e_tests/aws_sagemaker/e2e_sagemaker_update_deployment.py
@@ -134,7 +134,6 @@ if __name__ == '__main__':
     bento_name = f'{loaded_ver_one_service.name}:{loaded_ver_one_service.version}'
     create_deployment_command = [
         'bentoml',
-        '--verbose',
         'sagemaker',
         'deploy',
         deployment_name,
@@ -142,6 +141,7 @@ if __name__ == '__main__':
         bento_name,
         '--api-name',
         'classify',
+        '--verbose',
     ]
     deployment_failed, endpoint_name = run_sagemaker_create_or_update_command(
         create_deployment_command
@@ -157,12 +157,12 @@ if __name__ == '__main__':
     #     logger.info('UPDATED ENV FOR DEPLOYMENT')
     #     update_deployment_command = [
     #         'bentoml',
-    #         '--verbose',
     #         'deploy',
     #         'update',
     #         deployment_name,
     #         '--api-name',
     #         'predict',
+    #         '--verbose',
     #     ]
     #     deployment_failed, endpoint_name = run_sagemaker_create_or_update_command(
     #         update_deployment_command
@@ -185,13 +185,13 @@ if __name__ == '__main__':
 
         update_bento_version_deployment_command = [
             'bentoml',
-            '--verbose',
             'sagemaker',
             'update',
             deployment_name,
             '-b',
             bento_name,
             '--wait',
+            '--verbose',
         ]
         deployment_failed, endpoint_name = run_sagemaker_create_or_update_command(
             update_bento_version_deployment_command

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -25,7 +25,15 @@ def test_run_command_with_input_file(bento_bundle_path):
     run_cmd = cli.commands["run"]
     result = runner.invoke(
         run_cmd,
-        ["predict_dataframe", bento_bundle_path, "--input", input_path, "-o", "json"],
+        [
+            "predict_dataframe",
+            bento_bundle_path,
+            "--input",
+            input_path,
+            "-o",
+            "json",
+            "--quiet",
+        ],
     )
 
     assert result.exit_code == 0

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -22,7 +22,7 @@ def test_run_command_with_input_file(bento_bundle_path):
     runner = CliRunner()
 
     cli = create_bento_service_cli()
-    run_cmd = cli.commands["<API_NAME>"]
+    run_cmd = cli.commands["run"]
     result = runner.invoke(
         run_cmd,
         ["predict_dataframe", bento_bundle_path, "--input", input_path, "-o", "json"],

--- a/tests/test_pip_install_saved_bundle.py
+++ b/tests/test_pip_install_saved_bundle.py
@@ -43,7 +43,7 @@ def test_pip_install_saved_bentoservice_bundle(bento_bundle_path, tmpdir):
     env["PYTHONPATH"] = ":".join(sys.path + [install_path, bentoml_path])
 
     output = subprocess.check_output(
-        [cli_bin_path, "--quiet", "info"], env=env
+        [cli_bin_path, "info", "--quiet"], env=env
     ).decode()
     output = json.loads(output)
     assert output["name"] == "TestBentoService"
@@ -51,7 +51,7 @@ def test_pip_install_saved_bentoservice_bundle(bento_bundle_path, tmpdir):
     assert "predict_dataframe" in map(lambda x: x["name"], output["apis"])
 
     output = subprocess.check_output(
-        [cli_bin_path, "--quiet", "open-api-spec"], env=env
+        [cli_bin_path, "open-api-spec", "--quiet"], env=env
     ).decode()
     output = json.loads(output)
     assert output["info"]["version"] == svc.version


### PR DESCRIPTION
* BREAKING CHANGE - changed the signature of 'bentoml run' 

previous users can directly use the API name as the command to load and run a model API from cli, it looks like this: `bentoml predict {saved_path} --input=my_test_data.csv`. The problem is that the API names are dynamically loaded and this makes it hard for bentoml command to provide useful `--help` docs. And the `default command` workaround with Click, makes it very confusing when the user types a wrong command. So we decided to make this change.

* Also a breaking change but less intrusive. The `--quiet` and  `--verbose` options are now an option for subcommands instead of only at top-level command.

Basically instead of `bentoml --verbose lambda deploy ...`, you will now do  `bentoml lambda deploy ... --verbose`

* Support for run/serve/info command to load a BentoService by its name and version. Previously the only way to load and serve a BentoService saved bundle is via its saved path:
```
bentoml serve {saved_path}
```

Now with the introduction of `bentoml list` and `bentoml get` command, we found it easier to simply use the name and version tag to reference to a saved model:
```
> bentoml list
BENTO_SERVICE                                    CREATED_AT                  APIS                        ARTIFACTS
IrisClassifier:20200121114004_360ECB            2020-01-21 19:40:19.697973  predict:(DataframeHandler)  model(SklearnModelArtifact)
IrisClassifier:20200121113013_0425F3            2020-01-21 19:30:27.532379  predict:(DataframeHandler)  model(SklearnModelArtifact)

> bentoml serve risClassifier:20200121113013_0425F3
```


* refactored the --with-conda code path