### PR TITLE
MISC API server docker image improvements

### DIFF
--- a/bentoml/bundler/bundler.py
+++ b/bentoml/bundler/bundler.py
@@ -25,9 +25,10 @@ from bentoml.bundler.py_module_utils import copy_used_py_modules
 from bentoml.bundler.templates import (
     BENTO_SERVICE_BUNDLE_SETUP_PY_TEMPLATE,
     MANIFEST_IN_TEMPLATE,
-    BENTO_SERVICE_DOCKERFILE_CPU_TEMPLATE,
+    MODEL_SERVER_DOCKERFILE_CPU,
     INIT_PY_TEMPLATE,
     BENTO_INIT_SH_TEMPLATE,
+    DOCKER_ENTRYPOINT_SH,
 )
 from bentoml.bundler.utils import add_local_bentoml_package_to_repo
 from bentoml.utils import _is_bentoml_in_develop_mode
@@ -138,7 +139,15 @@ def save_to_dir(bento_service, path, version=None, silent=False):
 
     # write Dockerfile
     with open(os.path.join(path, "Dockerfile"), "w") as f:
-        f.write(BENTO_SERVICE_DOCKERFILE_CPU_TEMPLATE)
+        f.write(MODEL_SERVER_DOCKERFILE_CPU)
+
+    # write docker-entrypoint.sh
+    docker_entrypoint_sh_file = os.path.join(path, "docker-entrypoint.sh")
+    with open(docker_entrypoint_sh_file, "w") as f:
+        f.write(DOCKER_ENTRYPOINT_SH)
+    # chmod +x docker-entrypoint.sh
+    st = os.stat(docker_entrypoint_sh_file)
+    os.chmod(docker_entrypoint_sh_file, st.st_mode | stat.S_IEXEC)
 
     # write bento init sh for install targz bundles
     bentoml_init_script_file = os.path.join(path, 'bentoml_init.sh')

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -225,7 +225,9 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         "--port",
         type=click.INT,
         default=BentoAPIServer._DEFAULT_PORT,
-        help="The port to listen on for the REST api server, default is 5000.",
+        help=f"The port to listen on for the REST api server, "
+        f"default is ${BentoAPIServer._DEFAULT_PORT}",
+        envvar='BENTOML_PORT',
     )
     @click.option(
         '--with-conda',
@@ -282,7 +284,15 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         short_help="Start local gunicorn server",
     )
     @conditional_argument(pip_installed_bundle_path is None, "bento", type=click.STRING)
-    @click.option("-p", "--port", type=click.INT, default=BentoAPIServer._DEFAULT_PORT)
+    @click.option(
+        "-p",
+        "--port",
+        type=click.INT,
+        default=BentoAPIServer._DEFAULT_PORT,
+        help=f"The port to listen on for the REST api server, "
+        f"default is ${BentoAPIServer._DEFAULT_PORT}",
+        envvar='BENTOML_PORT',
+    )
     @click.option(
         "-w",
         "--workers",


### PR DESCRIPTION
* Updated miniconda version to 4.8.2
* Added `docker-entrypoint.sh`, now users can pass extra parameters to bentoml docker container directly, e.g.:
```
 $ docker run -p 3000:3000 parano/test:latest --port=3000 --enable-microbatch
```
* Support direct heroku deployment with the $PART env var:
```
$ docker run -e PORT=3333 -p 3333:3333 parano/test:latest
```
* Fixed an issue with custom pip index with BentoML docker build

* Removed the previously added $FLAGS env var, cc @hrmthw 

* TODO: move dockerfile and entry-point code to separate file instead of string template in a python file