### PR TITLE
Remove pandas from BentoML install requires

### DIFF
--- a/bentoml/handlers/base_handlers.py
+++ b/bentoml/handlers/base_handlers.py
@@ -19,7 +19,10 @@ from __future__ import print_function
 import json
 from typing import Iterable
 
-import pandas as pd
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
 import numpy as np
 
 from bentoml import config as bentoml_config
@@ -136,10 +139,10 @@ def api_func_result_to_json(result, pandas_dataframe_orient="records"):
         pandas_dataframe_orient in PANDAS_DATAFRAME_TO_DICT_ORIENT_OPTIONS
     ), f"unkown pandas dataframe orient '{pandas_dataframe_orient}'"
 
-    if isinstance(result, pd.DataFrame):
+    if pd and isinstance(result, pd.DataFrame):
         return result.to_json(orient=pandas_dataframe_orient)
 
-    if isinstance(result, pd.Series):
+    if pd and isinstance(result, pd.Series):
         return pd.DataFrame(result).to_dict(orient=pandas_dataframe_orient)
 
     try:

--- a/bentoml/handlers/dataframe_handler.py
+++ b/bentoml/handlers/dataframe_handler.py
@@ -219,6 +219,10 @@ class DataframeHandler(BentoHandler):
             )
 
     @property
+    def pip_dependencies(self):
+        return ['pandas']
+
+    @property
     def config(self):
         base_config = super(self.__class__, self).config
         return dict(

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ install_requires = [
     "flask",
     "gunicorn",
     "click>=7.0",
-    "pandas",
     "prometheus_client",
     "python-json-logger",
     "boto3",


### PR DESCRIPTION
`pandas` should not be a required dependency for BentoML, it should be required only when user is using DataframeHandler.