### PR TITLE
BentoML `get` improvement

### DIFF
--- a/bentoml/cli/bento.py
+++ b/bentoml/cli/bento.py
@@ -87,15 +87,16 @@ def _print_bentos_info(bentos, output_type, print_location=False):
             _print_bento_info(bento, output_type)
 
 
-def _unpack_jq_like_string(bento_dict, jq):
-    tokens = jq.split(".")
+def _unpack_jq_like_string(bento_dict, json_query):
+    tokens = json_query.split(".")
     for _t in tokens:
         try:
             bento_dict = bento_dict[_t]
         except KeyError:
             _echo(
-                f'Key {_t} not found, ignoring', CLI_COLOR_ERROR,
+                f'Failed to get {json_query}. Key {_t} is missing', CLI_COLOR_ERROR,
             )
+            return None
     return bento_dict
 
 

--- a/bentoml/cli/bento.py
+++ b/bentoml/cli/bento.py
@@ -94,8 +94,7 @@ def _unpack_jq_like_string(bento_dict, jq):
             bento_dict = bento_dict[_t]
         except KeyError:
             _echo(
-                f'Key {_t} not found, ignoring',
-                CLI_COLOR_ERROR,
+                f'Key {_t} not found, ignoring', CLI_COLOR_ERROR,
             )
     return bento_dict
 
@@ -110,7 +109,7 @@ def add_bento_sub_command(cli):
     @click.option(
         '--json-output',
         type=click.STRING,
-        help='Fetch specific field from JSON in a jq-like syntax'
+        help='Fetch specific field from JSON in a jq-like syntax',
     )
     @click.option('--ascending-order', is_flag=True)
     @click.option('--print-location', is_flag=True)
@@ -146,12 +145,7 @@ def add_bento_sub_command(cli):
             if json_output:
                 resp_dict = MessageToDict(get_bento_result.bento)
                 res = _unpack_jq_like_string(resp_dict, json_output)
-                _echo(json.dumps(
-                    res,
-                    sort_keys=True,
-                    indent=4,
-                    separators=(',', ': ')
-                ))
+                _echo(json.dumps(res, sort_keys=True, indent=4, separators=(',', ': ')))
                 return
             _print_bento_info(get_bento_result.bento, output)
             return
@@ -174,9 +168,7 @@ def add_bento_sub_command(cli):
                 return
 
             _print_bentos_info(
-                list_bento_versions_result.bentos,
-                output,
-                print_location
+                list_bento_versions_result.bentos, output, print_location
             )
 
     @cli.command(name='list', help='List BentoServices information')

--- a/bentoml/cli/bento.py
+++ b/bentoml/cli/bento.py
@@ -108,7 +108,9 @@ def add_bento_sub_command(cli):
         '--limit', type=click.INT, help='Limit how many resources will be retrieved'
     )
     @click.option(
-        '--json-output', type=click.STRING, help='Fetch specific field from JSON in a jq-like syntax'
+        '--json-output',
+        type=click.STRING,
+        help='Fetch specific field from JSON in a jq-like syntax'
     )
     @click.option('--ascending-order', is_flag=True)
     @click.option('--print-location', is_flag=True)
@@ -145,9 +147,9 @@ def add_bento_sub_command(cli):
                 resp_dict = MessageToDict(get_bento_result.bento)
                 res = _unpack_jq_like_string(resp_dict, json_output)
                 _echo(json.dumps(
-                    res, 
-                    sort_keys=True, 
-                    indent=4, 
+                    res,
+                    sort_keys=True,
+                    indent=4,
                     separators=(',', ': ')
                 ))
                 return
@@ -171,7 +173,11 @@ def add_bento_sub_command(cli):
                 )
                 return
 
-            _print_bentos_info(list_bento_versions_result.bentos, output, print_location)
+            _print_bentos_info(
+                list_bento_versions_result.bentos,
+                output,
+                print_location
+            )
 
     @cli.command(name='list', help='List BentoServices information')
     @click.option(

--- a/bentoml/cli/bento.py
+++ b/bentoml/cli/bento.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 import click
 import os
-from google.protobuf.json_format import MessageToJson
+import json
+from google.protobuf.json_format import MessageToJson, MessageToDict
 from tabulate import tabulate
 
 from bentoml.cli.click_utils import (
@@ -140,9 +141,18 @@ def add_bento_sub_command(cli):
             if print_location:
                 _echo(get_bento_result.bento.uri.uri)
                 return
-            else:
-                _print_bento_info(get_bento_result.bento, output)
+            if json_output:
+                resp_dict = MessageToDict(get_bento_result.bento)
+                res = _unpack_jq_like_string(resp_dict, json_output)
+                _echo(json.dumps(
+                    res, 
+                    sort_keys=True, 
+                    indent=4, 
+                    separators=(',', ': ')
+                ))
                 return
+            _print_bento_info(get_bento_result.bento, output)
+            return
         # get by name only
         elif name:
             track_cli('bento-list')

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -6,7 +6,7 @@ import mock
 from click.testing import CliRunner
 import psutil  # noqa # pylint: disable=unused-import
 
-from bentoml.cli import create_bento_service_cli
+from bentoml.cli import create_bento_service_cli, _unpack_jq_like_string
 
 
 def generate_test_input_file():
@@ -20,6 +20,22 @@ def generate_test_input_file():
         f.write('[{"col1": 1}, {"col1": 2}]')
     return file_path
 
+
+def test_unpack_jq_like_string():
+    test_obj = {
+        "a": "b",
+        "c": {
+            "d": "e",
+        }
+    }
+
+    assert _unpack_jq_like_string(test_obj, "a") == test_obj["a"]
+    assert _unpack_jq_like_string(test_obj, "") == test_obj
+    assert _unpack_jq_like_string(test_obj, "c.d") == test_obj["c"]["d"]
+
+    # key not found should use last working key
+    assert _unpack_jq_like_string(test_obj, "b") == test_obj
+    assert _unpack_jq_like_string(test_obj, "c.g") == test_obj["c"]
 
 def test_run_command_with_input_file(bento_bundle_path):
     input_path = generate_test_input_file()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -23,12 +23,7 @@ def generate_test_input_file():
 
 
 def test_unpack_jq_like_string():
-    test_obj = {
-        "a": "b",
-        "c": {
-            "d": "e",
-        }
-    }
+    test_obj = {"a": "b", "c": {"d": "e",}}
 
     assert _unpack_jq_like_string(test_obj, "a") == test_obj["a"]
     assert _unpack_jq_like_string(test_obj, "") == test_obj

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -7,7 +7,6 @@ from click.testing import CliRunner
 import psutil  # noqa # pylint: disable=unused-import
 
 from bentoml.cli import create_bento_service_cli
-from bentoml.cli.bento import _unpack_jq_like_string
 
 
 def generate_test_input_file():
@@ -20,18 +19,6 @@ def generate_test_input_file():
     with open(file_path, "w") as f:
         f.write('[{"col1": 1}, {"col1": 2}]')
     return file_path
-
-
-def test_unpack_jq_like_string():
-    test_obj = {"a": "b", "c": {"d": "e"}}
-
-    assert _unpack_jq_like_string(test_obj, "a") == test_obj["a"]
-    assert _unpack_jq_like_string(test_obj, "c.d") == test_obj["c"]["d"]
-
-    # key not found should return None
-    assert _unpack_jq_like_string(test_obj, "") is None
-    assert _unpack_jq_like_string(test_obj, "b") is None
-    assert _unpack_jq_like_string(test_obj, "c.g") is None
 
 
 def test_run_command_with_input_file(bento_bundle_path):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 import psutil  # noqa # pylint: disable=unused-import
 
 from bentoml.cli import create_bento_service_cli
-from bentoml.cli.bento import t_unpack_jq_like_string
+from bentoml.cli.bento import _unpack_jq_like_string
 
 
 def generate_test_input_file():

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -6,7 +6,8 @@ import mock
 from click.testing import CliRunner
 import psutil  # noqa # pylint: disable=unused-import
 
-from bentoml.cli import create_bento_service_cli, _unpack_jq_like_string
+from bentoml.cli import create_bento_service_cli
+from bentoml.cli.bento import t_unpack_jq_like_string
 
 
 def generate_test_input_file():
@@ -36,6 +37,7 @@ def test_unpack_jq_like_string():
     # key not found should use last working key
     assert _unpack_jq_like_string(test_obj, "b") == test_obj
     assert _unpack_jq_like_string(test_obj, "c.g") == test_obj["c"]
+
 
 def test_run_command_with_input_file(bento_bundle_path):
     input_path = generate_test_input_file()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -23,15 +23,15 @@ def generate_test_input_file():
 
 
 def test_unpack_jq_like_string():
-    test_obj = {"a": "b", "c": {"d": "e",}}
+    test_obj = {"a": "b", "c": {"d": "e"}}
 
     assert _unpack_jq_like_string(test_obj, "a") == test_obj["a"]
-    assert _unpack_jq_like_string(test_obj, "") == test_obj
     assert _unpack_jq_like_string(test_obj, "c.d") == test_obj["c"]["d"]
 
-    # key not found should use last working key
-    assert _unpack_jq_like_string(test_obj, "b") == test_obj
-    assert _unpack_jq_like_string(test_obj, "c.g") == test_obj["c"]
+    # key not found should return None
+    assert _unpack_jq_like_string(test_obj, "") is None
+    assert _unpack_jq_like_string(test_obj, "b") is None
+    assert _unpack_jq_like_string(test_obj, "c.g") is None
 
 
 def test_run_command_with_input_file(bento_bundle_path):


### PR DESCRIPTION
## Description
Adds `--print-location` flag to `bentoml get <bento>:<version>`

## Motivation and Context
* Closes #819.
* Implemented `--print-location`

## How Has This Been Tested?
Locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation
- [ ] Test, CI, or build
- [ ] None

## Components (if applicable)
- [x] BentoService (model packaging, dependency management, handler definition)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, logging, metrics, tracing, benchmark, OpenAPI)
- [ ] YataiService (model management, deployment automation)
- [ ] Documentation


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change in [bentoml/gallery](https://github.com/bentoml/gallery) example notebooks
- [ ] I have sent a pull request to [bentoml/gallery](https://github.com/bentoml/gallery) to make that change
