### PR TITLE
Fix prometheus multiprocess mode directory missing

### DIFF
--- a/bentoml/server/utils.py
+++ b/bentoml/server/utils.py
@@ -58,10 +58,12 @@ def setup_prometheus_multiproc_dir(lock: multiprocessing.Lock = None):
         logger.debug(
             "Setting up prometheus_multiproc_dir: %s", prometheus_multiproc_dir
         )
-        if not os.path.exists(prometheus_multiproc_dir):
-            os.mkdir(prometheus_multiproc_dir)
-        if os.listdir(prometheus_multiproc_dir):
-            shutil.rmtree(prometheus_multiproc_dir)
+        # Wipe prometheus metrics directory between runs
+        # https://github.com/prometheus/client_python#multiprocess-mode-gunicorn
+        # Ignore errors so it does not fail when directory does not exist
+        shutil.rmtree(prometheus_multiproc_dir, ignore_errors=True)
+        os.makedirs(prometheus_multiproc_dir, exist_ok=True)
+
         os.environ['prometheus_multiproc_dir'] = prometheus_multiproc_dir
     finally:
         if lock is not None:


### PR DESCRIPTION
This PR fixed an issue(introduced in 0.7.0) where the prometheus multiprocess directory is not setup properly in-between runs, and user may see the following error message when starting up BentoML API server:
```
FileNotFoundError: [Errno 2] No such file or directory: '/Users/chaoyu/bentoml/prometheus_multiproc_dir/gauge_all_83520.db'
```

Thanks @fernandocamargoti for reporting the issue