### PR TITLE
[Test] Fix assert result in sagemaker e2e test

### DIFF
--- a/e2e_tests/aws_sagemaker/test_sagemaker_update_deployment.py
+++ b/e2e_tests/aws_sagemaker/test_sagemaker_update_deployment.py
@@ -38,7 +38,7 @@ def test_sagemaker_update_deployment(basic_bentoservice_v1, basic_bentoservice_v
 
         request_success, prediction_result = send_test_data_to_endpoint(endpoint_name)
         assert request_success, 'Failed to make successful Sagemaker request'
-        assert prediction_result == "cat", 'Sagemaker prediction result mismatch'
+        assert prediction_result == '"cat"\n', 'Sagemaker prediction result mismatch'
 
         update_bento_version_deployment_command = [
             'bentoml',
@@ -63,6 +63,6 @@ def test_sagemaker_update_deployment(basic_bentoservice_v1, basic_bentoservice_v
 
         request_success, prediction_result = send_test_data_to_endpoint(endpoint_name)
         assert request_success, 'Failed to make successful Sagemaker request'
-        assert prediction_result == "dog", 'Sagemaker prediction result mismatch'
+        assert prediction_result == '"dog"\n', 'Sagemaker prediction result mismatch'
     finally:
         delete_deployment('sagemaker', deployment_name)

--- a/e2e_tests/aws_sagemaker/test_sagemaker_update_deployment.py
+++ b/e2e_tests/aws_sagemaker/test_sagemaker_update_deployment.py
@@ -38,7 +38,9 @@ def test_sagemaker_update_deployment(basic_bentoservice_v1, basic_bentoservice_v
 
         request_success, prediction_result = send_test_data_to_endpoint(endpoint_name)
         assert request_success, 'Failed to make successful Sagemaker request'
-        assert prediction_result == '"cat"\n', 'Sagemaker prediction result mismatch'
+        assert (
+            prediction_result.strip() == '"cat"'
+        ), 'Sagemaker prediction result mismatch'
 
         update_bento_version_deployment_command = [
             'bentoml',
@@ -63,6 +65,8 @@ def test_sagemaker_update_deployment(basic_bentoservice_v1, basic_bentoservice_v
 
         request_success, prediction_result = send_test_data_to_endpoint(endpoint_name)
         assert request_success, 'Failed to make successful Sagemaker request'
-        assert prediction_result == '"dog"\n', 'Sagemaker prediction result mismatch'
+        assert (
+            prediction_result.strip() == '"dog"'
+        ), 'Sagemaker prediction result mismatch'
     finally:
         delete_deployment('sagemaker', deployment_name)


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation
- [x] Test, CI, or build
- [ ] None

## Components (if applicable)
- [ ] BentoService (model packaging, dependency management, handler definition)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, logging, metrics, tracing, benchmark, OpenAPI)
- [ ] YataiService (model management, deployment automation)
- [ ] Documentation


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change in [bentoml/gallery](https://github.com/bentoml/gallery) example notebooks
- [ ] I have sent a pull request to [bentoml/gallery](https://github.com/bentoml/gallery) to make that change
