### PR TITLE
Fix Windows compatibility while packaging models

### DIFF
--- a/bentoml/marshal/marshal.py
+++ b/bentoml/marshal/marshal.py
@@ -18,6 +18,7 @@ import logging
 import multiprocessing
 from functools import partial
 
+import psutil
 import aiohttp
 
 from bentoml import config
@@ -138,10 +139,10 @@ class MarshalService:
         self.bento_service_metadata_pb = load_bento_service_metadata(bento_bundle_path)
 
         self.setup_routes_from_pb(self.bento_service_metadata_pb)
-        try:
+        if psutil.POSIX:
             import resource
             self.CONNECTION_LIMIT = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
-        except ImportError:
+        else:
             self.CONNECTION_LIMIT = 1024
         logger.info(
             "Your system nofile limit is %d, which means each instance of microbatch "

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ install_requires = [
     "aiohttp",
     "py_zipkin",
     'contextvars;python_version < "3.7"',
+    "psutil",
     # python-dateutil required by pandas and boto3, this makes sure the version
     # works for both
     "python-dateutil>=2.1,<2.8.1",


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below.)

What changes were proposed in this pull request?
------------------------------------------------
Many a times people create the model in windows and serve in in Linux. Even though gunicorn is not supported windows we can remove issues with creating and packaging model in windows. These changes allow the same.

Fixed Issues in windows
1. ModuleNotFoundError: No module named 'resource'
2. AttributeError: module 'aiohttp' has no attribute 'web'

Does this close any currently open issues?
------------------------------------------
I have not seen any related issues. But I am sure people will experience these issues in the future when using windows

How was this patch tested?
--------------------------
Tested on Windows 10 machine by creating a Pytorch seq2seq model. It is working without any issues.