### PR TITLE
Support "latest" bento service version in model management CLI

### DIFF
--- a/bentoml/repository/metadata_store.py
+++ b/bentoml/repository/metadata_store.py
@@ -210,6 +210,7 @@ class BentoMetadataStore(object):
             if bento_name:
                 # filter_by apply filtering criterion to a copy of the query
                 query = query.filter_by(name=bento_name)
+            query = query.filter_by(deleted=False)
 
             # We are not defaulting limit to 200 in the signature,
             # because protobuf will pass 0 as value
@@ -221,9 +222,5 @@ class BentoMetadataStore(object):
                 query = query.offset(offset)
 
             query_result = query.all()
-            result = [
-                _bento_orm_obj_to_pb(bento_obj)
-                for bento_obj in query_result
-                if not bento_obj.deleted
-            ]
+            result = [_bento_orm_obj_to_pb(bento_obj) for bento_obj in query_result]
             return result

--- a/bentoml/repository/metadata_store.py
+++ b/bentoml/repository/metadata_store.py
@@ -107,10 +107,12 @@ class BentoMetadataStore(object):
 
     def _get_latest(self, bento_name):
         with create_session(self.sess_maker) as sess:
-            query = sess.query(Bento)\
-                .filter_by(name=bento_name, deleted=False)\
-                .order_by(desc(Bento.created_at))\
+            query = (
+                sess.query(Bento)
+                .filter_by(name=bento_name, deleted=False)
+                .order_by(desc(Bento.created_at))
                 .limit(1)
+            )
 
             query_result = query.all()
             if len(query_result) == 1:

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -343,6 +343,9 @@ def _validate_version_str(version_str):
             "128 characthers".format(version_str)
         )
 
+    if version_str.lower() == "latest":
+        raise InvalidArgument('BentoService version can not be set to "latest"')
+
 
 def save(bento_service, base_path=None, version=None):
     from bentoml.yatai.client import YataiClient

--- a/bentoml/utils/validator/__init__.py
+++ b/bentoml/utils/validator/__init__.py
@@ -38,7 +38,7 @@ deployment_schema = {
                 'allowed': DeploymentSpec.DeploymentOperator.keys(),
             },
             'bento_name': {'type': 'string', 'required': True},
-            'bento_version': {'type': 'string', 'required': True},
+            'bento_version': {'type': 'string', 'required': True, 'bento_service_version': True},
             'custom_operator_config': {
                 'type': 'dict',
                 'schema': {
@@ -110,6 +110,20 @@ class YataiDeploymentValidator(Validator):
                     field,
                     'AWS Lambda memory must be between 128 MB to 3,008 MB, '
                     'in 64 MB increments.',
+                )
+
+    def _validate_bento_service_version(self, bento_service_version, field, value):
+        """ Test the given BentoService version is not "latest"
+        
+        The rule's arguments are validated against this schema:
+        {'type': 'string'}
+        """
+        if bento_service_version:
+            if value.lower() == "latest":
+                self._error(
+                    field,
+                    'Must set specific "bento_version" in deployment, using "latest" is'
+                    'an anti-pattern.',
                 )
 
 

--- a/bentoml/utils/validator/__init__.py
+++ b/bentoml/utils/validator/__init__.py
@@ -38,7 +38,11 @@ deployment_schema = {
                 'allowed': DeploymentSpec.DeploymentOperator.keys(),
             },
             'bento_name': {'type': 'string', 'required': True},
-            'bento_version': {'type': 'string', 'required': True, 'bento_service_version': True},
+            'bento_version': {
+                'type': 'string',
+                'required': True,
+                'bento_service_version': True,
+            },
             'custom_operator_config': {
                 'type': 'dict',
                 'schema': {
@@ -96,7 +100,7 @@ class YataiDeploymentValidator(Validator):
         """ Test the memory size restriction for AWS Lambda.
 
         The rule's arguments are validated against this schema:
-        {'type': 'integer'}
+        {'type': 'boolean'}
         """
         if aws_lambda_memory:
             if value > 3008 or value < 128:
@@ -114,17 +118,16 @@ class YataiDeploymentValidator(Validator):
 
     def _validate_bento_service_version(self, bento_service_version, field, value):
         """ Test the given BentoService version is not "latest"
-        
+
         The rule's arguments are validated against this schema:
-        {'type': 'string'}
+        {'type': 'boolean'}
         """
-        if bento_service_version:
-            if value.lower() == "latest":
-                self._error(
-                    field,
-                    'Must set specific "bento_version" in deployment, using "latest" is'
-                    'an anti-pattern.',
-                )
+        if bento_service_version and value.lower() == "latest":
+            self._error(
+                field,
+                'Must use specific "bento_version" in deployment, using "latest" is '
+                'an anti-pattern.',
+            )
 
 
 def validate_pb_schema(pb, schema):

--- a/tests/utils/test_validators.py
+++ b/tests/utils/test_validators.py
@@ -2,7 +2,7 @@ from bentoml.utils.validator import validate_deployment_pb_schema
 from bentoml.proto.deployment_pb2 import Deployment, DeploymentSpec
 
 
-def test_validate_deployment_pb_schema():
+def _get_test_sagemaker_deployment_pb():
     test_pb = Deployment(name='test_deployment_name', namespace='namespace')
     test_pb.spec.bento_name = 'bento_name'
     test_pb.spec.bento_version = 'bento_version'
@@ -10,18 +10,10 @@ def test_validate_deployment_pb_schema():
     test_pb.spec.sagemaker_operator_config.api_name = 'api_name'
     test_pb.spec.sagemaker_operator_config.instance_type = 'mock_instance_type'
     test_pb.spec.sagemaker_operator_config.instance_count = 1
-
-    result = validate_deployment_pb_schema(test_pb)
-
-    assert result is None
-
-    test_bad_pb = test_pb
-    test_bad_pb.name = ''
-    bad_result = validate_deployment_pb_schema(test_bad_pb)
-    assert bad_result == {'name': ['required field']}
+    return test_pb
 
 
-def test_validate_aws_lambda_schema():
+def _get_test_lambda_deployment_pb():
     test_pb = Deployment(name='test_deployment_name', namespace='namespace')
     test_pb.spec.bento_name = 'bento_name'
     test_pb.spec.bento_version = 'bento_version'
@@ -30,17 +22,36 @@ def test_validate_aws_lambda_schema():
     test_pb.spec.aws_lambda_operator_config.region = 'us-west-2'
     test_pb.spec.aws_lambda_operator_config.timeout = 100
     test_pb.spec.aws_lambda_operator_config.memory_size = 128
+    return test_pb
 
-    result = validate_deployment_pb_schema(test_pb)
-    assert result is None
 
-    test_pb.spec.aws_lambda_operator_config.timeout = 1000
-    test_pb.spec.aws_lambda_operator_config.memory_size = 129
-    failed_memory_test = validate_deployment_pb_schema(test_pb)
-    print(failed_memory_test)
-    aws_spec_fail_msg = failed_memory_test['spec'][0]['aws_lambda_operator_config'][0]
+def test_validate_deployment_pb_schema():
+    deployment_pb = _get_test_sagemaker_deployment_pb()
+    assert validate_deployment_pb_schema(deployment_pb) is None
 
-    assert aws_spec_fail_msg['memory_size']
+    deployment_pb_with_empty_name = _get_test_sagemaker_deployment_pb()
+    deployment_pb_with_empty_name.name = ''
+    errors = validate_deployment_pb_schema(deployment_pb_with_empty_name)
+    assert errors == {'name': ['required field']}
+
+    deployment_pb_with_invalid_service_version = _get_test_sagemaker_deployment_pb()
+    deployment_pb_with_invalid_service_version.spec.bento_version = 'latest'
+    errors = validate_deployment_pb_schema(deployment_pb_with_invalid_service_version)
+    assert errors['spec'][0]['bento_version'] == [
+        'Must use specific "bento_version" in deployment, using "latest" is an '
+        'anti-pattern.'
+    ]
+
+
+def test_validate_aws_lambda_schema():
+    deployment_pb = _get_test_lambda_deployment_pb()
+    assert validate_deployment_pb_schema(deployment_pb) is None
+
+    deployment_pb_with_bad_memory_size = _get_test_lambda_deployment_pb()
+    deployment_pb_with_bad_memory_size.spec.aws_lambda_operator_config.timeout = 1000
+    deployment_pb_with_bad_memory_size.spec.aws_lambda_operator_config.memory_size = 129
+    errors = validate_deployment_pb_schema(deployment_pb_with_bad_memory_size)
+    aws_spec_fail_msg = errors['spec'][0]['aws_lambda_operator_config'][0]
+
     assert 'AWS Lambda memory' in aws_spec_fail_msg['memory_size'][0]
-    assert aws_spec_fail_msg['timeout']
     assert 'max value is 900' in aws_spec_fail_msg['timeout'][0]


### PR DESCRIPTION
* users can do `bentoml serve IrisClassifier:latest` or `bentoml get IrisClassifier:latest` now
* creating deployment with version 'latest' is not allowed by design