### PR TITLE
[FIX] properly handle s3 delete_object response

### DIFF
--- a/bentoml/repository/__init__.py
+++ b/bentoml/repository/__init__.py
@@ -231,21 +231,39 @@ class _S3BentoRepository(BentoRepositoryBase):
             # }
             # An open issue on github: https://github.com/boto/boto3/issues/759
             if DELETE_MARKER in response:
-                return response[DELETE_MARKER]
+                if response[DELETE_MARKER]:
+                    return
+                else:
+                    logger.warning(
+                        f"BentoML has deleted service '{bento_name}:{bento_version}' "
+                        f"from YataiService records, but it failed to delete the saved "
+                        f"bundle files stored in s3: // {self.bucket} / {object_name}, "
+                        f"the files may have already been deleted by the user."
+                    )
+                    return
             elif 'ResponseMetadata' in response:
                 # Note: Use head_object to 'check' is the object deleted or not.
                 # head_object only try to retrieve the metadata without returning
                 # the object itself.
                 try:
                     self.s3_client.head_object(Bucket=self.bucket, Key=object_name)
-                    raise YataiRepositoryException(
-                        f'Fail to delete {bento_name}:{bento_version} in bucket: '
-                        f'{self.bucket}'
+                    logger.warning(
+                        f"BentoML has deleted service '{bento_name}:{bento_version}' "
+                        f"from YataiService records, but it failed to delete the saved "
+                        f"bundle files stored in s3://{self.bucket}/{object_name}, "
+                        f"the files may have already been deleted by the user."
                     )
                 except ClientError as e:
+                    # expected ClientError with Code 404, as target object should be
+                    # deleted and 'head_object' should raise
                     error_response = e.response.get('Error', {})
-                    error_code = error_response.get('Code', 'Unknown')
-                    if error_code != '404':
+                    error_code = error_response.get('Code', None)
+                    if error_code == '404':
+                        # Error code 404 means target file object does not exist, as
+                        # expected after delete_object call
+                        return
+                    else:
+                        # unexpected boto3 ClientError
                         raise e
             else:
                 raise YataiRepositoryException(

--- a/bentoml/repository/__init__.py
+++ b/bentoml/repository/__init__.py
@@ -237,7 +237,7 @@ class _S3BentoRepository(BentoRepositoryBase):
                     logger.warning(
                         f"BentoML has deleted service '{bento_name}:{bento_version}' "
                         f"from YataiService records, but it failed to delete the saved "
-                        f"bundle files stored in s3: // {self.bucket} / {object_name}, "
+                        f"bundle files stored in s3://{self.bucket}/{object_name}, "
                         f"the files may have already been deleted by the user."
                     )
                     return


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below.)

What changes were proposed in this pull request?
------------------------------------------------
Fix https://github.com/bentoml/BentoML/issues/697

This PR adds additional handles to the s3 delete object response that is not documented.  The undocumented response was causing `bentoml delete` display internal error, even when the metadata and file obj are deleted.

Does this close any currently open issues?
------------------------------------------
https://github.com/bentoml/BentoML/issues/697

How was this patch tested?
--------------------------
