### PR TITLE
add options to set PIP_INDEX_URL when build image

### DIFF
--- a/bentoml/bundler/templates.py
+++ b/bentoml/bundler/templates.py
@@ -90,6 +90,8 @@ RUN if [ -f /bento/setup.sh ]; then /bin/bash -c /bento/setup.sh; fi
 
 # update conda base env
 RUN conda env update -n base -f /bento/environment.yml
+ARG PIP_TRUSTED_HOST
+ARG PIP_INDEX_URL
 RUN pip install -r /bento/requirements.txt
 
 # Install additional pip dependencies inside bundled_pip_dependencies dir

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -50,6 +50,7 @@ from bentoml.exceptions import BentoMLException
 
 try:
     import click_completion
+
     click_completion.init()
     shell_types = click_completion.DocumentedChoice(click_completion.core.shells)
 except ImportError:
@@ -346,24 +347,25 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         help="Install shell command completion",
         short_help="Install shell command completion",
     )
-    @click.option('--append/--overwrite',
-                  help="Append the completion code to the file",
-                  default=None)
-    @click.argument('shell',
-                    required=False,
-                    type=shell_types
-                    )
+    @click.option(
+        '--append/--overwrite',
+        help="Append the completion code to the file",
+        default=None,
+    )
+    @click.argument('shell', required=False, type=shell_types)
     @click.argument('path', required=False)
     def install_completion(append, shell, path):
         if click_completion:
             # click_completion package is imported
-            shell, path = click_completion.core.install(shell=shell,
-                                                        path=path,
-                                                        append=append)
+            shell, path = click_completion.core.install(
+                shell=shell, path=path, append=append
+            )
             click.echo('%s completion installed in %s' % (shell, path))
         else:
-            click.echo("'click_completion' is required for BentoML auto-completion, "
-                       "install it with `pip install click_completion`")
+            click.echo(
+                "'click_completion' is required for BentoML auto-completion, "
+                "install it with `pip install click_completion`"
+            )
 
     # pylint: enable=unused-variable
     return bentoml_cli


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below.)

What changes were proposed in this pull request?
------------------------------------------------
add options to set PIP_INDEX_URL when build image.
With this change, users can set local pypi mirrors/cache during building docker images.
Pypi cache with Nginx: https://gist.github.com/dctrwatson/5785638

Does this close any currently open issues?
------------------------------------------


How was this patch tested?
--------------------------
