### PR TITLE
Skip collecting test artifacts

### DIFF
--- a/tests/test_save_and_load.py
+++ b/tests/test_save_and_load.py
@@ -85,6 +85,8 @@ def test_pack_on_bento_service_instance(tmpdir, example_bento_service_class):
 
 
 class TestBentoWithOutArtifact(bentoml.BentoService):
+    __test__ = False
+
     @bentoml.api(DataframeHandler)
     def test(self, df):
         return df


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below. -->

## Description
Skip collecting the `TestBentoWithOutArtifact` class when running tests by adding `__test__ = False`

## Motivation and Context
When running tests with `./travis/unit_tests.sh` right now, a warning is logged to the console.
```
home/aanand/PycharmProjects/BentoML/tests/test_save_and_load.py:87: PytestCollectionWarning: cannot collect test class 'TestBentoWithOutArtifact' because it has a __init__ constructor (from: tests/test_save_and_load.py)
  class TestBentoWithOutArtifact(bentoml.BentoService):
```

## How Has This Been Tested?
I reran the unit tests after making this change, and it does not cause any tests to be skipped.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation
- [x] Test, CI, or build
- [ ] None

## Components (if applicable)
- [ ] BentoService (model packaging, dependency management, handler definition)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, logging, metrics, tracing, benchmark, OpenAPI)
- [ ] YataiService (model management, deployment automation)
- [ ] Documentation


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change in [bentoml/gallery](https://github.com/bentoml/gallery) example notebooks
- [ ] I have sent a pull request to [bentoml/gallery](https://github.com/bentoml/gallery) to make that change
