### PR TITLE
[TESTING] add postgres dependency to part of test_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ test_requires = (
     ]
     + imageio
     + aws_sam_cli
+    + postgres
 )
 
 dev_requires = [


### PR DESCRIPTION
package `psycopg2-binary` was missing for test yatai_server Postgres