### PR TITLE
Fix marshal server TypeError: argument of type 'BentoServiceApi' is not iterable

### DIFF
--- a/bentoml/marshal/marshal.py
+++ b/bentoml/marshal/marshal.py
@@ -184,22 +184,22 @@ class MarshalService:
             self.batch_handlers[api_name] = _func
 
     def setup_routes_from_pb(self, bento_service_metadata_pb):
-        for api_config in bento_service_metadata_pb.apis:
-            if api_config.input_type in BATCH_MODE_SUPPORTED_INPUT_TYPES:
+        for api_pb in bento_service_metadata_pb.apis:
+            if api_pb.input_type in BATCH_MODE_SUPPORTED_INPUT_TYPES:
                 max_latency = (
-                    api_config["mb_max_latency"]
-                    if "mb_max_latency" in api_config
+                    api_pb["mb_max_latency"]
+                    if "mb_max_latency" in api_pb.input_config
                     else self._DEFAULT_MAX_LATENCY
                 )
                 max_batch_size = (
-                    api_config["mb_max_batch_size"]
-                    if "mb_max_batch_size" in api_config
+                    api_pb["mb_max_batch_size"]
+                    if "mb_max_batch_size" in api_pb.input_config
                     else self._DEFAULT_MAX_BATCH_SIZE
                 )
                 self.add_batch_handler(
-                    api_config.name, max_latency, max_batch_size,
+                    api_pb.name, max_latency, max_batch_size,
                 )
-                logger.info("Micro batch enabled for API `%s`", api_config.name)
+                logger.info("Micro batch enabled for API `%s`", api_pb.name)
 
     async def request_dispatcher(self, request):
         with async_trace(


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
Fixed the following error when starting API server with `--enable-microbatch`:

```
TypeError: argument of type 'BentoServiceApi' is not iterable
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation
- [ ] Test, CI, or build
- [ ] None

## Components (if applicable)
- [ ] BentoService (model packaging, dependency management, handler definition)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, logging, metrics, tracing, benchmark, OpenAPI)
- [ ] YataiService (model management, deployment automation)
- [ ] Documentation


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change in [bentoml/gallery](https://github.com/bentoml/gallery) example notebooks
- [ ] I have sent a pull request to [bentoml/gallery](https://github.com/bentoml/gallery) to make that change
