### PR TITLE
[BUG] fix deleting Sagemaker deployment with namespace from CLI

### DIFF
--- a/bentoml/cli/aws_sagemaker.py
+++ b/bentoml/cli/aws_sagemaker.py
@@ -284,7 +284,8 @@ def get_aws_sagemaker_sub_command():
     @aws_sagemaker.command(help='Delete AWS Sagemaker deployment')
     @click.argument('name', type=click.STRING)
     @click.option(
-        '-n' '--namespace',
+        '-n',
+        '--namespace',
         type=click.STRING,
         help='Deployment namespace managed by BentoML, default value is "dev" which'
         'can be changed in BentoML configuration yatai_service/default_namespace',


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
The comma between two value `-n` and `--namespace` was missing. It was causeing the option name changed  from `namespace` to `n__namespace`


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->
https://github.com/bentoml/BentoML/issues/732

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation
- [ ] Test, CI, or build
- [ ] None

## Components (if applicable)
- [ ] BentoService (model packaging, dependency management, handler definition)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, logging, metrics, tracing, benchmark, OpenAPI)
- [ ] YataiService (model management, deployment automation)
- [ ] Documentation


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change in [bentoml/gallery](https://github.com/bentoml/gallery) example notebooks
- [ ] I have sent a pull request to [bentoml/gallery](https://github.com/bentoml/gallery) to make that change
