### PR TITLE
[Bug] use default deployment namespace config on server side

### DIFF
--- a/bentoml/cli/aws_lambda.py
+++ b/bentoml/cli/aws_lambda.py
@@ -67,7 +67,7 @@ def get_aws_lambda_sub_command():
         '--namespace',
         type=click.STRING,
         help='Deployment namespace managed by BentoML, default value is "dev" which'
-        'can be changed in BentoML configuration file',
+        'can be changed in BentoML configuration yatai_service/default_namespace',
     )
     @click.option(
         '-l',
@@ -177,7 +177,7 @@ def get_aws_lambda_sub_command():
         '--namespace',
         type=click.STRING,
         help='Deployment namespace managed by BentoML, default value is "dev" which'
-        'can be changed in BentoML configuration file',
+        'can be changed in BentoML configuration yatai_service/default_namespace',
     )
     @click.option(
         '--memory-size',
@@ -249,10 +249,11 @@ def get_aws_lambda_sub_command():
     @aws_lambda.command(help='Delete AWS Lambda deployment')
     @click.argument('name', type=click.STRING)
     @click.option(
+        '-n',
         '--namespace',
         type=click.STRING,
         help='Deployment namespace managed by BentoML, default value is "dev" which'
-        'can be changed in BentoML configuration file',
+        'can be changed in BentoML configuration yatai_service/default_namespace',
     )
     @click.option(
         '--force',
@@ -319,10 +320,11 @@ def get_aws_lambda_sub_command():
     @aws_lambda.command(help='Get AWS Lambda deployment information')
     @click.argument('name', type=click.STRING)
     @click.option(
+        '-n',
         '--namespace',
         type=click.STRING,
         help='Deployment namespace managed by BentoML, default value is "dev" which'
-        'can be changed in BentoML configuration file',
+        'can be changed in BentoML configuration yatai_service/default_namespace',
     )
     @click.option(
         '-o', '--output', type=click.Choice(['json', 'yaml', 'table']), default='json'
@@ -361,7 +363,7 @@ def get_aws_lambda_sub_command():
         '--namespace',
         type=click.STRING,
         help='Deployment namespace managed by BentoML, default value is "dev" which'
-        'can be changed in BentoML configuration file',
+        'can be changed in BentoML configuration yatai_service/default_namespace',
         default=ALL_NAMESPACE_TAG,
     )
     @click.option(

--- a/bentoml/cli/aws_sagemaker.py
+++ b/bentoml/cli/aws_sagemaker.py
@@ -66,10 +66,11 @@ def get_aws_sagemaker_sub_command():
         'in format of name:version. For example: "iris_classifier:v1.2.0"',
     )
     @click.option(
+        '-n',
         '--namespace',
         type=click.STRING,
         help='Deployment namespace managed by BentoML, default value is "dev" which'
-        'can be changed in BentoML configuration file',
+        'can be changed in BentoML configuration yatai_service/default_namespace',
     )
     @click.option(
         '-l',
@@ -188,6 +189,7 @@ def get_aws_sagemaker_sub_command():
         'in format of name:version. For example: "iris_classifier:v1.2.0"',
     )
     @click.option(
+        '-n',
         '--namespace',
         type=click.STRING,
         help='Deployment namespace managed by BentoML, default value is "dev" which'
@@ -282,10 +284,10 @@ def get_aws_sagemaker_sub_command():
     @aws_sagemaker.command(help='Delete AWS Sagemaker deployment')
     @click.argument('name', type=click.STRING)
     @click.option(
-        '--namespace',
+        '-n' '--namespace',
         type=click.STRING,
         help='Deployment namespace managed by BentoML, default value is "dev" which'
-        'can be changed in BentoML configuration file',
+        'can be changed in BentoML configuration yatai_service/default_namespace',
     )
     @click.option(
         '--force',
@@ -342,10 +344,11 @@ def get_aws_sagemaker_sub_command():
     @aws_sagemaker.command(help='Get AWS Sagemaker deployment information')
     @click.argument('name', type=click.STRING)
     @click.option(
+        '-n',
         '--namespace',
         type=click.STRING,
         help='Deployment namespace managed by BentoML, default value is "dev" which'
-        'can be changed in BentoML configuration file',
+        'can be changed in BentoML configuration yatai_service/default_namespace',
     )
     @click.option(
         '-o', '--output', type=click.Choice(['json', 'yaml', 'table']), default='json'
@@ -392,7 +395,7 @@ def get_aws_sagemaker_sub_command():
         '--namespace',
         type=click.STRING,
         help='Deployment namespace managed by BentoML, default value is "dev" which'
-        'can be changed in BentoML configuration file',
+        'can be changed in BentoML configuration yatai_service/default_namespace',
         default=ALL_NAMESPACE_TAG,
     )
     @click.option(

--- a/bentoml/utils/validator/__init__.py
+++ b/bentoml/utils/validator/__init__.py
@@ -23,7 +23,9 @@ from bentoml.proto.deployment_pb2 import DeploymentSpec, DeploymentState
 
 deployment_schema = {
     'name': {'type': 'string', 'required': True, 'minlength': 4},
-    'namespace': {'type': 'string', 'required': True, 'minlength': 3},
+    # namespace is optional - YataiService will fill-in the default namespace configured
+    # when it is missing in the apply deployment request
+    'namespace': {'type': 'string', 'required': False, 'minlength': 3},
     'labels': {'type': 'dict', 'allow_unknown': True},
     'annotations': {'type': 'dict', 'allow_unknown': True},
     'created_at': {'type': 'string'},

--- a/bentoml/yatai/client/deployment_api.py
+++ b/bentoml/yatai/client/deployment_api.py
@@ -88,17 +88,11 @@ class DeploymentAPIClient:
         )
 
     def get(self, namespace, name):
-        namespace = (
-            namespace if namespace else config().get('deployment', 'default_namespace')
-        )
         return self.yatai_service.GetDeployment(
             GetDeploymentRequest(deployment_name=name, namespace=namespace)
         )
 
     def describe(self, namespace, name):
-        namespace = (
-            namespace if namespace else config().get('deployment', 'default_namespace')
-        )
         return self.yatai_service.DescribeDeployment(
             DescribeDeploymentRequest(deployment_name=name, namespace=namespace)
         )
@@ -249,10 +243,6 @@ class DeploymentAPIClient:
         Raises:
             BentoMLException
         """
-        namespace = (
-            namespace if namespace else config().get('deployment', 'default_namespace')
-        )
-
         deployment_pb = Deployment(
             name=name, namespace=namespace, labels=labels, annotations=annotations
         )
@@ -408,9 +398,6 @@ class DeploymentAPIClient:
             BentoMLException
 
         """
-        namespace = (
-            namespace if namespace else config().get('deployment', 'default_namespace')
-        )
         deployment_pb = Deployment(
             name=name, namespace=namespace, labels=labels, annotations=annotations
         )


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
Currently, deployment namespace configured on the client-side will be used for creating deployments. This PR fixes this issue.

Does this close any currently open issues?
------------------------------------------
No, reported via community slack

How was this patch tested?
--------------------------
e2e test covered