### PR TITLE
Lock grpcio version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
     "sqlalchemy>=1.3.0",
     "sqlalchemy-utils",
     "protobuf>=3.6.0",
-    "grpcio",
+    "grpcio<=1.27.2",
     "cerberus",
     "tabulate",
     "humanfriendly",


### PR DESCRIPTION
Lock grpcio to 1.27.2 or below. New grpcio version 1.28.2(Apr 3, 2020) is breaking AWS lambda deployment
