### PR TITLE
[Docs] clean up deployment guides

### DIFF
--- a/docs/source/deployment/aws_ecs.rst
+++ b/docs/source/deployment/aws_ecs.rst
@@ -40,9 +40,8 @@ Prerequisites
 AWS ECS deployment with BentoML
 -------------------------------------------------
 
-This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
-
-Build the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
+Run the example project from the :doc:`quick start guide <../quickstart>` to create the
+BentoML saved bundle for deployment:
 
 
 .. code-block:: bash
@@ -50,6 +49,7 @@ Build the IrisClassifier BentoService from the :doc:`Quick start guide <../quick
     git clone git@github.com:bentoml/BentoML.git
     python ./bentoml/guides/quick-start/main.py
 
+Verify the saved bundle created:
 
 .. code-block:: bash
 
@@ -107,12 +107,14 @@ BentoService and available for sending test request:
       --data '[[5.1, 3.5, 1.4, 0.2]]' \
       http://localhost:5000/predict
 
-======================================================================
-Dockerize BentoML model server for AWS ECR(Elastic Container Registry)
-======================================================================
+=============================================
+Dockerize BentoML model server for deployment
+=============================================
 
 In order to create ECS deployment, the model server need to be containerized and push to
-a container registry such as AWS ECR.
+a container registry. Amazon Elastic Container Registry (ECR) is a fully-managed Docker
+container registry that makes it easy for developers to store, manage, and deploy Docker
+container images.
 
 Docker login with AWS ECR
 
@@ -159,7 +161,7 @@ Create AWS ECR repository
 
 .. code-block:: bash
 
-    # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
+    # Install jq, the command-line JSON processor: https://stedolan.github.io/jq/download/
     $ saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
     $ docker build --tag=192023623294.dkr.ecr.us-west-2.amazonaws.com/irisclassifier-ecs $saved_path
 

--- a/docs/source/deployment/aws_ecs.rst
+++ b/docs/source/deployment/aws_ecs.rst
@@ -8,6 +8,10 @@ of AWS Lambda without sacrificing computing performance. It is great for running
 advanced ML prediction service that require more computing power compare to AWS Lambda,
 while still want to take advantage of the benefits that AWS Lambda brings.
 
+This guide demonstrates how to serve a scikit-learn based iris classifier model with
+BentoML on AWS ECS. The same deployment steps are also applicable for models
+trained with other machine learning frameworks, see more BentoML examples :doc:`here <../examples>`.
+
 Prerequisites
 -------------
 
@@ -36,11 +40,12 @@ Prerequisites
 AWS ECS deployment with BentoML
 -------------------------------------------------
 
-This guide will walk through from deploying BentoService with ECS, validate result with
-sample data and removing service and clean up AWS resources.
+This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
+The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
+service. The predict endpoint expects `pandas.DataFrame` as input.
 
+Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
 
-Use the IrisClassifier BentoService from the :doc:`Quick start guide<../quickstart>`:
 
 .. code-block:: bash
 
@@ -86,8 +91,26 @@ Use the IrisClassifier BentoService from the :doc:`Quick start guide<../quicksta
     }
 
 
+The BentoML saved bundle created can now be used to start a REST API Server hosting the
+BentoService and available for sending test request:
+
+.. code-block:: bash
+
+    # Start BentoML API server:
+    bentoml serve IrisClassifier:latest
+
+
+.. code-block:: bash
+
+    # Send test request:
+    curl -i \
+      --header "Content-Type: application/json" \
+      --request POST \
+      --data '[[5.1, 3.5, 1.4, 0.2]]' \
+      http://localhost:5000/predict
+
 ==================================================================
-Build and push docker image to AWS ECR(Elastic Container Registry)
+Build BentoML model server for AWS ECR(Elastic Container Registry)
 ==================================================================
 
 

--- a/docs/source/deployment/azure_container_instance.rst
+++ b/docs/source/deployment/azure_container_instance.rst
@@ -32,11 +32,8 @@ Prerequisites
 Deploying BentoService to Azure Container Instance
 --------------------------------------------------
 
-This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
-The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
-service. The predict endpoint expects `pandas.DataFrame` as input.
-
-Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
+Run the example project from the :doc:`quick start guide <../quickstart>` to create the
+BentoML saved bundle for deployment:
 
 
 .. code-block:: bash
@@ -44,6 +41,7 @@ Build the IrisClassifier BentoService from the :doc:`quick start guide <../quick
     git clone git@github.com:bentoml/BentoML.git
     python ./bentoml/guides/quick-start/main.py
 
+Verify the saved bundle created:
 
 .. code-block:: bash
 
@@ -223,10 +221,9 @@ Build and push docker image to ACR
 
 .. code-block:: bash
 
-    # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
+    # Install jq, the command-line JSON processor: https://stedolan.github.io/jq/download/
     $ saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
-    $ cd $saved_path
-    $ docker build -t bentomlirisclassifier.azurecr.io/iris-classifier .
+    $ docker build -t bentomlirisclassifier.azurecr.io/iris-classifier $saved_path
 
     # Sample output
 

--- a/docs/source/deployment/azure_container_instance.rst
+++ b/docs/source/deployment/azure_container_instance.rst
@@ -74,6 +74,25 @@ This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide
     }
 
 
+After saving the BentoService instance, you can now start a REST API server with the
+model trained and test the API server locally:
+
+.. code-block:: bash
+
+    # Start BentoML API server:
+    bentoml serve IrisClassifier:latest
+
+
+.. code-block:: bash
+
+    # Send test request:
+    curl -i \
+      --header "Content-Type: application/json" \
+      --request POST \
+      --data '[[5.1, 3.5, 1.4, 0.2]]' \
+      http://localhost:5000/predict
+
+
 ===================
 Configure Azure CLI
 ===================
@@ -193,6 +212,7 @@ Build and push docker image to ACR
 
 .. code-block:: bash
 
+    > # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
     > saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
     > cd $saved_path
     > docker build -t bentomlirisclassifier.azurecr.io/iris-classifier .

--- a/docs/source/deployment/azure_container_instance.rst
+++ b/docs/source/deployment/azure_container_instance.rst
@@ -47,7 +47,7 @@ Build the IrisClassifier BentoService from the :doc:`quick start guide <../quick
 
 .. code-block:: bash
 
-    bentoml get IrisClassifier:latest
+    $ bentoml get IrisClassifier:latest
 
     # sample output
     {
@@ -108,7 +108,9 @@ Configure Azure CLI
 
 .. code-block:: bash
 
-    az login
+    $ az login
+
+    # Sample output
 
     You have logged in. Now let us find all the subscriptions to which you have access...
     [
@@ -129,7 +131,7 @@ Configure Azure CLI
 
 .. code-block:: bash
 
-    az group create --name iris-classifier --location eastus
+    $ az group create --name iris-classifier --location eastus
 
     # Sample output
     {
@@ -150,7 +152,7 @@ Create and configure Azure ACR (Azure Container Registry)
 
 .. code-block:: bash
 
-    az acr create --resource-group iris-classifier --name bentomlirisclassifier --sku Basic --admin-enabled true
+    $ az acr create --resource-group iris-classifier --name bentomlirisclassifier --sku Basic --admin-enabled true
 
     # Sample output
 
@@ -199,14 +201,14 @@ Create and configure Azure ACR (Azure Container Registry)
 
 .. code-block:: bash
 
-    az acr login --name bentomlirisclassifier
+    $ az acr login --name bentomlirisclassifier
 
     Login Succeeded
 
 
 .. code-block:: bash
 
-    az acr show --name BentoMLIrisClassifier --query loginServer --output table
+    $ az acr show --name BentoMLIrisClassifier --query loginServer --output table
 
     # Sample output
 
@@ -222,9 +224,11 @@ Build and push docker image to ACR
 .. code-block:: bash
 
     # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
-    saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
-    cd $saved_path
-    docker build -t bentomlirisclassifier.azurecr.io/iris-classifier .
+    $ saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
+    $ cd $saved_path
+    $ docker build -t bentomlirisclassifier.azurecr.io/iris-classifier .
+
+    # Sample output
 
     Sending build context to Docker daemon  8.314MB
     Step 1/12 : FROM continuumio/miniconda3:4.7.12
@@ -254,7 +258,7 @@ Build and push docker image to ACR
 
 .. code-block:: bash
 
-    docker push bentomlirisclassifier.azurecr.io/iris-classifier
+    $ docker push bentomlirisclassifier.azurecr.io/iris-classifier
 
     # Sample output
 
@@ -270,7 +274,7 @@ Retrieve registry username and password for container deployment
 
 .. code-block:: bash
 
-    az acr repository list --name bentomlirisclassifier --output table
+    $ az acr repository list --name bentomlirisclassifier --output table
 
     # Sample output
 
@@ -281,7 +285,7 @@ Retrieve registry username and password for container deployment
 
 .. code-block:: bash
 
-    az acr credential show -n bentomlirisclassifier
+    $ az acr credential show -n bentomlirisclassifier
 
     # Sample output
 
@@ -303,16 +307,16 @@ Deploying image as Azure container. `registry-username` and `registry-password` 
 
 .. code-block:: bash
 
-    az container create --resource-group iris-classifier \
-    --name bentomlirisclassifier \
-    --image bentomlirisclassifier.azurecr.io/iris-classifier \
-    --cpu 1 \
-    --memory 1 \
-    --registry-login-server bentomlirisclassifier.azurecr.io \
-    --registry-username bentomlirisclassifier \
-    --registry-password i/qE2Eu/Ngv344HjfOEPjNKkN9hHre+k \
-    --dns-name-label bentomlirisclassifier777 \
-    --ports 5000
+    $ az container create --resource-group iris-classifier \
+        --name bentomlirisclassifier \
+        --image bentomlirisclassifier.azurecr.io/iris-classifier \
+        --cpu 1 \
+        --memory 1 \
+        --registry-login-server bentomlirisclassifier.azurecr.io \
+        --registry-username bentomlirisclassifier \
+        --registry-password i/qE2Eu/Ngv344HjfOEPjNKkN9hHre+k \
+        --dns-name-label bentomlirisclassifier777 \
+        --ports 5000
 
     # Sample output
 
@@ -430,7 +434,7 @@ Use `az container show` command to fetch container instace state
 
 .. code-block:: bash
 
-    az container show --resource-group iris-classifier --name bentomlirisclassifier --query instanceView.state
+    $ az container show --resource-group iris-classifier --name bentomlirisclassifier --query instanceView.state
 
     "Running"
 
@@ -439,7 +443,7 @@ We can use the same `az container show` command to retreive endpoint address
 
 .. code-block:: bash
 
-    az container show --resource-group iris-classifier --name bentomlirisclassifier --query ipAddress.fqdn
+    $ az container show --resource-group iris-classifier --name bentomlirisclassifier --query ipAddress.fqdn
 
     "bentomlirisclassifier777.eastus.azurecontainer.io"
 
@@ -450,10 +454,10 @@ Validate Azure container instance with sample data POST request
 
 .. code-block:: bash
 
-    curl -X \
-    POST "http://bentomlirisclassifier777.eastus.azurecontainer.io:5000/predict" \
-    --header "Content-Type: application/json" \
-    -d '[[5.1, 3.5, 1.4, 0.2]]'
+    $ curl -X \
+        POST "http://bentomlirisclassifier777.eastus.azurecontainer.io:5000/predict" \
+        --header "Content-Type: application/json" \
+        -d '[[5.1, 3.5, 1.4, 0.2]]'
 
     [0]
 

--- a/docs/source/deployment/google_cloud_run.rst
+++ b/docs/source/deployment/google_cloud_run.rst
@@ -62,11 +62,8 @@ Create Google cloud project
 Build and push BentoML model service image to GCP repository
 ============================================================
 
-This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
-The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
-service. The predict endpoint expects `pandas.DataFrame` as input.
-
-Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
+Run the example project from the :doc:`quick start guide <../quickstart>` to create the
+BentoML saved bundle for deployment:
 
 
 .. code-block:: bash
@@ -74,6 +71,7 @@ Build the IrisClassifier BentoService from the :doc:`quick start guide <../quick
     git clone git@github.com:bentoml/BentoML.git
     python ./bentoml/guides/quick-start/main.py
 
+Verify the saved bundle created:
 
 .. code-block:: bash
 
@@ -136,7 +134,7 @@ Use `gcloud` CLI to build the docker image
 
 .. code-block:: bash
 
-    # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
+    # Install jq, the command-line JSON processor: https://stedolan.github.io/jq/download/
     $ saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
     $ cd $saved_path
     $ gcloud builds submit --tag gcr.io/irisclassifier-gcloud-run/iris-classifier

--- a/docs/source/deployment/google_cloud_run.rst
+++ b/docs/source/deployment/google_cloud_run.rst
@@ -5,6 +5,10 @@ Google Cloud Run is a fully manged compute platform that automatically scales. I
 alternative to run BentoService that requires more computing power. Cloud Run is serverless. It
 abstracts away infrastructure management, so you can focus on building service.
 
+This guide demonstrates how to deploy a scikit-learn based iris classifier model with
+BentoML to Google Cloud Run. The same deployment steps are also applicable for models
+trained with other machine learning frameworks, see more BentoML examples :doc:`here <../examples>`.
+
 
 Prerequisites
 -------------
@@ -53,11 +57,16 @@ Create Google cloud project
     Updated property [core/project]
 
 
-=============================================
-Build and push docker image to GCP repository
-=============================================
+============================================================
+Build and push BentoML model service image to GCP repository
+============================================================
 
-This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`:
+This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
+The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
+service. The predict endpoint expects `pandas.DataFrame` as input.
+
+Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
+
 
 .. code-block:: bash
 
@@ -103,8 +112,8 @@ This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide
     }
 
 
-After saving the BentoService instance, you can now start a REST API server with the
-model trained and test the API server locally:
+The BentoML saved bundle created can now be used to start a REST API Server hosting the
+BentoService and available for sending test request:
 
 .. code-block:: bash
 

--- a/docs/source/deployment/google_cloud_run.rst
+++ b/docs/source/deployment/google_cloud_run.rst
@@ -67,7 +67,7 @@ This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide
 
 .. code-block:: bash
 
-    > bentoml get IrisClassifier:latest
+    bentoml get IrisClassifier:latest
 
     # Sample output
     {
@@ -103,13 +103,33 @@ This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide
     }
 
 
+After saving the BentoService instance, you can now start a REST API server with the
+model trained and test the API server locally:
+
+.. code-block:: bash
+
+    # Start BentoML API server:
+    bentoml serve IrisClassifier:latest
+
+
+.. code-block:: bash
+
+    # Send test request:
+    curl -i \
+      --header "Content-Type: application/json" \
+      --request POST \
+      --data '[[5.1, 3.5, 1.4, 0.2]]' \
+      http://localhost:5000/predict
+
+
 Use `gcloud` CLI to build the docker image
 
 .. code-block:: bash
 
-    > saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
-    > cd $saved_path
-    > gcloud builds submit --tag gcr.io/irisclassifier-gcloud-run/iris-classifier
+    # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
+    saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
+    cd $saved_path
+    gcloud builds submit --tag gcr.io/irisclassifier-gcloud-run/iris-classifier
 
     # Sample output
     Creating temporary tarball archive of 15 file(s) totalling 15.8 MiB before compression.
@@ -159,11 +179,11 @@ Copy the service URL from the screen
 
 .. code-block:: bash
 
-    > curl -i \
-      --header "Content-Type: application/json" \
-      --request POST \
-      -d '[[5.1, 3.5, 1.4, 0.2]]' \
-      https://iris-classifier-7v6yobzlcq-uw.a.run.app/predict
+    curl -i \
+    --header "Content-Type: application/json" \
+    --request POST \
+    -d '[[5.1, 3.5, 1.4, 0.2]]' \
+    https://iris-classifier-7v6yobzlcq-uw.a.run.app/predict
 
     # Sample output
     [0]

--- a/docs/source/deployment/google_cloud_run.rst
+++ b/docs/source/deployment/google_cloud_run.rst
@@ -33,16 +33,17 @@ Create Google cloud project
 
 .. code-block:: bash
 
-    > glcoud components update
+    $ glcoud components update
 
     All components are up to date.
 
 
 .. code-block:: bash
 
-    > gcloud projects create irisclassifier-gcloud-run
+    $ gcloud projects create irisclassifier-gcloud-run
 
     # Sample ouput
+
     Create in progress for [https://cloudresourcemanager.googleapis.com/v1/projects/irisclassifier-gcloud-run].
     Waiting for [operations/cp.6403723248945195918] to finish...done.
     Enabling service [cloudapis.googleapis.com] on project [irisclassifier-gcloud-run]...
@@ -52,7 +53,7 @@ Create Google cloud project
 
 .. code-block:: bash
 
-    > gcloud config set project irisclassifier-gcloud-run
+    $ gcloud config set project irisclassifier-gcloud-run
 
     Updated property [core/project]
 
@@ -76,7 +77,7 @@ Build the IrisClassifier BentoService from the :doc:`quick start guide <../quick
 
 .. code-block:: bash
 
-    bentoml get IrisClassifier:latest
+    $ bentoml get IrisClassifier:latest
 
     # Sample output
     {
@@ -136,11 +137,12 @@ Use `gcloud` CLI to build the docker image
 .. code-block:: bash
 
     # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
-    saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
-    cd $saved_path
-    gcloud builds submit --tag gcr.io/irisclassifier-gcloud-run/iris-classifier
+    $ saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
+    $ cd $saved_path
+    $ gcloud builds submit --tag gcr.io/irisclassifier-gcloud-run/iris-classifier
 
     # Sample output
+
     Creating temporary tarball archive of 15 file(s) totalling 15.8 MiB before compression.
     Uploading tarball of [.] to [gs://irisclassifier-gcloud-run_cloudbuild/source/1587430763.39-03422068242448efbcfc45f2aed218d3.tgz]
     Created [https://cloudbuild.googleapis.com/v1/projects/irisclassifier-gcloud-run/builds/9c0f3ef4-11c0-4089-9406-1c7fb9c7e8e8].
@@ -188,11 +190,11 @@ Copy the service URL from the screen
 
 .. code-block:: bash
 
-    curl -i \
-    --header "Content-Type: application/json" \
-    --request POST \
-    -d '[[5.1, 3.5, 1.4, 0.2]]' \
-    https://iris-classifier-7v6yobzlcq-uw.a.run.app/predict
+    $ curl -i \
+        --header "Content-Type: application/json" \
+        --request POST \
+        -d '[[5.1, 3.5, 1.4, 0.2]]' \
+        https://iris-classifier-7v6yobzlcq-uw.a.run.app/predict
 
     # Sample output
     [0]

--- a/docs/source/deployment/heroku.rst
+++ b/docs/source/deployment/heroku.rst
@@ -31,17 +31,16 @@ Prerequsities
 Heroku deployment with BentoML
 ------------------------------
 
-This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
-The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
-service. The predict endpoint expects `pandas.DataFrame` as input.
+Run the example project from the :doc:`quick start guide <../quickstart>` to create the
+BentoML saved bundle for deployment:
 
-Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
 
 .. code-block:: bash
 
     git clone git@github.com:bentoml/BentoML.git
     python ./bentoml/guides/quick-start/main.py
 
+Verify the saved bundle created:
 
 .. code-block:: bash
 
@@ -131,7 +130,7 @@ Find the IrisClassifier SavedBundle directory:
 
 .. code-block:: bash
 
-    # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
+    # Install jq, the command-line JSON processor: https://stedolan.github.io/jq/download/
     cd $(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
 
 

--- a/docs/source/deployment/heroku.rst
+++ b/docs/source/deployment/heroku.rst
@@ -5,6 +5,9 @@ Heroku is a popular platform as a service based on managed container system. It 
 an easy solution to quickly build, run and scale applications. BentoML works great with
 Heroku. BentoServices could quickly deploy to Heroku as API model server for production.
 
+This guide demonstrates how to deploy a scikit-learn based iris classifier model with
+BentoML to Heroku. The same deployment steps are also applicable for models
+trained with other machine learning frameworks, see more BentoML examples :doc:`here <../examples>`.
 
 Prerequsities
 -------------
@@ -28,10 +31,11 @@ Prerequsities
 Heroku deployment with BentoML
 ------------------------------
 
-This example builds a BentoService with iris classifier model, and deploy the
-BentoService to Heroku as API server for inferencing.
+This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
+The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
+service. The predict endpoint expects `pandas.DataFrame` as input.
 
-Use the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
+Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
 
 .. code-block:: bash
 
@@ -75,6 +79,25 @@ Use the IrisClassifier BentoService from the :doc:`Quick start guide <../quickst
         ]
       }
     }
+
+
+The BentoML saved bundle created can now be used to start a REST API Server hosting the
+BentoService and available for sending test request:
+
+.. code-block:: bash
+
+    # Start BentoML API server:
+    bentoml serve IrisClassifier:latest
+
+
+.. code-block:: bash
+
+    # Send test request:
+    curl -i \
+      --header "Content-Type: application/json" \
+      --request POST \
+      --data '[[5.1, 3.5, 1.4, 0.2]]' \
+      http://localhost:5000/predict
 
 
 ==========================

--- a/docs/source/deployment/heroku.rst
+++ b/docs/source/deployment/heroku.rst
@@ -45,9 +45,10 @@ Build the IrisClassifier BentoService from the :doc:`quick start guide <../quick
 
 .. code-block:: bash
 
-    > bentoml get IrisClassifier:latest
+    $ bentoml get IrisClassifier:latest
 
     # Sample output
+
     {
       "name": "IrisClassifier",
       "version": "20200121141808_FE78B5",
@@ -109,21 +110,21 @@ Follow the CLI instruction and login to a Heroku account:
 
 .. code-block:: bash
 
-    $ heroku login
+    heroku login
 
 Login to the Heroku Container Registry:
 
 .. code-block:: bash
 
-    $ heroku container:login
+    heroku container:login
 
 
 Create a Heroku app:
 
 .. code-block:: bash
 
-    $ APP_NAME=bentoml-her0ku-$(date +%s | base64 | tr '[:upper:]' '[:lower:]' | tr -dc _a-z-0-9)
-    $ heroku create $APP_NAME
+    APP_NAME=bentoml-her0ku-$(date +%s | base64 | tr '[:upper:]' '[:lower:]' | tr -dc _a-z-0-9)
+    heroku create $APP_NAME
 
 
 Find the IrisClassifier SavedBundle directory:
@@ -131,7 +132,7 @@ Find the IrisClassifier SavedBundle directory:
 .. code-block:: bash
 
     # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
-    $ cd $(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
+    cd $(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
 
 
 Build and push API server container with the SavedBundle, and push to the Heroku app
@@ -139,27 +140,27 @@ Build and push API server container with the SavedBundle, and push to the Heroku
 
 .. code-block:: bash
 
-    $ heroku container:push web --app $APP_NAME
+    heroku container:push web --app $APP_NAME
 
 
 Release the app:
 
 .. code-block:: bash
 
-    $ heroku container:release web --app $APP_NAME
+    heroku container:release web --app $APP_NAME
 
 
 To view the deployment logs on heroku and verify the web server has been created:
 
 .. code-block:: bash
 
-    $ heroku logs --tail -a $APP_NAME
+    heroku logs --tail -a $APP_NAME
 
 Now, make prediction request with sample data:
 
 .. code-block:: bash
 
-    $ curl -i \
+    curl -i \
       --header "Content-Type: application/json" \
       --request POST \
       --data '[[5.1, 3.5, 1.4, 0.2]]' \
@@ -170,5 +171,5 @@ Remove deployment on Heroku
 
 .. code-block:: bash
 
-    $ heroku apps:destroy $APP_NAME
+    heroku apps:destroy $APP_NAME
 

--- a/docs/source/deployment/heroku.rst
+++ b/docs/source/deployment/heroku.rst
@@ -107,6 +107,7 @@ Find the IrisClassifier SavedBundle directory:
 
 .. code-block:: bash
 
+    # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
     $ cd $(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
 
 

--- a/docs/source/deployment/kfserving.rst
+++ b/docs/source/deployment/kfserving.rst
@@ -32,11 +32,8 @@ Before starting this guide, make sure you have the following:
 KFServing deployment with BentoML
 ---------------------------------
 
-This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
-The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
-service. The predict endpoint expects `pandas.DataFrame` as input.
-
-Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
+Run the example project from the :doc:`quick start guide <../quickstart>` to create the
+BentoML saved bundle for deployment:
 
 
 .. code-block:: bash
@@ -44,7 +41,7 @@ Build the IrisClassifier BentoService from the :doc:`quick start guide <../quick
     git clone git@github.com:bentoml/BentoML.git
     python ./bentoml/guides/quick-start/main.py
 
-Use BentoML CLI tool to get the information of IrisClassifier created above:
+Verify the saved bundle created:
 
 .. code-block:: bash
 
@@ -116,6 +113,7 @@ BentoML provides a convenient way to containerize the model API server with Dock
 
 .. code-block:: bash
 
+    # Install jq, the command-line JSON processor: https://stedolan.github.io/jq/download/
     model_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
 
     # Replace {docker_username} with your Docker Hub username

--- a/docs/source/deployment/kfserving.rst
+++ b/docs/source/deployment/kfserving.rst
@@ -155,21 +155,18 @@ Use `kubectl apply` command to deploy the InferenceService:
 Run prediction
 ==============
 
-*Note: Use kfserving-ingressgateway as your INGRESS_GATEWAY if you are deploying
-KFServing as part of Kubeflow install, and not independently.*
-
 .. code-block:: bash
 
     MODEL_NAME=iris-classifier
     INGRESS_GATEWAY=istio-ingressgateway
     CLUSTER_IP=$(kubectl -n istio-system get service $INGRESS_GATEWAY -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    SERVICE_HOSTNAME=$(kubectl get inferenceservice ${MODEL_NAME} -o jsonpath='{.status.url}' | cut -d "/" -f 3)
+    SERVICE_HOSTNAME=$(kubectl get route ${MODEL_NAME} -o jsonpath='{.status.url}' | cut -d "/" -f 3)
 
     curl -v -H "Host: ${SERVICE_HOSTNAME}" \
       --header "Content-Type: application/json" \
       --request POST \
       --data '[[5.1, 3.5, 1.4, 0.2]]' \
-      http://$CLUSTER_IP/model/predict
+      http://$CLUSTER_IP/predict
 
 
 =================

--- a/docs/source/deployment/kfserving.rst
+++ b/docs/source/deployment/kfserving.rst
@@ -2,12 +2,13 @@ Deploying to KFServing
 ======================
 
 
-This guide demostrates how to deploy a BentoService to a KFServing cluster.
-
 KFServing enables serverless inferencing on Kubernetes cluster for common machine learning
 frameworks like Tensorflow, XGBoost, scikit-learn and etc. BentoServices can easily
 deploy to KFServing and take advantage of what KFServing offers.
 
+This guide demonstrates how to serve a scikit-learn based iris classifier model with
+BentoML on a KFServing cluster. The same deployment steps are also applicable for models
+trained with other machine learning frameworks, see more BentoML examples :doc:`here <../examples>`.
 
 =============
 Prerequisites
@@ -31,7 +32,12 @@ Before starting this guide, make sure you have the following:
 KFServing deployment with BentoML
 ---------------------------------
 
-This guide use the IrisClassifier BentoService from the quick start guide:
+This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
+The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
+service. The predict endpoint expects `pandas.DataFrame` as input.
+
+Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
+
 
 .. code-block:: bash
 
@@ -78,8 +84,8 @@ Use BentoML CLI tool to get the information of IrisClassifier created above:
       }
     }
 
-After saving the BentoService instance, you can now start a REST API server with the
-model trained and test the API server locally:
+The BentoML saved bundle created can now be used to start a REST API Server hosting the
+BentoService and available for sending test request:
 
 .. code-block:: bash
 
@@ -100,14 +106,13 @@ model trained and test the API server locally:
 Deploy BentoService to KFServing
 ================================
 
-BentoML provides a convenient way of containerizing the model API server with Docker. To
-create a docker container image for the sample model above:
+BentoML provides a convenient way to containerize the model API server with Docker:
 
-  1. Find the file directory of the SavedBundle with `bentoml get` command, which is
-  directory structured as a docker build context.
+    1. Find the SavedBundle directory with `bentoml get` command
 
-  2. Running docker build with this directory produces a docker image containing the API
-  model server.
+    2. Run docker build with the SavedBundle directory which contains a generated Dockerfile
+
+    3. Run the generated docker image to start a docker container serving the model
 
 .. code-block:: bash
 

--- a/docs/source/deployment/kfserving.rst
+++ b/docs/source/deployment/kfserving.rst
@@ -48,7 +48,7 @@ Use BentoML CLI tool to get the information of IrisClassifier created above:
 
 .. code-block:: bash
 
-    bentoml get IrisClassifier:latest
+    $ bentoml get IrisClassifier:latest
 
     # Sample output
 

--- a/docs/source/deployment/knative.rst
+++ b/docs/source/deployment/knative.rst
@@ -1,15 +1,22 @@
-Deploying to Knative
+Deploying to KNative
 ====================
 
 Knative is kubernetes based platform to deploy and manage serverless workloads. It is a
 solution for deploying ML workload that requires more computing power that abstracts away
 infrastructure management and without worry about vendor lock.
 
+This guide demonstrates how to serve a scikit-learn based iris classifier model with
+BentoML on a KNative cluster. The same deployment steps are also applicable for models
+trained with other machine learning frameworks, see more BentoML examples :doc:`here <../examples>`.
 
 Prerequisites
 -------------
 
-* kubernetes cluster version 1.15 or newer.
+* A kubernetes installed cluster. `minikube` is used in this guide.
+
+    * Kubernetes guide: https://kubernetes.io/docs/setup/
+
+    * `minikube` install instruction: https://kubernetes.io/docs/tasks/tools/install-minikube/
 
 * Knative with istio as network layer
 
@@ -17,16 +24,21 @@ Prerequisites
 
     * Install istio for knative: https://knative.dev/docs/install/installing-istio/
 
-* Saved BentoService bundle
+* Python 3.6 or above and install required packages: `bentoml` and `scikit-learn`
 
-    * for this guide, we are using the IrisClassifier that was created in the
-      quick start guide: https://docs.bentoml.org/en/latest/quickstart.html
+    * .. code-block:: bash
+
+            pip install bentoml scikit-learn
 
 
 Knative deployment with BentoML
 -------------------------------
 
-This guide use the IrisClassifier BentoService from the :doc:`Quick start guide<../quickstart>`.
+This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
+The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
+service. The predict endpoint expects `pandas.DataFrame` as input.
+
+Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
 
 .. code-block:: bash
 
@@ -72,8 +84,8 @@ Use BentoML CLI tool to get the information about IrisClassifier.
     }
 
 
-After saving the BentoService instance, you can now start a REST API server with the
-model trained and test the API server locally:
+The BentoML saved bundle created can now be used to start a REST API Server hosting the
+BentoService and available for sending test request:
 
 .. code-block:: bash
 
@@ -91,18 +103,17 @@ model trained and test the API server locally:
       http://localhost:5000/predict
 
 
-==============================
-Deploy BentoService to Knative
-==============================
+======================================
+Deploy BentoML model server to KNative
+======================================
 
-BentoML provides a convenient way of containerizing the model API server with Docker. To
-create a docker container image for the sample model above:
+BentoML provides a convenient way to containerize the model API server with Docker:
 
-1. Find the file directory of the SavedBundle with bentoml get command, which is directory
-structured as a docker build context.
+    1. Find the SavedBundle directory with `bentoml get` command
 
-2. Running docker build with this directory produces a docker image containing the model
-API server
+    2. Run docker build with the SavedBundle directory which contains a generated Dockerfile
+
+    3. Run the generated docker image to start a docker container serving the model
 
 .. code-block:: bash
 
@@ -171,7 +182,7 @@ Create bentoml namespace and then deploy BentoService to Knative with kubectl ap
 
 
 
-Monitor the status with kubectl get ksvc command.
+View the status of the deployment with `kubectl get ksvc` command:
 
 .. code-block:: bash
 
@@ -185,8 +196,7 @@ Validate prediction server with sample data
 ===========================================
 
 
-For this guide, the kubernetes cluster run on minikube, Get the appropriate ip from
-minikube and the port from istio
+Find the cluster IP address and exposed port of the deployed Knative service, in the context of minikube:
 
 .. code-block::
 
@@ -197,7 +207,7 @@ minikube and the port from istio
     31871
 
 
-With the ip address and port, makes a curl request to the prediction result from Knative
+With the IP address and port, Use `curl` to make an HTTP request to the deployment in Knative:
 
 .. code-block:: bash
 

--- a/docs/source/deployment/knative.rst
+++ b/docs/source/deployment/knative.rst
@@ -12,11 +12,11 @@ trained with other machine learning frameworks, see more BentoML examples :doc:`
 Prerequisites
 -------------
 
-* A kubernetes installed cluster. `minikube` is used in this guide.
+* A kubernetes cluster.
+
+    * `minikube` is the recommended way to run Kubernetes locally:: https://kubernetes.io/docs/tasks/tools/install-minikube/
 
     * Kubernetes guide: https://kubernetes.io/docs/setup/
-
-    * `minikube` install instruction: https://kubernetes.io/docs/tasks/tools/install-minikube/
 
 * Knative with istio as network layer
 
@@ -34,18 +34,16 @@ Prerequisites
 Knative deployment with BentoML
 -------------------------------
 
-This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
-The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
-service. The predict endpoint expects `pandas.DataFrame` as input.
+Run the example project from the :doc:`quick start guide <../quickstart>` to create the
+BentoML saved bundle for deployment:
 
-Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
 
 .. code-block:: bash
 
     git clone git@github.com:bentoml/BentoML.git
     python ./bentoml/guides/quick-start/main.py
 
-Use BentoML CLI tool to get the information about IrisClassifier.
+Verify the saved bundle created:
 
 .. code-block:: bash
 
@@ -119,7 +117,7 @@ BentoML provides a convenient way to containerize the model API server with Dock
 
 .. code-block:: bash
 
-    # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
+    # Install jq, the command-line JSON processor: https://stedolan.github.io/jq/download/
     saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
 
     # Replace {docker_username} with your Docker Hub username

--- a/docs/source/deployment/knative.rst
+++ b/docs/source/deployment/knative.rst
@@ -49,7 +49,9 @@ Use BentoML CLI tool to get the information about IrisClassifier.
 
 .. code-block:: bash
 
-    > bentoml get IrisClassifier:20200121141808_FE78B5
+    $ bentoml get IrisClassifier:20200121141808_FE78B5
+
+    # Sample output
 
     {
       "name": "IrisClassifier",
@@ -129,7 +131,10 @@ Make sure Knative serving components are running.
 
 .. code-block:: bash
 
-    > kubectl get pods --namespace knative-serving
+    $ kubectl get pods --namespace knative-serving
+
+    # Sample output
+
     NAME                                READY   STATUS    RESTARTS   AGE
     activator-845b77cbb5-thpcw          2/2     Running   0          4h33m
     autoscaler-7fc56894f5-f2vqc         2/2     Running   0          4h33m
@@ -176,8 +181,11 @@ Create bentoml namespace and then deploy BentoService to Knative with kubectl ap
 
 .. code-block:: bash
 
-    > kubectl create namespace bentoml
-    > kubectl apply -f service.yaml
+    $ kubectl create namespace bentoml
+    $ kubectl apply -f service.yaml
+
+    # Sample output
+
     service.serving.knative.dev/iris-classifier created
 
 
@@ -186,7 +194,10 @@ View the status of the deployment with `kubectl get ksvc` command:
 
 .. code-block:: bash
 
-    > kubectl get ksvc --all-namespaces
+    $ kubectl get ksvc --all-namespaces
+
+    # Sample output
+
     NAMESPACE   NAME              URL                                          LATESTCREATED           LATESTREADY             READY   REASON
     bentoml     iris-classifier   http://iris-classifier.bentoml.example.com   iris-classifier-7k2dv   iris-classifier-7k2dv   True
 
@@ -200,10 +211,16 @@ Find the cluster IP address and exposed port of the deployed Knative service, in
 
 .. code-block::
 
-    > minikube ip
+    $ minikube ip
+
+    # Sample output
+
     192.168.64.4
 
-    > kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}
+    $ kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}
+
+    # Sample output
+
     31871
 
 
@@ -211,12 +228,14 @@ With the IP address and port, Use `curl` to make an HTTP request to the deployme
 
 .. code-block:: bash
 
-    > curl -v -i \
+    $ curl -v -i \
         --header "Content-Type: application/json" \
         --header "Host: iris-classifier.bentoml.example.com" \
         --request POST \
         --data '[[5.1, 3.5, 1.4, 0.2]]' \
         http://192.168.64.4:31871/predict
+
+    # Sample output
 
     Note: Unnecessary use of -X or --request, POST is already inferred.
     *   Trying 192.168.64.4...
@@ -256,4 +275,4 @@ Clean up deployment
 
 .. code-block:: bash
 
-    > kubectl delete namespace bentoml
+    kubectl delete namespace bentoml

--- a/docs/source/deployment/kubeflow.rst
+++ b/docs/source/deployment/kubeflow.rst
@@ -101,6 +101,7 @@ API server
 
 .. code-block:: bash
 
+    # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
     saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
 
     # Replace {docker_username} with your Docker Hub username

--- a/docs/source/deployment/kubeflow.rst
+++ b/docs/source/deployment/kubeflow.rst
@@ -49,7 +49,7 @@ Use BentoML CLI tool to get the information of IrisClassifier created above
 
 .. code-block:: bash
 
-    bentoml get IrisClassifier:latest
+    $ bentoml get IrisClassifier:latest
 
 
     # Sample output

--- a/docs/source/deployment/kubeflow.rst
+++ b/docs/source/deployment/kubeflow.rst
@@ -33,11 +33,8 @@ Before starting this guide, make sure you have the following:
 Kubeflow deployment with BentoML
 --------------------------------
 
-This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
-The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
-service. The predict endpoint expects `pandas.DataFrame` as input.
-
-Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
+Run the example project from the :doc:`quick start guide <../quickstart>` to create the
+BentoML saved bundle for deployment:
 
 .. code-block:: bash
 
@@ -100,7 +97,7 @@ BentoML provides a convenient way to containerize the model API server with Dock
 
 .. code-block:: bash
 
-    # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
+    # Install jq, the command-line JSON processor: https://stedolan.github.io/jq/download/
     saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
 
     # Replace {docker_username} with your Docker Hub username

--- a/docs/source/deployment/kubeflow.rst
+++ b/docs/source/deployment/kubeflow.rst
@@ -1,12 +1,12 @@
 Deploying to Kubeflow
 =====================
 
-
-This guide demostrates how to deploy a BentoService to Kubernetes cluster with Kubeflow
-installed.
-
 Kubeflow is the machine learning toolkit for Kubernetes. It makes producing ML services
 as simple as possible from data preparation to service management.
+
+This guide demonstrates how to serve a scikit-learn based iris classifier model with
+BentoML on a Kubernetes cluster. The same deployment steps are also applicable for models
+trained with other machine learning frameworks, see more BentoML examples :doc:`here <../examples>`.
 
 
 ==============
@@ -33,11 +33,11 @@ Before starting this guide, make sure you have the following:
 Kubeflow deployment with BentoML
 --------------------------------
 
-This guide builds a BentoService with iris classifier mode, and deploy BentoService to
-Kubeflow enabled Kubernetes cluster as API model server.
+This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
+The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
+service. The predict endpoint expects `pandas.DataFrame` as input.
 
-
-Use the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
+Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
 
 .. code-block:: bash
 
@@ -90,14 +90,13 @@ Use BentoML CLI tool to get the information of IrisClassifier created above
 Deploy BentoService to Kubeflow
 ===============================
 
-BentoML provides a convenient way of containerizing the model API server with Docker. To
-create a docker container image for the sample model above:
+BentoML provides a convenient way to containerize the model API server with Docker:
 
-1. Find the file directory of the SavedBundle with bentoml get command, which is directory
-structured as a docker build context.
+    1. Find the SavedBundle directory with `bentoml get` command
 
-2. Running docker build with this directory produces a docker image containing the model
-API server
+    2. Run docker build with the SavedBundle directory which contains a generated Dockerfile
+
+    3. Run the generated docker image to start a docker container serving the model
 
 .. code-block:: bash
 

--- a/docs/source/deployment/kubernetes.rst
+++ b/docs/source/deployment/kubernetes.rst
@@ -105,6 +105,7 @@ API server
 
 .. code-block:: bash
 
+    # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
     saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
 
     # Replace {docker_username} with your Docker Hub username

--- a/docs/source/deployment/kubernetes.rst
+++ b/docs/source/deployment/kubernetes.rst
@@ -16,11 +16,11 @@ Prerequsities
 
 Before starting this guide, make sure you have the following:
 
-* A kubernetes installed cluster. `minikube` is used in this guide.
+* A kubernetes cluster.
+
+    * `minikube` is the recommended way to run Kubernetes locally:: https://kubernetes.io/docs/tasks/tools/install-minikube/
 
     * Kubernetes guide: https://kubernetes.io/docs/setup/
-
-    * `minikube` install instruction: https://kubernetes.io/docs/tasks/tools/install-minikube/
 
 * `kubectl` CLI tool
 
@@ -41,11 +41,8 @@ Before starting this guide, make sure you have the following:
 Kubernetes deployment with BentoML
 ----------------------------------
 
-This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
-The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
-service. The predict endpoint expects `pandas.DataFrame` as input.
-
-Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
+Run the example project from the :doc:`quick start guide <../quickstart>` to create the
+BentoML saved bundle for deployment:
 
 .. code-block:: bash
 
@@ -53,7 +50,7 @@ Build the IrisClassifier BentoService from the :doc:`quick start guide <../quick
     python ./bentoml/guides/quick-start/main.py
 
 
-Use BentoML CLI tool to get the information of IrisClassifier created above
+Verify the saved bundle created:
 
 .. code-block:: bash
 
@@ -126,7 +123,7 @@ BentoML provides a convenient way to containerize the model API server with Dock
 
 .. code-block:: bash
 
-    # Download and install jq, the JSON processor: https://stedolan.github.io/jq/download/
+    # Install jq, the command-line JSON processor: https://stedolan.github.io/jq/download/
     saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
 
     # Replace {docker_username} with your Docker Hub username

--- a/docs/source/deployment/kubernetes.rst
+++ b/docs/source/deployment/kubernetes.rst
@@ -57,7 +57,7 @@ Use BentoML CLI tool to get the information of IrisClassifier created above
 
 .. code-block:: bash
 
-    bentoml get IrisClassifier:latest
+    $ bentoml get IrisClassifier:latest
 
     # Sample output
     {

--- a/docs/source/deployment/kubernetes.rst
+++ b/docs/source/deployment/kubernetes.rst
@@ -1,12 +1,14 @@
 Deploying to Kubernetes Cluster
 ===============================
 
-This guide demostrates how to deploy a model server built with BentoML to Kubernetes cluster.
-
 Kubernetes is an open-source system for automating deployment, scaling, and management of
 containerized applications. It is the de-facto solution for deploying applications today.
-Machine larning services also can take advantage of Kubernetes' ability to quickly deploy
+Machine learning services also can take advantage of Kubernetes' ability to quickly deploy
 and scale base on demand.
+
+This guide demonstrates how to serve a scikit-learn based iris classifier model with
+BentoML on a Kubernetes cluster. The same deployment steps are also applicable for models
+trained with other machine learning frameworks, see more BentoML examples :doc:`here <../examples>`.
 
 
 Prerequsities
@@ -39,11 +41,11 @@ Before starting this guide, make sure you have the following:
 Kubernetes deployment with BentoML
 ----------------------------------
 
-This guide builds a BentoService with iris classifier model, and deploys the
-BentoService to Kubernetes as API model server.
+This guide uses the IrisClassifier BentoService from the :doc:`Quick start guide <../quickstart>`.
+The IrisClassifier has an endpoint, `/predict`, as its entry point for accessing the prediction
+service. The predict endpoint expects `pandas.DataFrame` as input.
 
-
-Use the IrisClassifier BentoService from the quick start guide.
+Build the IrisClassifier BentoService from the :doc:`quick start guide <../quickstart>`.
 
 .. code-block:: bash
 
@@ -90,18 +92,37 @@ Use BentoML CLI tool to get the information of IrisClassifier created above
       }
     }
 
+
+The BentoML saved bundle created can now be used to start a REST API Server hosting the
+BentoService and available for sending test request:
+
+.. code-block:: bash
+
+    # Start BentoML API server:
+    bentoml serve IrisClassifier:latest
+
+
+.. code-block:: bash
+
+    # Send test request:
+    curl -i \
+      --header "Content-Type: application/json" \
+      --request POST \
+      --data '[[5.1, 3.5, 1.4, 0.2]]' \
+      http://localhost:5000/predict
+
+
 =================================
 Deploy BentoService to Kubernetes
 =================================
 
-BentoML provides a convenient way of containerizing the model API server with Docker. To
-create a docker container image for the sample model above:
+BentoML provides a convenient way to containerize the model API server with Docker:
 
-1. Find the file directory of the SavedBundle with bentoml get command, which is directory
-structured as a docker build context.
+    1. Find the SavedBundle directory with `bentoml get` command
 
-2. Running docker build with this directory produces a docker image containing the model
-API server
+    2. Run docker build with the SavedBundle directory which contains a generated Dockerfile
+
+    3. Run the generated docker image to start a docker container serving the model
 
 .. code-block:: bash
 


### PR DESCRIPTION
Add install instruction for `jq` and avoid use `we`
