### PR TITLE
Fix create s3 bucket issue for us-east-1 region

### DIFF
--- a/bentoml/marshal/marshal.py
+++ b/bentoml/marshal/marshal.py
@@ -141,6 +141,7 @@ class MarshalService:
         self.setup_routes_from_pb(self.bento_service_metadata_pb)
         if psutil.POSIX:
             import resource
+
             self.CONNECTION_LIMIT = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
         else:
             self.CONNECTION_LIMIT = 1024

--- a/bentoml/utils/s3.py
+++ b/bentoml/utils/s3.py
@@ -76,15 +76,25 @@ def create_s3_bucket_if_not_exists(bucket_name, region):
             # `LocationConstraint` is set to `us-east-1` region.
             # https://github.com/boto/boto3/issues/125.
             # This issue still show up in  boto3 1.13.4(May 6th 2020)
-            # solution is not specify a region, if the region is `us-east-1`
-
-            if region != 'us-east-1':
+            try:
                 s3_client.create_bucket(
                     Bucket=bucket_name,
                     CreateBucketConfiguration={'LocationConstraint': region},
                 )
-            else:
-                s3_client.create_bucket(Bucket=bucket_name)
+            except ClientError as s3_error:
+                if (
+                    s3_error.response
+                    and s3_error.response['Error']['Code']
+                    == 'InvalidLocationConstraint'
+                ):
+                    logger.debug(
+                        'Special s3 region: %s, will attempt create bucket without '
+                        '`LocationConstraint`',
+                        region
+                    )
+                    s3_client.create_bucket(Bucket=bucket_name)
+                else:
+                    raise s3_error
         else:
             raise error
 

--- a/bentoml/utils/s3.py
+++ b/bentoml/utils/s3.py
@@ -71,10 +71,23 @@ def create_s3_bucket_if_not_exists(bucket_name, region):
     except ClientError as error:
         if error.response and error.response['Error']['Code'] == 'NoSuchBucket':
             logger.debug('Creating s3 bucket: %s in region %s', bucket_name, region)
-            s3_client.create_bucket(
-                Bucket=bucket_name,
-                CreateBucketConfiguration={'LocationConstraint': region},
-            )
+            bucket_configuration = {}
+
+            # NOTE: boto3 will raise ClientError(InvalidLocationConstraint) if
+            # `LocationConstraint` is set to `us-east-1` region.
+            # https://github.com/boto/boto3/issues/125.
+            # This issue still show up in  boto3 1.13.4(May 6th 2020)
+            # solution is not specify a region, if the region is `us-east-1`
+
+            print(region)
+            if region != 'us-east-1':
+                s3_client.create_bucket(
+                    Bucket=bucket_name,
+                    # CreateBucketConfiguration=bucket_configuration
+                    CreateBucketConfiguration={'LocationConstraint': region},
+                )
+            else:
+                s3_client.create_bucket(Bucket=bucket_name)
         else:
             raise error
 

--- a/bentoml/utils/s3.py
+++ b/bentoml/utils/s3.py
@@ -71,7 +71,6 @@ def create_s3_bucket_if_not_exists(bucket_name, region):
     except ClientError as error:
         if error.response and error.response['Error']['Code'] == 'NoSuchBucket':
             logger.debug('Creating s3 bucket: %s in region %s', bucket_name, region)
-            bucket_configuration = {}
 
             # NOTE: boto3 will raise ClientError(InvalidLocationConstraint) if
             # `LocationConstraint` is set to `us-east-1` region.
@@ -79,11 +78,9 @@ def create_s3_bucket_if_not_exists(bucket_name, region):
             # This issue still show up in  boto3 1.13.4(May 6th 2020)
             # solution is not specify a region, if the region is `us-east-1`
 
-            print(region)
             if region != 'us-east-1':
                 s3_client.create_bucket(
                     Bucket=bucket_name,
-                    # CreateBucketConfiguration=bucket_configuration
                     CreateBucketConfiguration={'LocationConstraint': region},
                 )
             else:

--- a/e2e_tests/aws_lambda/test_lambda_deployment.py
+++ b/e2e_tests/aws_lambda/test_lambda_deployment.py
@@ -25,7 +25,7 @@ def test_aws_lambda_deployment(iris_clf_service):
         '-b',
         iris_clf_service,
         '--region',
-        'us-west-2',
+        'us-east-1',
         '--verbose',
     ]
     try:

--- a/e2e_tests/aws_lambda/test_lambda_deployment.py
+++ b/e2e_tests/aws_lambda/test_lambda_deployment.py
@@ -25,7 +25,7 @@ def test_aws_lambda_deployment(iris_clf_service):
         '-b',
         iris_clf_service,
         '--region',
-        'us-east-1',
+        'us-west-2',
         '--verbose',
     ]
     try:


### PR DESCRIPTION
For creating s3 bucket for `us-east-1` region, you can not specify the region in the request https://github.com/boto/boto3/issues/125.

