### PR TITLE
Set serve-gunicorn command options from envvar

### DIFF
--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -237,7 +237,8 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         '--enable-microbatch',
         is_flag=True,
         default=False,
-        help="(Alpha) Run API server with micro batch enabled",
+        help="(Beta) Run API server with micro-batch enabled",
+        envvar='BENTOML_ENABLE_MICROBATCH',
     )
     def serve(port, bento=None, with_conda=False, enable_microbatch=False):
         track_cli('serve')
@@ -288,6 +289,7 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         type=click.INT,
         default=None,
         help="Number of workers will start for the gunicorn server",
+        envvar='BENTOML_GUNICORN_WORKERS',
     )
     @click.option("--timeout", type=click.INT, default=None)
     @click.option(
@@ -300,13 +302,15 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         '--enable-microbatch',
         is_flag=True,
         default=False,
-        help="(Alpha) Run API server with micro batch enabled",
+        help="(Beta) Run API server with micro batch enabled",
+        envvar='BENTOML_ENABLE_MICROBATCH',
     )
     @click.option(
         '--microbatch-workers',
         type=click.INT,
         default=1,
-        help="(Alpha) Number of microbatch workers",
+        help="(Beta) Number of micro-batch request dispatcher workers",
+        envvar='BENTOML_MICROBATCH_WORKERS',
     )
     def serve_gunicorn(
         port,

--- a/bentoml/utils/log.py
+++ b/bentoml/utils/log.py
@@ -36,7 +36,6 @@ def get_logging_config_dict(logging_level, base_log_directory):
     FEEDBACK_LOG_FILENAME = conf.get("feedback_log_filename")
     FEEDBACK_LOG_JSON_FORMAT = conf.get("feedback_log_json_format")
 
-
     return {
         "version": 1,
         "disable_existing_loggers": False,


### PR DESCRIPTION
This made it possible to custom these options more easily when running API server docker image