### PR TITLE
Add input parameter type check to `@api`

### DIFF
--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -296,6 +296,10 @@ def api_decorator(
 
             handler = args[0](*args[1:], output_adapter=output, **kwargs)
         else:
+            assert isinstance(input, BaseInputAdapter), (
+                "API input parameter must be an instance of any classes inherited from "
+                "bentoml.adapters.BaseInputAdapter"
+            )
             handler = input
             handler._output_adapter = output
 
@@ -556,8 +560,6 @@ class BentoService(BentoServiceBase):
             self._env._add_pip_dependencies_if_missing(
                 api.output_adapter.pip_dependencies
             )
-
-        # TODO(bojiang): adapter dependencies
 
         for artifact in self._artifacts:
             self._env._add_pip_dependencies_if_missing(artifact.pip_dependencies)

--- a/bentoml/service_env.py
+++ b/bentoml/service_env.py
@@ -197,8 +197,9 @@ class BentoServiceEnv(object):
         # Insert dependencies to the beginning of self.dependencies, so that user
         # specified dependency version could overwrite this. This is used by BentoML
         # to inject ModelArtifact or Adapter's optional pip dependencies
-        if not isinstance(pip_dependencies, list):
-            pip_dependencies.insert(0, pip_dependencies)
+        assert isinstance(
+            pip_dependencies, list
+        ), 'pip_dependencies parameter must be list of str'
         self._pip_dependencies = pip_dependencies + self._pip_dependencies
 
     def _set_setup_sh(self, setup_sh_path_or_content):


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

When migrating from the old handler API to new Input/Output adapters API, one easy mistake was to pass in the class of InputAdapter instead of an instance.

E.g. from `@api(DataframeHandler)` to `@api(input=DataframeInput)`, which will produce an error when saving the BentoService: `AttributeError: 'property' object has no attribute 'insert'`

The right syntax with the new API is `@api(input=DataframeInput()`, this allow the user to customize the input adapter more easily, for example `@api(input=DataframeInput(input_dtypes={'col1': 'int64'})))`

This PR helps the user to avoid this mistake when migrating to new API


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation
- [ ] Test, CI, or build
- [x] None

## Components (if applicable)
- [x] BentoService (model packaging, dependency management, handler definition)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, logging, metrics, tracing, benchmark, OpenAPI)
- [ ] YataiService (model management, deployment automation)
- [ ] Documentation


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change in [bentoml/gallery](https://github.com/bentoml/gallery) example notebooks
- [ ] I have sent a pull request to [bentoml/gallery](https://github.com/bentoml/gallery) to make that change
