### PR TITLE
Add '-y' option to 'bentoml delete' command

### DIFF
--- a/bentoml/cli/bento.py
+++ b/bentoml/cli/bento.py
@@ -155,7 +155,10 @@ def add_bento_sub_command(cli):
 
     @cli.command(help='Delete BentoService')
     @click.argument('bento', type=click.STRING)
-    def delete(bento):
+    @click.option(
+        '-y', '--yes', '--assume-yes', is_flag=True, help='Automatic yes to prompts'
+    )
+    def delete(bento, yes):
         yatai_client = YataiClient()
         name, version = bento.split(':')
         if not name and not version:
@@ -165,7 +168,7 @@ def add_bento_sub_command(cli):
                 CLI_COLOR_ERROR,
             )
             return
-        if not click.confirm(
+        if not yes and not click.confirm(
             f'Are you sure about delete {bento}? This will delete the BentoService '
             f'saved bundle files permanently'
         ):


### PR DESCRIPTION
* use '-y' to bypass the 'bentoml delete' command's "Y/N" prompt