### PR TITLE
Move 'bentoml run' command option 'api_name' to behind "bento" option

### DIFF
--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -131,8 +131,8 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         short_help="Run API function",
         context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
     )
-    @click.argument("api_name", type=click.STRING)
     @conditional_argument(pip_installed_bundle_path is None, "bento", type=click.STRING)
+    @click.argument("api_name", type=click.STRING)
     @click.argument('run_args', nargs=-1, type=click.UNPROCESSED)
     @click.option(
         '--with-conda',

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -26,8 +26,8 @@ def test_run_command_with_input_file(bento_bundle_path):
     result = runner.invoke(
         run_cmd,
         [
-            "predict_dataframe",
             bento_bundle_path,
+            "predict_dataframe",
             "--input",
             input_path,
             "-o",


### PR DESCRIPTION
Changing from 
```bentoml run predict IrisClassifier:latest --input='[....]'```
to
```bentoml run IrisClassifier:latest predict --input='[....]'```