### PR TITLE
[BUILD] Exclude benchmark module in bdist_wheel build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -35,12 +35,6 @@ include bentoml/alembic.ini
 
 # include yatai server UI distribution files
 graft bentoml/yatai/web/dist
-prune bentoml/yatai/web/node_modules
 
 # include ".conf" file
 include bentoml/deployment/sagemaker/sagemaker_nginx.conf
-
-# exclude e2e_tests files
-prune e2e_tests
-prune tests
-prune benchmark

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -38,3 +38,7 @@ graft bentoml/yatai/web/dist
 
 # include ".conf" file
 include bentoml/deployment/sagemaker/sagemaker_nginx.conf
+
+prune e2e_tests
+prune tests
+prune benchmark

--- a/setup.py
+++ b/setup.py
@@ -123,15 +123,14 @@ setuptools.setup(
     cmdclass=versioneer.get_cmdclass(),
     author="bentoml.org",
     author_email="contact@bentoml.ai",
-    description="A platform for serving and deploying machine learning models in the "
-    "cloud",
+    description="An open-source platform for machine learning model serving.",
     long_description=long_description,
     license="Apache License 2.0",
     long_description_content_type="text/markdown",
     install_requires=install_requires,
     extras_require=extras_require,
     url="https://github.com/bentoml/BentoML",
-    packages=setuptools.find_packages(exclude=["tests*"]),
+    packages=setuptools.find_namespace_packages(include=["bentoml"]),
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,7 @@ setuptools.setup(
     install_requires=install_requires,
     extras_require=extras_require,
     url="https://github.com/bentoml/BentoML",
-    packages=setuptools.find_namespace_packages(include=["bentoml"]),
+    packages=setuptools.find_packages(exclude=["tests*", "benchmark*"]),
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
* The previous attempt https://github.com/bentoml/BentoML/pull/590, to exclude benchmark module from PyPI distribution, only works for sdist but not bdist_wheel build. This PR is fixing that