### PR TITLE
Use encoding specified in request header if presented

### DIFF
--- a/bentoml/adapters/dataframe_input.py
+++ b/bentoml/adapters/dataframe_input.py
@@ -146,13 +146,13 @@ class DataframeInput(BaseInputAdapter):
 
     def handle_request(self, request: flask.Request, func):
         if request.content_type == "text/csv":
-            csv_string = StringIO(request.get_data().decode('utf-8'))
+            csv_string = StringIO(request.get_data(as_text=True))
             df = pd.read_csv(csv_string)
         else:
             # Optimistically assuming Content-Type to be "application/json"
             try:
                 df = pd.read_json(
-                    request.get_data().decode("utf-8"),
+                    request.get_data(as_text=True),
                     orient=self.orient,
                     typ=self.typ,
                     dtype=False,

--- a/bentoml/adapters/json_input.py
+++ b/bentoml/adapters/json_input.py
@@ -38,7 +38,7 @@ class JsonInput(BaseInputAdapter):
 
     def handle_request(self, request: flask.Request, func):
         if request.content_type == "application/json":
-            parsed_json = json.loads(request.get_data().decode("utf-8"))
+            parsed_json = json.loads(request.get_data(as_text=True))
         else:
             raise BadInput(
                 "Request content-type must be 'application/json' for this "

--- a/bentoml/artifact/json_artifact.py
+++ b/bentoml/artifact/json_artifact.py
@@ -18,7 +18,9 @@ class JSONArtifact(BentoServiceArtifact):
             Defaults to stdlib's json module.
     """
 
-    def __init__(self, name, file_extension=".json", encoding="utf8", json_module=None):
+    def __init__(
+        self, name, file_extension=".json", encoding="utf-8", json_module=None
+    ):
         super().__init__(name)
         self._file_extension = file_extension
         self._encoding = encoding

--- a/bentoml/artifact/keras_model_artifact.py
+++ b/bentoml/artifact/keras_model_artifact.py
@@ -24,6 +24,9 @@ from bentoml.exceptions import (
 )
 
 
+MODULE_NAME_FILE_ENCODING = "utf-8"
+
+
 class KerasModelArtifact(BentoServiceArtifact):
     """
     Abstraction for saving/loading Keras model
@@ -186,7 +189,7 @@ class KerasModelArtifact(BentoServiceArtifact):
     def load(self, path):
         if os.path.isfile(self._keras_module_name_path(path)):
             with open(self._keras_module_name_path(path), "rb") as text_file:
-                keras_module_name = text_file.read().decode("utf-8")
+                keras_module_name = text_file.read().decode(MODULE_NAME_FILE_ENCODING)
                 try:
                     keras_module = importlib.import_module(keras_module_name)
                 except ImportError:
@@ -236,7 +239,9 @@ class _KerasModelArtifactWrapper(BentoServiceArtifactWrapper):
     def save(self, dst):
         # save the keras module name to be used when loading
         with open(self.spec._keras_module_name_path(dst), "wb") as text_file:
-            text_file.write(self.spec._keras_module_name.encode("utf-8"))
+            text_file.write(
+                self.spec._keras_module_name.encode(MODULE_NAME_FILE_ENCODING)
+            )
 
         # save custom_objects for model
         cloudpickle.dump(

--- a/bentoml/artifact/text_file_artifact.py
+++ b/bentoml/artifact/text_file_artifact.py
@@ -30,7 +30,7 @@ class TextFileArtifact(BentoServiceArtifact):
 
     """
 
-    def __init__(self, name, file_extension=".txt", encoding="utf8"):
+    def __init__(self, name, file_extension=".txt", encoding="utf-8"):
         super(TextFileArtifact, self).__init__(name)
         self._file_extension = file_extension
         self._encoding = encoding

--- a/bentoml/cli/config.py
+++ b/bentoml/cli/config.py
@@ -21,7 +21,11 @@ import logging
 from configparser import ConfigParser
 
 from bentoml import config as bentoml_config
-from bentoml.configuration import get_local_config_file, DEFAULT_CONFIG_FILE
+from bentoml.configuration import (
+    get_local_config_file,
+    DEFAULT_CONFIG_FILE,
+    CONFIG_FILE_ENCODING,
+)
 from bentoml.cli.click_utils import BentoMLCommandGroup, _echo, CLI_COLOR_ERROR
 from bentoml.utils.usage_stats import track_cli
 
@@ -57,7 +61,7 @@ def get_configuration_sub_command():
     def view():
         track_cli('config-view')
         local_config = ConfigParser()
-        local_config.read(get_local_config_file(), encoding='utf-8')
+        local_config.read(get_local_config_file(), encoding=CONFIG_FILE_ENCODING)
         local_config.write(sys.stdout)
         return
 
@@ -80,7 +84,7 @@ def get_configuration_sub_command():
         track_cli('config-set')
         local_config = ConfigParser()
         local_config_file = get_local_config_file()
-        local_config.read(local_config_file, encoding='utf-8')
+        local_config.read(local_config_file, encoding=CONFIG_FILE_ENCODING)
 
         try:
             for update in updates:
@@ -111,7 +115,7 @@ def get_configuration_sub_command():
         track_cli('config-unset')
         local_config = ConfigParser()
         local_config_file = get_local_config_file()
-        local_config.read(local_config_file, encoding='utf-8')
+        local_config.read(local_config_file, encoding=CONFIG_FILE_ENCODING)
 
         try:
             for update in updates:

--- a/bentoml/configuration/__init__.py
+++ b/bentoml/configuration/__init__.py
@@ -30,6 +30,8 @@ logger = logging.getLogger(__name__)
 # Default bentoml config comes with the library bentoml/config/default_bentoml.cfg
 DEFAULT_CONFIG_FILE = os.path.join(os.path.dirname(__file__), "default_bentoml.cfg")
 
+CONFIG_FILE_ENCODING = "utf-8"
+
 
 def expand_env_var(env_var):
     """Expands potentially nested env var by repeatedly applying `expandvars` and
@@ -99,7 +101,7 @@ def load_config():
         )
 
     with open(DEFAULT_CONFIG_FILE, "rb") as f:
-        DEFAULT_CONFIG = f.read().decode("utf-8")
+        DEFAULT_CONFIG = f.read().decode(CONFIG_FILE_ENCODING)
 
     loaded_config = BentoMLConfigParser(
         default_config=parameterized_config(DEFAULT_CONFIG)
@@ -109,7 +111,9 @@ def load_config():
     if os.path.isfile(local_config_file):
         logger.info("Loading local BentoML config file: %s", local_config_file)
         with open(local_config_file, "rb") as f:
-            loaded_config.read_string(parameterized_config(f.read().decode("utf-8")))
+            loaded_config.read_string(
+                parameterized_config(f.read().decode(CONFIG_FILE_ENCODING))
+            )
     else:
         logger.info("No local BentoML config file found, using default configurations")
 

--- a/tests/handlers/test_dataframe_handler.py
+++ b/tests/handlers/test_dataframe_handler.py
@@ -115,7 +115,7 @@ def test_dataframe_handle_request_csv():
         return df["name"][0]
 
     input_adapter = DataframeInput()
-    csv_data = 'name,game,city\njohn,mario,sf'.encode('utf-8')
+    csv_data = 'name,game,city\njohn,mario,sf'
     request = MagicMock(spec=flask.Request)
     request.headers = {'orient': 'records'}
     request.content_type = 'text/csv'


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
Attempt to fix issue https://github.com/bentoml/BentoML/issues/742

When a request has specified encoding in its header, flask's `request.get_data(as_text=True)` will use this encoding. But in BentoML, it has been using `utf-8` for all requests.

cc @bojiang, do we need to worry about this issue when handling batched request?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->
https://github.com/bentoml/BentoML/issues/742

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [x] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
