### PR TITLE
[Bug] Fix overwriting pip_dependencies specified through @env

### DIFF
--- a/bentoml/marshal/dispatcher.py
+++ b/bentoml/marshal/dispatcher.py
@@ -35,6 +35,7 @@ class Optimizer:
     '''
     Analyse historical data to optimize CorkDispatcher.
     '''
+
     N_KEPT_SAMPLE = 50  # amount of outbound info kept for inferring params
     N_SKIPPED_SAMPLE = 2  # amount of outbound info skipped after init
     INTERVAL_REFRESH_PARAMS = 5  # seconds between each params refreshing

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -482,10 +482,10 @@ class BentoService(BentoServiceBase):
         self._env = self.__class__._env or BentoServiceEnv(self.name)
 
         for api in self._service_apis:
-            self._env._add_pip_dependencies(api.handler.pip_dependencies)
+            self._env._add_pip_dependencies_if_missing(api.handler.pip_dependencies)
 
         for artifact in self._artifacts:
-            self._env._add_pip_dependencies(artifact.pip_dependencies)
+            self._env._add_pip_dependencies_if_missing(artifact.pip_dependencies)
 
     @property
     def artifacts(self):

--- a/bentoml/service_env.py
+++ b/bentoml/service_env.py
@@ -189,6 +189,14 @@ class BentoServiceEnv(object):
             pip_dependencies = [pip_dependencies]
         self._pip_dependencies += pip_dependencies
 
+    def _add_pip_dependencies_if_missing(self, pip_dependencies):
+        # Insert dependencies to the beginning of self.dependencies, so that user
+        # specified dependency version could overwrite this. This is used by BentoML
+        # to inject ModelArtifact or Handler's optional pip dependencies
+        if not isinstance(pip_dependencies, list):
+            pip_dependencies.insert(0, pip_dependencies)
+        self._pip_dependencies = pip_dependencies + self._pip_dependencies
+
     def _set_setup_sh(self, setup_sh_path_or_content):
         self._setup_sh = None
 

--- a/bentoml/utils/pip_pkg.py
+++ b/bentoml/utils/pip_pkg.py
@@ -137,7 +137,8 @@ class DepSeekWork(object):
         self.seek_in_file(self.target_py_file_path)
 
     def seek_in_file(self, file_path):
-        # ast解析py file，获取其依赖的modules
+        # Extract all dependency modules by searching through the trees of the Python
+        # abstract syntax grammar with Python's built-in ast module
         with open(file_path) as f:
             content = f.read()
             tree = ast.parse(content)
@@ -157,7 +158,7 @@ class DepSeekWork(object):
                 if module_name in self.module_manager.searched_modules:
                     m = self.module_manager.searched_modules[module_name]
                     if m.is_local:
-                        # 递归解析
+                        # Recursively search dependencies in sub-modules
                         if m.is_pkg:
                             self.seek_in_dir(os.path.join(m.path, m.name))
                         else:
@@ -165,7 +166,7 @@ class DepSeekWork(object):
                                 os.path.join(m.path, "{}.py".format(m.name))
                             )
                     else:
-                        # 判断是否在pip安装包中
+                        # check if the package has already been added to the list
                         if (
                             module_name in self.module_manager.pip_module_map
                             and module_name not in self.dependencies
@@ -178,7 +179,8 @@ class DepSeekWork(object):
                 else:
                     if module_name in self.module_manager.pip_module_map:
                         if module_name not in self.dependencies:
-                            # 某些特殊情况下，pip安装的module不存在searched_modules中
+                            # In some special cases, the pip-installed module can not
+                            # be located in the searched_modules
                             self.dependencies[
                                 module_name
                             ] = self.module_manager.pip_module_map[module_name]

--- a/tests/test_service_env.py
+++ b/tests/test_service_env.py
@@ -5,6 +5,7 @@ import bentoml
 from bentoml.handlers import DataframeHandler
 from bentoml.artifact import SklearnModelArtifact
 
+
 def test_pip_dependencies_env():
     @bentoml.env(pip_dependencies=["numpy"])
     class ServiceWithString(bentoml.BentoService):
@@ -62,6 +63,7 @@ def test_artifact_pip_dependencies(tmpdir):
         saved_requirements = f.read()
         module_list = saved_requirements.decode('utf-8').split('\n')
         assert 'scikit-learn==0.23.0' in module_list
+
 
 def test_can_instantiate_setup_sh_from_file(tmpdir):
     script_path = os.path.join(tmpdir, 'script.sh')

--- a/tests/test_service_env.py
+++ b/tests/test_service_env.py
@@ -3,7 +3,7 @@ import stat
 
 import bentoml
 from bentoml.handlers import DataframeHandler
-
+from bentoml.artifact import SklearnModelArtifact
 
 def test_pip_dependencies_env():
     @bentoml.env(pip_dependencies=["numpy"])
@@ -45,6 +45,23 @@ def test_service_env_pip_dependencies(tmpdir):
         assert 'pandas' in module_list
         assert 'torch' in module_list
 
+
+def test_artifact_pip_dependencies(tmpdir):
+    @bentoml.artifacts([SklearnModelArtifact('model')])
+    @bentoml.env(pip_dependencies=['scikit-learn==0.23.0'])
+    class ServiceWithList(bentoml.BentoService):
+        @bentoml.api(DataframeHandler)
+        def predict(self, df):
+            return df
+
+    service_with_list = ServiceWithList()
+    service_with_list.save_to_dir(str(tmpdir))
+
+    requirements_txt_path = os.path.join(str(tmpdir), 'requirements.txt')
+    with open(requirements_txt_path, 'rb') as f:
+        saved_requirements = f.read()
+        module_list = saved_requirements.decode('utf-8').split('\n')
+        assert 'scikit-learn==0.23.0' in module_list
 
 def test_can_instantiate_setup_sh_from_file(tmpdir):
     script_path = os.path.join(tmpdir, 'script.sh')


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
* fix an issue where handler or artifact optional dependencies are overwriting the dependency version that user has specified through `@env`

Does this close any currently open issues?
------------------------------------------
https://github.com/bentoml/BentoML/issues/642

How was this patch tested?
--------------------------
* Manual test on my local machine
* Unit Test