### PR TITLE
Chore: allow yatai client to connect secure gRPC

### DIFF
--- a/bentoml/configuration/default_bentoml.cfg
+++ b/bentoml/configuration/default_bentoml.cfg
@@ -58,6 +58,7 @@ zipkin_api_url =
 [yatai_service]
 # example for connecting local YataiService grpc server: http://127.0.0.1:50051
 url =
+client_certificate_file =
 
 [apiserver]
 default_port = 5000

--- a/bentoml/yatai/utils.py
+++ b/bentoml/yatai/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import subprocess
+import urllib3
 
 from bentoml.exceptions import BentoMLException, MissingDependencyException
 
@@ -29,3 +30,14 @@ def ensure_node_available_or_raise():
             'Node is required for Yatai web UI. Please visit '
             'www.nodejs.org for instructions'
         )
+
+
+def parse_grpc_url(url):
+    '''
+    >>> parse_grpc_url("grpcs://yatai.com:43/query")
+    ('grpcs', 'yatai.com:43/query')
+    >>> parse_grpc_url("yatai.com:43/query")
+    (None, 'yatai.com:43/query')
+    '''
+    parts = urllib3.util.parse_url(url)
+    return parts.scheme, url.replace(f"{parts.scheme}://", "", 1)

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ install_requires = [
     # python-dateutil required by pandas and boto3, this makes sure the version
     # works for both
     "python-dateutil>=2.1,<2.8.1",
+    "certifi",
 ]
 
 imageio = ["imageio>=2.5.0"]


### PR DESCRIPTION
* How to use:
https://www.notion.so/How-to-deploy-yatai-server-behind-Nginx-and-TLS-1327e8a3cd484a1d998ec1c7c9edde57

* grpcs:// ?
Nginx use this scheme in its config: https://www.nginx.com/blog/nginx-1-13-10-grpc/

* How to specify ca cert?
`bentoml config set yatai_service.client_certificate_file=<path_to_your_ca_cert.pem>`
It is using Mozilla ca cert as default.