### PR TITLE
Add documentation around use of retrieve cli cmd

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -924,3 +924,27 @@ creating model serving deployments.
     the security best practices built-in, to bootstrap the end-to-end model management 
     and model serving deployment workflow. `Contact us <mailto:contact@bentoml.ai>`_ to
     learn more about our offerings.
+
+Retrieving BentoServices
+-------------------
+
+After saving your Model services to BentoML, you can retrieve the artifact bundle using the CLI from any environment configured to use the YataiService. The `--target_dir` flag specifies where the artifact bundle will be populated. If the directory exists, it will not be overwritten to avoid inconsistent bundles.
+
+.. code-block:: bash
+
+    > bentoml retrieve --help
+    Usage: bentoml retrieve [OPTIONS] BENTO
+
+      Retrieves BentoService artifacts into a target directory
+
+    Options:
+      --target_dir TEXT   Directory to put artifacts into. Defaults to pwd.
+      -q, --quiet         Hide all warnings and info logs
+      --verbose, --debug  Show debug logs when running the command
+      --help              Show this message and exit.
+
+This command extends BentoML to be useful in a CI workflow or to provide a rapid way to share Services with others.
+
+.. code-block:: bash
+
+    bentoml retrieve ModelServe --target_dir=~/bentoml_bundle/

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -928,7 +928,7 @@ creating model serving deployments.
 Retrieving BentoServices
 -------------------
 
-After saving your Model services to BentoML, you can retrieve the artifact bundle using the CLI from any environment configured to use the YataiService. The `--target_dir` flag specifies where the artifact bundle will be populated. If the directory exists, it will not be overwritten to avoid inconsistent bundles.
+After saving your Model services to BentoML, you can retrieve the artifact bundle using the CLI from any environment configured to use the YataiService. The :code:`--target_dir` flag specifies where the artifact bundle will be populated. If the directory exists, it will not be overwritten to avoid inconsistent bundles.
 
 .. code-block:: bash
 


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description

Add documentation for the new`bentoml retrieve` command.

## Motivation and Context

In https://github.com/bentoml/BentoML/pull/810 I added the retrieve command, but there should be some docs to describe its usage.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [x] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [x] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
