### PR TITLE
Add YataiService dockerfile and release script

### DIFF
--- a/bentoml/cli/yatai_service.py
+++ b/bentoml/cli/yatai_service.py
@@ -35,12 +35,14 @@ def add_yatai_service_sub_command(cli):
         help='Database URL following RFC-1738, and usually can include username, '
         'password, hostname, database name as well as optional keyword arguments '
         'for additional configuration',
+        envvar='BENTOML_DB_URL',
     )
     @click.option(
         '--repo-base-url',
         type=click.STRING,
         help='Base URL for storing saved BentoService bundle files, this can be a '
         'filesystem path(POSIX/Windows), or a S3 URL, usually starts with "s3://"',
+        envvar='BENTOML_REPO_BASE_URL',
     )
     @click.option(
         '--grpc-port', type=click.INT, default=50051, help='Port for Yatai server'
@@ -49,7 +51,10 @@ def add_yatai_service_sub_command(cli):
         '--ui-port', type=click.INT, default=3000, help='Port for Yatai web UI'
     )
     @click.option(
-        '--ui/--no-ui', default=True, help='Start BentoML YataiService without Web UI'
+        '--ui/--no-ui',
+        default=True,
+        help='Start BentoML YataiService without Web UI',
+        envvar='BENTOML_ENABLE_WEB_UI',
     )
     def yatai_service_start(db_url, repo_base_url, grpc_port, ui_port, ui):
         track_cli('yatai-service-start')

--- a/bentoml/yatai/__init__.py
+++ b/bentoml/yatai/__init__.py
@@ -128,7 +128,7 @@ def start_yatai_service_grpc_server(db_url, repo_base_url, grpc_port, ui_port, w
         f'* Running on 127.0.0.1:{grpc_port} (Press CTRL+C to quit)\n'
         f'* Usage: `bentoml config set yatai_service.url=127.0.0.1:{grpc_port}`\n'
         f'* Help and instructions: '
-        f'https://docs.bentoml.org/en/latest/concepts/yatai_service.html\n'
+        f'https://docs.bentoml.org/en/latest/guides/yatai_service.html\n'
         f'{f"* Web server log can be found here: {web_ui_log_path}" if with_ui else ""}'
     )
 

--- a/dev/release_yatai_service_docker_image.sh
+++ b/dev/release_yatai_service_docker_image.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -eq 1 ]; then
+  BENTOML_VERSION=$1
+else
+  echo "Must provide target BentoML version, e.g. ./script/release_yatai_service_docker_image.sh 0.7.0"
+  exit 1
+fi
+
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+cd $GIT_ROOT/docker/yatai-service
+
+docker build --pull \
+    --build-arg version=$BENTOML_VERSION \
+    -t bentoml/yatai-service:$BENTOML_VERSION \
+    .
+
+docker push bentoml/yatai-service:$BENTOML_VERSION

--- a/docker/yatai-service/Dockerfile
+++ b/docker/yatai-service/Dockerfile
@@ -6,10 +6,55 @@ EXPOSE 50051
 # YataiService Web UI port
 EXPOSE 3000
 
+COPY entrypoint.sh /usr/local/bin/
+
+# Install Node, required by the Web UI Server
+# Code copied from https://github.com/nodejs/docker-node/blob/master/13/buster/Dockerfile
+ENV NODE_VERSION 13.12.0
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  # gpg keys listed at https://github.com/nodejs/node#release-keys
+  && set -ex \
+  && for key in \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+    4ED778F539E3634C779C87C6D7062848A1AB005C \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+  ; do \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  # smoke tests
+  && node --version \
+  && npm --version
+
 # Build time argument - the BentoML version to be used in this image
 ARG version
 ENV BENTOML_VERSION=$version
 RUN pip install bentoml==$version
 
-ENTRYPOINT ["bentoml", "yatai-service-start"]
-CMD []
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["bentoml", "yatai-service-start"]

--- a/docker/yatai-service/Dockerfile
+++ b/docker/yatai-service/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.7-buster
+
+# YataiService GRPC port
+EXPOSE 50051
+
+# YataiService Web UI port
+EXPOSE 3000
+
+# Build time argument - the BentoML version to be used in this image
+ARG version
+ENV BENTOML_VERSION=$version
+RUN pip install bentoml==$version
+
+ENTRYPOINT ["bentoml", "yatai-service-start"]
+CMD []

--- a/docker/yatai-service/entrypoint.sh
+++ b/docker/yatai-service/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to start bentoml YataiService
+	if [ "${1:0:1}" = '-' ]; then
+		set -- bentoml yatai-service-start "$@"
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -571,7 +571,7 @@ server to start the YataiService:
     * Web UI: running on http://127.0.0.1:3000
     * Running on 127.0.0.1:50051 (Press CTRL+C to quit)
     * Usage: `bentoml config set yatai_service.url=127.0.0.1:50051`
-    * Help and instructions: https://docs.bentoml.org/en/latest/concepts/yatai_service.html
+    * Help and instructions: https://docs.bentoml.org/en/latest/guides/yatai_service.html
     * Web server log can be found here: /Users/chaoyu/bentoml/logs/yatai_web_server.log
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import numpy as np
 from bentoml.yatai.client import YataiClient
 from tests.bento_service_examples.example_bento_service import ExampleBentoService
 
+
 @pytest.fixture()
 def img_file(tmpdir):
     img_file = tmpdir.join("test_img.jpg")


### PR DESCRIPTION
This PR made it more convinent to deploy YataiService(bentoml's model management and deployment automation component) via docker:
 ```
$ docker run bentoml/yatai-service:0.7.0  --db-url postgresql://chaoyu:passwd@localhost:5432/bentomldb --repo-base-url s3://my-bentoml-repo/
```