### PR TITLE
Use pre-signed S3 url for downloading saved bundle from s3 service

### DIFF
--- a/bentoml/bundler/loader.py
+++ b/bentoml/bundler/loader.py
@@ -25,7 +25,6 @@ import tempfile
 from contextlib import contextmanager
 from urllib.parse import urlparse
 
-import boto3
 from bentoml.utils.s3 import is_s3_url
 from bentoml.utils.usage_stats import track_load_finish, track_load_start
 from bentoml.exceptions import BentoMLException
@@ -35,20 +34,37 @@ from bentoml.bundler.config import SavedBundleConfig
 logger = logging.getLogger(__name__)
 
 
+def _is_http_url(bundle_path):
+    try:
+        return urlparse(bundle_path).scheme in ["http", "https"]
+    except ValueError:
+        return False
+
+
 def _is_remote_path(bundle_path):
-    return is_s3_url(bundle_path)
+    return is_s3_url(bundle_path) or _is_http_url(bundle_path)
 
 
 @contextmanager
 def _resolve_remote_bundle_path(bundle_path):
-    parsed_url = urlparse(bundle_path)
-    bucket_name = parsed_url.netloc
-    object_name = parsed_url.path.lstrip('/')
+    if is_s3_url(bundle_path):
+        import boto3
+        parsed_url = urlparse(bundle_path)
+        bucket_name = parsed_url.netloc
+        object_name = parsed_url.path.lstrip('/')
 
-    s3 = boto3.client('s3')
-    fileobj = io.BytesIO()
-    s3.download_fileobj(bucket_name, object_name, fileobj)
-    fileobj.seek(0, 0)
+        s3 = boto3.client('s3')
+        fileobj = io.BytesIO()
+        s3.download_fileobj(bucket_name, object_name, fileobj)
+        fileobj.seek(0, 0)
+    elif _is_http_url(bundle_path):
+        import requests
+        response = requests.get(bundle_path)
+        fileobj = io.BytesIO()
+        fileobj.write(response.content)
+        fileobj.seek(0, 0)
+    else:
+        raise BentoMLException(f"Saved bundle path: '{bundle_path}' is not supported")
 
     with tarfile.open(mode="r:gz", fileobj=fileobj) as tar:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/bentoml/bundler/loader.py
+++ b/bentoml/bundler/loader.py
@@ -49,6 +49,7 @@ def _is_remote_path(bundle_path):
 def _resolve_remote_bundle_path(bundle_path):
     if is_s3_url(bundle_path):
         import boto3
+
         parsed_url = urlparse(bundle_path)
         bucket_name = parsed_url.netloc
         object_name = parsed_url.path.lstrip('/')
@@ -59,6 +60,7 @@ def _resolve_remote_bundle_path(bundle_path):
         fileobj.seek(0, 0)
     elif _is_http_url(bundle_path):
         import requests
+
         response = requests.get(bundle_path)
         fileobj = io.BytesIO()
         fileobj.write(response.content)

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -338,10 +338,12 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
     ):
         track_cli('serve_gunicorn')
         if not psutil.POSIX:
-            _echo("The `bentoml server-gunicon` command is only supported on POSIX. "
-                  "On windows platform, use `bentoml serve` for local API testing and "
-                  "docker for running production API endpoint: "
-                  "https://docs.docker.com/docker-for-windows/ ")
+            _echo(
+                "The `bentoml server-gunicon` command is only supported on POSIX. "
+                "On windows platform, use `bentoml serve` for local API testing and "
+                "docker for running production API endpoint: "
+                "https://docs.docker.com/docker-for-windows/ "
+            )
             return
         bento_service_bundle_path = resolve_bundle_path(
             bento, pip_installed_bundle_path

--- a/bentoml/cli/__init__.py
+++ b/bentoml/cli/__init__.py
@@ -133,7 +133,11 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
                     f'BentoService {name}:{version} not found - '
                     f'{error_code}:{error_message}'
                 )
-            return get_bento_result.bento.uri.uri
+            if get_bento_result.bento.uri.s3_presigned_url:
+                # Use s3 presigned URL for downloading the repository if it is presented
+                return get_bento_result.bento.uri.s3_presigned_url
+            else:
+                return get_bento_result.bento.uri.uri
         else:
             raise BentoMLException(
                 f'BentoService "{bento}" not found - either specify the file path of '

--- a/bentoml/proto/repository_pb2.py
+++ b/bentoml/proto/repository_pb2.py
@@ -23,7 +23,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='bentoml',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\x10repository.proto\x12\x07\x62\x65ntoml\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x0cstatus.proto\"\xb7\x01\n\x08\x42\x65ntoUri\x12+\n\x04type\x18\x01 \x01(\x0e\x32\x1d.bentoml.BentoUri.StorageType\x12\x0b\n\x03uri\x18\x02 \x01(\t\x12\x19\n\x11\x61\x64\x64itional_fields\x18\x03 \x01(\t\"V\n\x0bStorageType\x12\t\n\x05UNSET\x10\x00\x12\t\n\x05LOCAL\x10\x01\x12\x06\n\x02S3\x10\x02\x12\x07\n\x03GCS\x10\x03\x12\x16\n\x12\x41ZURE_BLOB_STORAGE\x10\x04\x12\x08\n\x04HDFS\x10\x05\"\xb4\x04\n\x14\x42\x65ntoServiceMetadata\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12.\n\ncreated_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12:\n\x03\x65nv\x18\x04 \x01(\x0b\x32-.bentoml.BentoServiceMetadata.BentoServiceEnv\x12>\n\tartifacts\x18\x05 \x03(\x0b\x32+.bentoml.BentoServiceMetadata.BentoArtifact\x12;\n\x04\x61pis\x18\x06 \x03(\x0b\x32-.bentoml.BentoServiceMetadata.BentoServiceApi\x1ah\n\x0f\x42\x65ntoServiceEnv\x12\x10\n\x08setup_sh\x18\x01 \x01(\t\x12\x11\n\tconda_env\x18\x02 \x01(\t\x12\x18\n\x10pip_dependencies\x18\x03 \x01(\t\x12\x16\n\x0epython_version\x18\x04 \x01(\t\x1a\x34\n\rBentoArtifact\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rartifact_type\x18\x02 \x01(\t\x1at\n\x0f\x42\x65ntoServiceApi\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0chandler_type\x18\x02 \x01(\t\x12\x0c\n\x04\x64ocs\x18\x03 \x01(\t\x12/\n\x0ehandler_config\x18\x04 \x01(\x0b\x32\x17.google.protobuf.Struct\"\xac\x01\n\x05\x42\x65nto\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x1e\n\x03uri\x18\x03 \x01(\x0b\x32\x11.bentoml.BentoUri\x12=\n\x16\x62\x65nto_service_metadata\x18\x04 \x01(\x0b\x32\x1d.bentoml.BentoServiceMetadata\x12%\n\x06status\x18\x05 \x01(\x0b\x32\x15.bentoml.UploadStatus\"<\n\x0f\x41\x64\x64\x42\x65ntoRequest\x12\x12\n\nbento_name\x18\x01 \x01(\t\x12\x15\n\rbento_version\x18\x02 \x01(\t\"S\n\x10\x41\x64\x64\x42\x65ntoResponse\x12\x1f\n\x06status\x18\x01 \x01(\x0b\x32\x0f.bentoml.Status\x12\x1e\n\x03uri\x18\x02 \x01(\x0b\x32\x11.bentoml.BentoUri\"\xe5\x01\n\x0cUploadStatus\x12,\n\x06status\x18\x01 \x01(\x0e\x32\x1c.bentoml.UploadStatus.Status\x12.\n\nupdated_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x12\n\npercentage\x18\x03 \x01(\x05\x12\x15\n\rerror_message\x18\x04 \x01(\t\"L\n\x06Status\x12\x11\n\rUNINITIALIZED\x10\x00\x12\r\n\tUPLOADING\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\x12\t\n\x05\x45RROR\x10\x03\x12\x0b\n\x07TIMEOUT\x10\x04\"\xa6\x01\n\x12UpdateBentoRequest\x12\x12\n\nbento_name\x18\x01 \x01(\t\x12\x15\n\rbento_version\x18\x02 \x01(\t\x12,\n\rupload_status\x18\x03 \x01(\x0b\x32\x15.bentoml.UploadStatus\x12\x37\n\x10service_metadata\x18\x04 \x01(\x0b\x32\x1d.bentoml.BentoServiceMetadata\"6\n\x13UpdateBentoResponse\x12\x1f\n\x06status\x18\x01 \x01(\x0b\x32\x0f.bentoml.Status\"J\n\x1d\x44\x61ngerouslyDeleteBentoRequest\x12\x12\n\nbento_name\x18\x01 \x01(\t\x12\x15\n\rbento_version\x18\x02 \x01(\t\"A\n\x1e\x44\x61ngerouslyDeleteBentoResponse\x12\x1f\n\x06status\x18\x01 \x01(\x0b\x32\x0f.bentoml.Status\"<\n\x0fGetBentoRequest\x12\x12\n\nbento_name\x18\x01 \x01(\t\x12\x15\n\rbento_version\x18\x02 \x01(\t\"R\n\x10GetBentoResponse\x12\x1f\n\x06status\x18\x01 \x01(\x0b\x32\x0f.bentoml.Status\x12\x1d\n\x05\x62\x65nto\x18\x02 \x01(\x0b\x32\x0e.bentoml.Bento\"\xc8\x01\n\x10ListBentoRequest\x12\x12\n\nbento_name\x18\x01 \x01(\t\x12\x0e\n\x06offset\x18\x02 \x01(\x05\x12\r\n\x05limit\x18\x03 \x01(\x05\x12;\n\x08order_by\x18\x04 \x01(\x0e\x32).bentoml.ListBentoRequest.SORTABLE_COLUMN\x12\x17\n\x0f\x61scending_order\x18\x05 \x01(\x08\"+\n\x0fSORTABLE_COLUMN\x12\x0e\n\ncreated_at\x10\x00\x12\x08\n\x04name\x10\x01\"T\n\x11ListBentoResponse\x12\x1f\n\x06status\x18\x01 \x01(\x0b\x32\x0f.bentoml.Status\x12\x1e\n\x06\x62\x65ntos\x18\x02 \x03(\x0b\x32\x0e.bentoml.Bentob\x06proto3')
+  serialized_pb=_b('\n\x10repository.proto\x12\x07\x62\x65ntoml\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x0cstatus.proto\"\xb6\x01\n\x08\x42\x65ntoUri\x12+\n\x04type\x18\x01 \x01(\x0e\x32\x1d.bentoml.BentoUri.StorageType\x12\x0b\n\x03uri\x18\x02 \x01(\t\x12\x18\n\x10s3_presigned_url\x18\x03 \x01(\t\"V\n\x0bStorageType\x12\t\n\x05UNSET\x10\x00\x12\t\n\x05LOCAL\x10\x01\x12\x06\n\x02S3\x10\x02\x12\x07\n\x03GCS\x10\x03\x12\x16\n\x12\x41ZURE_BLOB_STORAGE\x10\x04\x12\x08\n\x04HDFS\x10\x05\"\xb4\x04\n\x14\x42\x65ntoServiceMetadata\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12.\n\ncreated_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12:\n\x03\x65nv\x18\x04 \x01(\x0b\x32-.bentoml.BentoServiceMetadata.BentoServiceEnv\x12>\n\tartifacts\x18\x05 \x03(\x0b\x32+.bentoml.BentoServiceMetadata.BentoArtifact\x12;\n\x04\x61pis\x18\x06 \x03(\x0b\x32-.bentoml.BentoServiceMetadata.BentoServiceApi\x1ah\n\x0f\x42\x65ntoServiceEnv\x12\x10\n\x08setup_sh\x18\x01 \x01(\t\x12\x11\n\tconda_env\x18\x02 \x01(\t\x12\x18\n\x10pip_dependencies\x18\x03 \x01(\t\x12\x16\n\x0epython_version\x18\x04 \x01(\t\x1a\x34\n\rBentoArtifact\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rartifact_type\x18\x02 \x01(\t\x1at\n\x0f\x42\x65ntoServiceApi\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0chandler_type\x18\x02 \x01(\t\x12\x0c\n\x04\x64ocs\x18\x03 \x01(\t\x12/\n\x0ehandler_config\x18\x04 \x01(\x0b\x32\x17.google.protobuf.Struct\"\xac\x01\n\x05\x42\x65nto\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x1e\n\x03uri\x18\x03 \x01(\x0b\x32\x11.bentoml.BentoUri\x12=\n\x16\x62\x65nto_service_metadata\x18\x04 \x01(\x0b\x32\x1d.bentoml.BentoServiceMetadata\x12%\n\x06status\x18\x05 \x01(\x0b\x32\x15.bentoml.UploadStatus\"<\n\x0f\x41\x64\x64\x42\x65ntoRequest\x12\x12\n\nbento_name\x18\x01 \x01(\t\x12\x15\n\rbento_version\x18\x02 \x01(\t\"S\n\x10\x41\x64\x64\x42\x65ntoResponse\x12\x1f\n\x06status\x18\x01 \x01(\x0b\x32\x0f.bentoml.Status\x12\x1e\n\x03uri\x18\x02 \x01(\x0b\x32\x11.bentoml.BentoUri\"\xe5\x01\n\x0cUploadStatus\x12,\n\x06status\x18\x01 \x01(\x0e\x32\x1c.bentoml.UploadStatus.Status\x12.\n\nupdated_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x12\n\npercentage\x18\x03 \x01(\x05\x12\x15\n\rerror_message\x18\x04 \x01(\t\"L\n\x06Status\x12\x11\n\rUNINITIALIZED\x10\x00\x12\r\n\tUPLOADING\x10\x01\x12\x08\n\x04\x44ONE\x10\x02\x12\t\n\x05\x45RROR\x10\x03\x12\x0b\n\x07TIMEOUT\x10\x04\"\xa6\x01\n\x12UpdateBentoRequest\x12\x12\n\nbento_name\x18\x01 \x01(\t\x12\x15\n\rbento_version\x18\x02 \x01(\t\x12,\n\rupload_status\x18\x03 \x01(\x0b\x32\x15.bentoml.UploadStatus\x12\x37\n\x10service_metadata\x18\x04 \x01(\x0b\x32\x1d.bentoml.BentoServiceMetadata\"6\n\x13UpdateBentoResponse\x12\x1f\n\x06status\x18\x01 \x01(\x0b\x32\x0f.bentoml.Status\"J\n\x1d\x44\x61ngerouslyDeleteBentoRequest\x12\x12\n\nbento_name\x18\x01 \x01(\t\x12\x15\n\rbento_version\x18\x02 \x01(\t\"A\n\x1e\x44\x61ngerouslyDeleteBentoResponse\x12\x1f\n\x06status\x18\x01 \x01(\x0b\x32\x0f.bentoml.Status\"<\n\x0fGetBentoRequest\x12\x12\n\nbento_name\x18\x01 \x01(\t\x12\x15\n\rbento_version\x18\x02 \x01(\t\"R\n\x10GetBentoResponse\x12\x1f\n\x06status\x18\x01 \x01(\x0b\x32\x0f.bentoml.Status\x12\x1d\n\x05\x62\x65nto\x18\x02 \x01(\x0b\x32\x0e.bentoml.Bento\"\xc8\x01\n\x10ListBentoRequest\x12\x12\n\nbento_name\x18\x01 \x01(\t\x12\x0e\n\x06offset\x18\x02 \x01(\x05\x12\r\n\x05limit\x18\x03 \x01(\x05\x12;\n\x08order_by\x18\x04 \x01(\x0e\x32).bentoml.ListBentoRequest.SORTABLE_COLUMN\x12\x17\n\x0f\x61scending_order\x18\x05 \x01(\x08\"+\n\x0fSORTABLE_COLUMN\x12\x0e\n\ncreated_at\x10\x00\x12\x08\n\x04name\x10\x01\"T\n\x11ListBentoResponse\x12\x1f\n\x06status\x18\x01 \x01(\x0b\x32\x0f.bentoml.Status\x12\x1e\n\x06\x62\x65ntos\x18\x02 \x03(\x0b\x32\x0e.bentoml.Bentob\x06proto3')
   ,
   dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,status__pb2.DESCRIPTOR,])
 
@@ -62,8 +62,8 @@ _BENTOURI_STORAGETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=204,
-  serialized_end=290,
+  serialized_start=203,
+  serialized_end=289,
 )
 _sym_db.RegisterEnumDescriptor(_BENTOURI_STORAGETYPE)
 
@@ -96,8 +96,8 @@ _UPLOADSTATUS_STATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1335,
-  serialized_end=1411,
+  serialized_start=1334,
+  serialized_end=1410,
 )
 _sym_db.RegisterEnumDescriptor(_UPLOADSTATUS_STATUS)
 
@@ -118,8 +118,8 @@ _LISTBENTOREQUEST_SORTABLE_COLUMN = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2085,
-  serialized_end=2128,
+  serialized_start=2084,
+  serialized_end=2127,
 )
 _sym_db.RegisterEnumDescriptor(_LISTBENTOREQUEST_SORTABLE_COLUMN)
 
@@ -146,7 +146,7 @@ _BENTOURI = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='additional_fields', full_name='bentoml.BentoUri.additional_fields', index=2,
+      name='s3_presigned_url', full_name='bentoml.BentoUri.s3_presigned_url', index=2,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -166,7 +166,7 @@ _BENTOURI = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=107,
-  serialized_end=290,
+  serialized_end=289,
 )
 
 
@@ -217,8 +217,8 @@ _BENTOSERVICEMETADATA_BENTOSERVICEENV = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=581,
-  serialized_end=685,
+  serialized_start=580,
+  serialized_end=684,
 )
 
 _BENTOSERVICEMETADATA_BENTOARTIFACT = _descriptor.Descriptor(
@@ -254,8 +254,8 @@ _BENTOSERVICEMETADATA_BENTOARTIFACT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=687,
-  serialized_end=739,
+  serialized_start=686,
+  serialized_end=738,
 )
 
 _BENTOSERVICEMETADATA_BENTOSERVICEAPI = _descriptor.Descriptor(
@@ -305,8 +305,8 @@ _BENTOSERVICEMETADATA_BENTOSERVICEAPI = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=741,
-  serialized_end=857,
+  serialized_start=740,
+  serialized_end=856,
 )
 
 _BENTOSERVICEMETADATA = _descriptor.Descriptor(
@@ -370,8 +370,8 @@ _BENTOSERVICEMETADATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=293,
-  serialized_end=857,
+  serialized_start=292,
+  serialized_end=856,
 )
 
 
@@ -429,8 +429,8 @@ _BENTO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=860,
-  serialized_end=1032,
+  serialized_start=859,
+  serialized_end=1031,
 )
 
 
@@ -467,8 +467,8 @@ _ADDBENTOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1034,
-  serialized_end=1094,
+  serialized_start=1033,
+  serialized_end=1093,
 )
 
 
@@ -505,8 +505,8 @@ _ADDBENTORESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1096,
-  serialized_end=1179,
+  serialized_start=1095,
+  serialized_end=1178,
 )
 
 
@@ -558,8 +558,8 @@ _UPLOADSTATUS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1182,
-  serialized_end=1411,
+  serialized_start=1181,
+  serialized_end=1410,
 )
 
 
@@ -610,8 +610,8 @@ _UPDATEBENTOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1414,
-  serialized_end=1580,
+  serialized_start=1413,
+  serialized_end=1579,
 )
 
 
@@ -641,8 +641,8 @@ _UPDATEBENTORESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1582,
-  serialized_end=1636,
+  serialized_start=1581,
+  serialized_end=1635,
 )
 
 
@@ -679,8 +679,8 @@ _DANGEROUSLYDELETEBENTOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1638,
-  serialized_end=1712,
+  serialized_start=1637,
+  serialized_end=1711,
 )
 
 
@@ -710,8 +710,8 @@ _DANGEROUSLYDELETEBENTORESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1714,
-  serialized_end=1779,
+  serialized_start=1713,
+  serialized_end=1778,
 )
 
 
@@ -748,8 +748,8 @@ _GETBENTOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1781,
-  serialized_end=1841,
+  serialized_start=1780,
+  serialized_end=1840,
 )
 
 
@@ -786,8 +786,8 @@ _GETBENTORESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1843,
-  serialized_end=1925,
+  serialized_start=1842,
+  serialized_end=1924,
 )
 
 
@@ -846,8 +846,8 @@ _LISTBENTOREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1928,
-  serialized_end=2128,
+  serialized_start=1927,
+  serialized_end=2127,
 )
 
 
@@ -884,8 +884,8 @@ _LISTBENTORESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2130,
-  serialized_end=2214,
+  serialized_start=2129,
+  serialized_end=2213,
 )
 
 _BENTOURI.fields_by_name['type'].enum_type = _BENTOURI_STORAGETYPE

--- a/bentoml/repository/__init__.py
+++ b/bentoml/repository/__init__.py
@@ -17,7 +17,6 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import json
 import shutil
 import boto3
 import logging
@@ -159,7 +158,6 @@ class _S3BentoRepository(BentoRepositoryBase):
         # Generate pre-signed s3 path for upload
 
         object_name = self._get_object_name(bento_name, bento_version)
-
         try:
             response = self.s3_client.generate_presigned_url(
                 'put_object',
@@ -188,11 +186,14 @@ class _S3BentoRepository(BentoRepositoryBase):
                 Params={'Bucket': self.bucket, 'Key': object_name},
                 ExpiresIn=self._expiration,
             )
-        except Exception as e:
-            raise YataiRepositoryException(
-                "Not able to get pre-signed URL on S3. Error: {}".format(e)
+            return response
+        except Exception:
+            logger.error(
+                "Failed generating presigned URL for downloading saved bundle from s3,"
+                f"falling back to using s3 path and client side credential for"
+                "downloading with boto3"
             )
-        return response
+            return 's3://{}/{}'.format(self.bucket, object_name)
 
     def dangerously_delete(self, bento_name, bento_version):
         # Remove s3 path containing related Bento files

--- a/bentoml/repository/__init__.py
+++ b/bentoml/repository/__init__.py
@@ -174,7 +174,7 @@ class _S3BentoRepository(BentoRepositoryBase):
         return BentoUri(
             type=self.uri_type,
             uri='s3://{}/{}'.format(self.bucket, object_name),
-            additional_fields=response,
+            s3_presigned_url=response,
         )
 
     def get(self, bento_name, bento_version):

--- a/bentoml/utils/pip_pkg.py
+++ b/bentoml/utils/pip_pkg.py
@@ -176,16 +176,13 @@ class DepSeekWork(object):
                     if m.is_pkg:
                         self.seek_in_dir(os.path.join(m.path, m.name))
                     else:
-                        self.seek_in_file(
-                            os.path.join(m.path, "{}.py".format(m.name))
-                        )
+                        self.seek_in_file(os.path.join(m.path, "{}.py".format(m.name)))
                 else:
                     # check if the package has already been added to the list
                     if (
                         module_name in self.module_manager.pip_module_map
                         and module_name not in self.dependencies
-                        and module_name
-                        not in self.module_manager.setuptools_module_set
+                        and module_name not in self.module_manager.setuptools_module_set
                     ):
                         self.dependencies[
                             module_name

--- a/bentoml/yatai/client/bento_repository_api.py
+++ b/bentoml/yatai/client/bento_repository_api.py
@@ -16,7 +16,6 @@
 
 import io
 import os
-import json
 import logging
 import tarfile
 import requests
@@ -125,13 +124,12 @@ class BentoRepositoryAPIClient:
                 tar.add(saved_bento_path, arcname=bento_service_metadata.name)
             fileobj.seek(0, 0)
 
-            http_response = requests.put(response.uri.additional_fields, data=fileobj)
+            http_response = requests.put(response.uri.s3_presigned_url, data=fileobj)
 
             if http_response.status_code != 200:
                 self._update_bento_upload_progress(
                     bento_service_metadata, UploadStatus.ERROR
                 )
-
                 raise BentoMLException(
                     f"Error saving BentoService bundle to S3. "
                     f"{http_response.status_code}: {http_response.text}"

--- a/bentoml/yatai/web/src/generated/bentoml_grpc.d.ts
+++ b/bentoml/yatai/web/src/generated/bentoml_grpc.d.ts
@@ -2147,8 +2147,8 @@ export namespace bentoml {
         /** BentoUri uri */
         uri?: (string|null);
 
-        /** BentoUri additional_fields */
-        additional_fields?: (string|null);
+        /** BentoUri s3_presigned_url */
+        s3_presigned_url?: (string|null);
     }
 
     /** Represents a BentoUri. */
@@ -2166,8 +2166,8 @@ export namespace bentoml {
         /** BentoUri uri. */
         public uri: string;
 
-        /** BentoUri additional_fields. */
-        public additional_fields: string;
+        /** BentoUri s3_presigned_url. */
+        public s3_presigned_url: string;
 
         /**
          * Creates a new BentoUri instance using the specified properties.

--- a/bentoml/yatai/web/src/generated/bentoml_grpc.js
+++ b/bentoml/yatai/web/src/generated/bentoml_grpc.js
@@ -5318,7 +5318,7 @@ export const bentoml = $root.bentoml = (() => {
          * @interface IBentoUri
          * @property {bentoml.BentoUri.StorageType|null} [type] BentoUri type
          * @property {string|null} [uri] BentoUri uri
-         * @property {string|null} [additional_fields] BentoUri additional_fields
+         * @property {string|null} [s3_presigned_url] BentoUri s3_presigned_url
          */
 
         /**
@@ -5353,12 +5353,12 @@ export const bentoml = $root.bentoml = (() => {
         BentoUri.prototype.uri = "";
 
         /**
-         * BentoUri additional_fields.
-         * @member {string} additional_fields
+         * BentoUri s3_presigned_url.
+         * @member {string} s3_presigned_url
          * @memberof bentoml.BentoUri
          * @instance
          */
-        BentoUri.prototype.additional_fields = "";
+        BentoUri.prototype.s3_presigned_url = "";
 
         /**
          * Creates a new BentoUri instance using the specified properties.
@@ -5388,8 +5388,8 @@ export const bentoml = $root.bentoml = (() => {
                 writer.uint32(/* id 1, wireType 0 =*/8).int32(message.type);
             if (message.uri != null && message.hasOwnProperty("uri"))
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.uri);
-            if (message.additional_fields != null && message.hasOwnProperty("additional_fields"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.additional_fields);
+            if (message.s3_presigned_url != null && message.hasOwnProperty("s3_presigned_url"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.s3_presigned_url);
             return writer;
         };
 
@@ -5431,7 +5431,7 @@ export const bentoml = $root.bentoml = (() => {
                     message.uri = reader.string();
                     break;
                 case 3:
-                    message.additional_fields = reader.string();
+                    message.s3_presigned_url = reader.string();
                     break;
                 default:
                     reader.skipType(tag & 7);
@@ -5483,9 +5483,9 @@ export const bentoml = $root.bentoml = (() => {
             if (message.uri != null && message.hasOwnProperty("uri"))
                 if (!$util.isString(message.uri))
                     return "uri: string expected";
-            if (message.additional_fields != null && message.hasOwnProperty("additional_fields"))
-                if (!$util.isString(message.additional_fields))
-                    return "additional_fields: string expected";
+            if (message.s3_presigned_url != null && message.hasOwnProperty("s3_presigned_url"))
+                if (!$util.isString(message.s3_presigned_url))
+                    return "s3_presigned_url: string expected";
             return null;
         };
 
@@ -5529,8 +5529,8 @@ export const bentoml = $root.bentoml = (() => {
             }
             if (object.uri != null)
                 message.uri = String(object.uri);
-            if (object.additional_fields != null)
-                message.additional_fields = String(object.additional_fields);
+            if (object.s3_presigned_url != null)
+                message.s3_presigned_url = String(object.s3_presigned_url);
             return message;
         };
 
@@ -5550,14 +5550,14 @@ export const bentoml = $root.bentoml = (() => {
             if (options.defaults) {
                 object.type = options.enums === String ? "UNSET" : 0;
                 object.uri = "";
-                object.additional_fields = "";
+                object.s3_presigned_url = "";
             }
             if (message.type != null && message.hasOwnProperty("type"))
                 object.type = options.enums === String ? $root.bentoml.BentoUri.StorageType[message.type] : message.type;
             if (message.uri != null && message.hasOwnProperty("uri"))
                 object.uri = message.uri;
-            if (message.additional_fields != null && message.hasOwnProperty("additional_fields"))
-                object.additional_fields = message.additional_fields;
+            if (message.s3_presigned_url != null && message.hasOwnProperty("s3_presigned_url"))
+                object.s3_presigned_url = message.s3_presigned_url;
             return object;
         };
 

--- a/bentoml/yatai/yatai_service_impl.py
+++ b/bentoml/yatai/yatai_service_impl.py
@@ -148,6 +148,9 @@ class YataiService(YataiServicer):
         except BentoMLException as e:
             logger.error("RPC ERROR ApplyDeployment: %s", e)
             return ApplyDeploymentResponse(status=e.status_proto)
+        except Exception as e:
+            logger.error("URPC ERROR ApplyDeployment: %s", e)
+            return ApplyDeploymentResponse(status=status_pb2.Status.INTERNAL)
 
     def DeleteDeployment(self, request, context=None):
         try:
@@ -202,6 +205,9 @@ class YataiService(YataiServicer):
         except BentoMLException as e:
             logger.error("RPC ERROR DeleteDeployment: %s", e)
             return DeleteDeploymentResponse(status=e.status_proto)
+        except Exception as e:
+            logger.error("RPC ERROR DeleteDeployment: %s", e)
+            return DeleteDeploymentResponse(status=status_pb2.Status.INTERNAL)
 
     def GetDeployment(self, request, context=None):
         try:
@@ -224,6 +230,9 @@ class YataiService(YataiServicer):
         except BentoMLException as e:
             logger.error("RPC ERROR GetDeployment: %s", e)
             return GetDeploymentResponse(status=e.status_proto)
+        except Exception as e:
+            logger.error("RPC ERROR GetDeployment: %s", e)
+            return GetDeploymentResponse(status=status_pb2.Status.INTERNAL)
 
     def DescribeDeployment(self, request, context=None):
         try:
@@ -255,6 +264,9 @@ class YataiService(YataiServicer):
         except BentoMLException as e:
             logger.error("RPC ERROR DescribeDeployment: %s", e)
             return DeleteDeploymentResponse(status=e.status_proto)
+        except Exception as e:
+            logger.error("RPC ERROR DescribeDeployment: %s", e)
+            return DeleteDeploymentResponse(status=status_pb2.Status.INTERNAL)
 
     def ListDeployments(self, request, context=None):
         try:
@@ -275,6 +287,9 @@ class YataiService(YataiServicer):
         except BentoMLException as e:
             logger.error("RPC ERROR ListDeployments: %s", e)
             return DeleteDeploymentResponse(status=e.status_proto)
+        except Exception as e:
+            logger.error("RPC ERROR ListDeployments: %s", e)
+            return DeleteDeploymentResponse(status=status_pb2.Status.INTERNAL)
 
     def AddBento(self, request, context=None):
         try:
@@ -302,6 +317,9 @@ class YataiService(YataiServicer):
         except BentoMLException as e:
             logger.error("RPC ERROR AddBento: %s", e)
             return DeleteDeploymentResponse(status=e.status_proto)
+        except Exception as e:
+            logger.error("URPC ERROR AddBento: %s", e)
+            return DeleteDeploymentResponse(status=status_pb2.Status.INTERNAL)
 
     def UpdateBento(self, request, context=None):
         try:
@@ -318,6 +336,9 @@ class YataiService(YataiServicer):
         except BentoMLException as e:
             logger.error("RPC ERROR UpdateBento: %s", e)
             return UpdateBentoResponse(status=e.status_proto)
+        except Exception as e:
+            logger.error("RPC ERROR UpdateBento: %s", e)
+            return UpdateBentoResponse(status=status_pb2.Status.INTERNAL)
 
     def DangerouslyDeleteBento(self, request, context=None):
         try:
@@ -343,6 +364,9 @@ class YataiService(YataiServicer):
         except BentoMLException as e:
             logger.error("RPC ERROR DangerouslyDeleteBento: %s", e)
             return DangerouslyDeleteBentoResponse(status=e.status_proto)
+        except Exception as e:
+            logger.error("RPC ERROR DangerouslyDeleteBento: %s", e)
+            return DangerouslyDeleteBentoResponse(status=status_pb2.Status.INTERNAL)
 
     def GetBento(self, request, context=None):
         try:
@@ -370,6 +394,9 @@ class YataiService(YataiServicer):
         except BentoMLException as e:
             logger.error("RPC ERROR GetBento: %s", e)
             return GetBentoResponse(status=e.status_proto)
+        except Exception as e:
+            logger.error("RPC ERROR GetBento: %s", e)
+            return GetBentoResponse(status=status_pb2.Status.INTERNAL)
 
     def ListBento(self, request, context=None):
         try:
@@ -386,5 +413,8 @@ class YataiService(YataiServicer):
         except BentoMLException as e:
             logger.error("RPC ERROR ListBento: %s", e)
             return ListBentoResponse(status=e.status_proto)
+        except Exception as e:
+            logger.error("RPC ERROR ListBento: %s", e)
+            return ListBentoResponse(status=status_pb2.Status.INTERNAL)
 
     # pylint: enable=unused-argument

--- a/bentoml/yatai/yatai_service_impl.py
+++ b/bentoml/yatai/yatai_service_impl.py
@@ -32,6 +32,7 @@ from bentoml.proto.repository_pb2 import (
     GetBentoResponse,
     UpdateBentoResponse,
     ListBentoResponse,
+    BentoUri,
 )
 from bentoml.proto.yatai_service_pb2_grpc import YataiServicer
 from bentoml.proto.yatai_service_pb2 import (
@@ -381,9 +382,10 @@ class YataiService(YataiServicer):
                 )
 
             if bento_pb:
-                bento_pb.uri.s3_presigned_url = self.repo.get(
-                    bento_pb.name, bento_pb.version
-                )
+                if bento_pb.uri.type == BentoUri.S3:
+                    bento_pb.uri.s3_presigned_url = self.repo.get(
+                        bento_pb.name, bento_pb.version
+                    )
                 return GetBentoResponse(status=Status.OK(), bento=bento_pb)
             else:
                 return GetBentoResponse(

--- a/protos/repository.proto
+++ b/protos/repository.proto
@@ -19,7 +19,7 @@ message BentoUri {
 
   StorageType type = 1;
   string uri = 2;
-  string additional_fields = 3;
+  string s3_presigned_url = 3;
 }
 
 message BentoServiceMetadata {


### PR DESCRIPTION
What changes were proposed in this pull request?
------------------------------------------------
* BentoML's model registry is designed to support s3, and only the server-side need to be configured with s3 credentials
* Currently the client-side use boto3 for s3 file download, which requires the client to also have the s3 credentials in order to load or run a BentoML bundle saved in s3
* This PR fixes this issue by using a pre-signed s3 URL to download 
* Updated BentoUri Protobuf definition. Replaced `additional_fields` with just `presigned_url`


How was this patch tested?
--------------------------
* All e2e tests are passing on my local machine now
* Manually tested with AWS s3 and MinIO deployment,  both`save` and `load` works as expected

cc @withsmilo @yubozhao 