### PR TITLE
Specify inputs in documentation for ImageHandler

### DIFF
--- a/bentoml/handlers/image_handler.py
+++ b/bentoml/handlers/image_handler.py
@@ -58,8 +58,8 @@ def get_default_accept_image_formats():
     return [
         extension.strip()
         for extension in config("apiserver")
-        .get("default_image_handler_accept_file_extensions")
-        .split(",")
+            .get("default_image_handler_accept_file_extensions")
+            .split(",")
     ]
 
 
@@ -68,7 +68,10 @@ class ImageHandler(BentoHandler):
     array.
 
     Handle incoming image data from different sources, transform them into numpy array
-    and pass down to user defined API functions
+    and pass down to user defined API functions.
+
+    Processes application/octet-stream and multipart/form-data (image should be passed
+    as the "image_file" parameter)
 
     Args:
         accept_image_formats (string[]):  A list of acceptable image formats.
@@ -89,7 +92,7 @@ class ImageHandler(BentoHandler):
     BATCH_MODE_SUPPORTED = True
 
     def __init__(
-        self, accept_image_formats=None, pilmode="RGB", **base_kwargs,
+            self, accept_image_formats=None, pilmode="RGB", **base_kwargs,
     ):
         super(ImageHandler, self).__init__(**base_kwargs)
         if 'input_names' in base_kwargs:
@@ -102,7 +105,7 @@ class ImageHandler(BentoHandler):
 
         self.pilmode = pilmode
         self.accept_image_formats = (
-            accept_image_formats or get_default_accept_image_formats()
+                accept_image_formats or get_default_accept_image_formats()
         )
 
     @property
@@ -156,7 +159,7 @@ class ImageHandler(BentoHandler):
         return input_data
 
     def handle_batch_request(
-        self, requests: Iterable[SimpleRequest], func: callable
+            self, requests: Iterable[SimpleRequest], func: callable
     ) -> Iterable[SimpleResponse]:
         """
         Batch version of handle_request
@@ -221,7 +224,7 @@ class ImageHandler(BentoHandler):
         )
 
         for i in range(0, len(file_paths), batch_size):
-            step_file_paths = file_paths[i : i + batch_size]
+            step_file_paths = file_paths[i: i + batch_size]
             image_arrays = []
             for file_path in step_file_paths:
                 verify_image_format_or_raise(file_path, self.accept_image_formats)

--- a/bentoml/handlers/image_handler.py
+++ b/bentoml/handlers/image_handler.py
@@ -58,8 +58,8 @@ def get_default_accept_image_formats():
     return [
         extension.strip()
         for extension in config("apiserver")
-            .get("default_image_handler_accept_file_extensions")
-            .split(",")
+        .get("default_image_handler_accept_file_extensions")
+        .split(",")
     ]
 
 
@@ -92,7 +92,7 @@ class ImageHandler(BentoHandler):
     BATCH_MODE_SUPPORTED = True
 
     def __init__(
-            self, accept_image_formats=None, pilmode="RGB", **base_kwargs,
+        self, accept_image_formats=None, pilmode="RGB", **base_kwargs,
     ):
         super(ImageHandler, self).__init__(**base_kwargs)
         if 'input_names' in base_kwargs:
@@ -105,7 +105,7 @@ class ImageHandler(BentoHandler):
 
         self.pilmode = pilmode
         self.accept_image_formats = (
-                accept_image_formats or get_default_accept_image_formats()
+            accept_image_formats or get_default_accept_image_formats()
         )
 
     @property
@@ -159,7 +159,7 @@ class ImageHandler(BentoHandler):
         return input_data
 
     def handle_batch_request(
-            self, requests: Iterable[SimpleRequest], func: callable
+        self, requests: Iterable[SimpleRequest], func: callable
     ) -> Iterable[SimpleResponse]:
         """
         Batch version of handle_request
@@ -224,7 +224,7 @@ class ImageHandler(BentoHandler):
         )
 
         for i in range(0, len(file_paths), batch_size):
-            step_file_paths = file_paths[i: i + batch_size]
+            step_file_paths = file_paths[i : i + batch_size]
             image_arrays = []
             for file_path in step_file_paths:
                 verify_image_format_or_raise(file_path, self.accept_image_formats)


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below. -->

## Description
Just the title, specify the MIME types that the `ImageHandler` accepts so that they don't have to be found in Swagger.

## Motivation and Context
This change helps developers discover the features in `ImageHandler` without having to set it up, build their service, open it in Swagger, and then browse the available MIME types.

## How Has This Been Tested?
Rebuilt the documentation and verified that the changes show up correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation
- [ ] Test, CI, or build
- [ ] None

## Components (if applicable)
- [ ] BentoService (model packaging, dependency management, handler definition)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, logging, metrics, tracing, benchmark, OpenAPI)
- [ ] YataiService (model management, deployment automation)
- [x] Documentation


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change requires a change in [bentoml/gallery](https://github.com/bentoml/gallery) example notebooks
- [ ] I have sent a pull request to [bentoml/gallery](https://github.com/bentoml/gallery) to make that change
