### PR TITLE
Generate a presigned-url instead of presigned-post for S3

### DIFF
--- a/bentoml/configuration/default_bentoml.cfg
+++ b/bentoml/configuration/default_bentoml.cfg
@@ -51,6 +51,7 @@ zipkin_api_url =
 [yatai_service]
 # URL of remote YataiService gRPC server endpoint to use
 url =
+s3_signature_version = s3v4
 
 # YataiService server configs
 repository_base_url = {BENTOML_HOME}/repository/

--- a/bentoml/repository/__init__.py
+++ b/bentoml/repository/__init__.py
@@ -137,7 +137,7 @@ class _S3BentoRepository(BentoRepositoryBase):
         self.base_path = parse_result.path.lstrip('/')
 
         s3_client_args = {}
-        signature_version = os.environ.get('BENTOML_S3_SIGNATURE_VERSION', 's3v4')
+        signature_version = config('yatai_service').get('S3_SIGNATURE_VERSION')
         s3_client_args['config'] = boto3.session.Config(
             signature_version=signature_version
         )

--- a/bentoml/yatai/client/bento_repository_api.py
+++ b/bentoml/yatai/client/bento_repository_api.py
@@ -127,11 +127,9 @@ class BentoRepositoryAPIClient:
 
             files = {'file': ('dummy', fileobj)}  # dummy file name because file name
             # has been generated when getting the pre-signed signature.
-            data = json.loads(response.uri.additional_fields)
-            uri = data.pop('url')
-            http_response = requests.post(uri, data=data, files=files)
+            http_response = requests.put(response.uri.uri, files=files)
 
-            if http_response.status_code != 204:
+            if http_response.status_code != 200:
                 self._update_bento_upload_progress(
                     bento_service_metadata, UploadStatus.ERROR
                 )


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below.)

What changes were proposed in this pull request?
------------------------------------------------
1. I set the signature version of the S3 client `s3v4` as default. If user needs to change it, the user can change it via a new environment variable named `BENTOML_S3_SIGNATURE_VERSION`.
2. I changed from `generate_presigned_post` to `generate_presigned_url` because the former might have a bug for MinIO or other S3-compatible services.

Does this close any currently open issues?
------------------------------------------
maybe #676 

How was this patch tested?
--------------------------
Our company has an internal S3-compatible service. I succeeded in testing there.