### PR TITLE
Feature/670 add jsonartifact

### DIFF
--- a/bentoml/artifact/__init__.py
+++ b/bentoml/artifact/__init__.py
@@ -22,6 +22,7 @@ from bentoml.artifact.artifact import (
     ArtifactCollection,
 )
 from bentoml.artifact.text_file_artifact import TextFileArtifact
+from bentoml.artifact.json_artifact import JSONArtifact
 from bentoml.artifact.pickle_artifact import PickleArtifact
 from bentoml.artifact.pytorch_model_artifact import PytorchModelArtifact
 from bentoml.artifact.keras_model_artifact import KerasModelArtifact
@@ -42,6 +43,7 @@ __all__ = [
     "PickleArtifact",
     "PytorchModelArtifact",
     "TextFileArtifact",
+    "JSONArtifact",
     "KerasModelArtifact",
     "XgboostModelArtifact",
     "H2oModelArtifact",

--- a/bentoml/artifact/json_artifact.py
+++ b/bentoml/artifact/json_artifact.py
@@ -49,6 +49,10 @@ class JSONArtifact(BentoServiceArtifact):
 
 class _JSONArtifactWrapper(BentoServiceArtifactWrapper):
     def __init__(self, spec, content, **json_dumps_kwargs):
+        """
+        Args:
+              **json_dumps_kwargs: keyword args forwarded to call to json.dumps().
+        """
         super().__init__(spec)
         self._content = content
         self._json_dumps_kwargs = json_dumps_kwargs

--- a/bentoml/artifact/json_artifact.py
+++ b/bentoml/artifact/json_artifact.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import re
+
+from bentoml.artifact import BentoServiceArtifact, BentoServiceArtifactWrapper
+
+
+class JSONArtifact(BentoServiceArtifact):
+    """Abstraction for saving/loading objects to/from JSON files.
+
+    Args:
+        name (str): Name of the artifact
+        file_extension (:obj:`str`, optional): The file extention used for the saved
+            text file. Defaults to ".txt"
+        encoding (:obj:`str`, optional): The encoding will be used for saving/loading
+            text. Defaults to "utf8"
+        json_module (module|object, optional): Namespace/object implementing `loads()`
+            and `dumps()` methods for serializing/deserializing to/from JSON string.
+            Defaults to stdlib's json module.
+    """
+
+    def __init__(self, name, file_extension=".json", encoding="utf8", json_module=None):
+        super().__init__(name)
+        self._file_extension = file_extension
+        self._encoding = encoding
+        if json_module:
+            self.json_module = json_module
+        else:
+            import json
+            self.json_module = json
+
+    def _file_path(self, base_path):
+        return os.path.join(
+            base_path,
+            re.sub("[^-a-zA-Z0-9_.() ]+", "", self.name) + self._file_extension,
+        )
+
+    def load(self, path):
+        with open(self._file_path(path), "rt", encoding=self._encoding) as fp:
+            content = self.json_module.loads(fp.read())
+        return self.pack(content)
+
+    def pack(self, content, **json_dumps_kwargs):  # pylint:disable=arguments-differ
+        return _JSONArtifactWrapper(self, content, **json_dumps_kwargs)
+
+
+class _JSONArtifactWrapper(BentoServiceArtifactWrapper):
+    def __init__(self, spec, content, **json_dumps_kwargs):
+        super().__init__(spec)
+        self._content = content
+        self._json_dumps_kwargs = json_dumps_kwargs
+
+    def get(self):
+        return self._content
+
+    def save(self, dst):
+        with open(self.spec._file_path(dst), "wt", encoding=self.spec._encoding) as fp:
+            fp.write(
+                self.spec.json_module.dumps(self._content, **self._json_dumps_kwargs)
+            )

--- a/tests/artifact/test_json_artifact.py
+++ b/tests/artifact/test_json_artifact.py
@@ -10,7 +10,12 @@ class ExampleServiceWithJSONArtifact(bentoml.BentoService):
 def test_json_artifact_simple_service_round_trip(tmp_path):
     service = ExampleServiceWithJSONArtifact()
     # 'hparams' = hyperparameters used at training time.
-    service.pack("hparams", {"lr": 1e-3, "patience": 10, "decay": 0.1, "batch_size": 16})
+    service.pack("hparams", {
+        "lr": 1e-3,
+        "patience": 10,
+        "decay": 0.1,
+        "batch_size": 16
+    })
     service.save_to_dir(str(tmp_path))
     del service
     new_service = bentoml.bundler.load(str(tmp_path))

--- a/tests/artifact/test_json_artifact.py
+++ b/tests/artifact/test_json_artifact.py
@@ -10,13 +10,14 @@ class ExampleServiceWithJSONArtifact(bentoml.BentoService):
 def test_json_artifact_simple_service_round_trip(tmp_path):
     service = ExampleServiceWithJSONArtifact()
     # 'hparams' = hyperparameters used at training time.
-    service.pack("hparams", {
+    hparams = {
         "lr": 1e-3,
         "patience": 10,
         "decay": 0.1,
         "batch_size": 16
-    })
+    }
+    service.pack("hparams", hparams)
     service.save_to_dir(str(tmp_path))
     del service
     new_service = bentoml.bundler.load(str(tmp_path))
-    assert isinstance(new_service.artifacts.hparams, (dict, list, int, float, str))
+    assert new_service.artifacts.hparams == hparams

--- a/tests/artifact/test_json_artifact.py
+++ b/tests/artifact/test_json_artifact.py
@@ -1,0 +1,17 @@
+import bentoml
+from bentoml.artifact import JSONArtifact
+
+
+@bentoml.artifacts([JSONArtifact("hparams")])
+class ExampleServiceWithJSONArtifact(bentoml.BentoService):
+    pass
+
+
+def test_json_artifact_simple_service_round_trip(tmp_path):
+    service = ExampleServiceWithJSONArtifact()
+    # 'hparams' = hyperparameters used at training time.
+    service.pack("hparams", {"lr": 1e-3, "patience": 10, "decay": 0.1, "batch_size": 16})
+    service.save_to_dir(str(tmp_path))
+    del service
+    new_service = bentoml.bundler.load(str(tmp_path))
+    assert isinstance(new_service.artifacts.hparams, (dict, list, int, float, str))


### PR DESCRIPTION
## Description

This PR introduces a new Artifact type for saving/loading JSON files in a SavedBundle, as described in #670. A simple integration test is included.

## Motivation and Context

#670.

## How Has This Been Tested?

Followed the development guide. Used pytest with python 3.7. (Too lazy to set up Tox.) However, implementation does not rely on new features added since 3.4. In addition, new modules have been Blacked and linted. 

Not sure if optional or still to-do:

- Rebuild documentation
- Report code coverage

## Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation
- [x] Test, CI, or build
- [ ] None

## Components (if applicable)

- [ ] BentoService (model packaging, dependency management, handler definition)
- [x] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, logging, metrics, tracing, benchmark, OpenAPI)
- [ ] YataiService (model management, deployment automation)
- [ ] Documentation


## Checklist:

- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change in [bentoml/gallery](https://github.com/bentoml/gallery) example notebooks
- [ ] I have sent a pull request to [bentoml/gallery](https://github.com/bentoml/gallery) to make that change
