### PR TITLE
Fix DataFrameInput passing NaN values over HTTP JSON request

### DIFF
--- a/bentoml/adapters/dataframe_input.py
+++ b/bentoml/adapters/dataframe_input.py
@@ -152,10 +152,7 @@ class DataframeInput(BaseInputAdapter):
             # Optimistically assuming Content-Type to be "application/json"
             try:
                 df = pd.read_json(
-                    request.get_data(as_text=True),
-                    orient=self.orient,
-                    typ=self.typ,
-                    dtype=False,
+                    request.get_data(as_text=True), orient=self.orient, typ=self.typ,
                 )
             except ValueError:
                 raise BadInput(
@@ -234,9 +231,7 @@ class DataframeInput(BaseInputAdapter):
         else:
             # Optimistically assuming Content-Type to be "application/json"
             try:
-                df = pd.read_json(
-                    event["body"], orient=self.orient, typ=self.typ, dtype=False
-                )
+                df = pd.read_json(event["body"], orient=self.orient, typ=self.typ)
             except ValueError:
                 raise BadInput(
                     "Failed parsing request data, only Content-Type application/json "

--- a/bentoml/adapters/dataframe_input.py
+++ b/bentoml/adapters/dataframe_input.py
@@ -206,7 +206,7 @@ class DataframeInput(BaseInputAdapter):
             if cli_input.endswith(".csv"):
                 df = pd.read_csv(cli_input)
             elif cli_input.endswith(".json"):
-                df = pd.read_json(cli_input, orient=orient, typ=self.typ, dtype=False)
+                df = pd.read_json(cli_input, orient=orient, typ=self.typ)
             else:
                 raise BadInput(
                     "Input file format not supported, BentoML cli only accepts .json "
@@ -215,7 +215,7 @@ class DataframeInput(BaseInputAdapter):
         else:
             # Assuming input string is JSON format
             try:
-                df = pd.read_json(cli_input, orient=orient, typ=self.typ, dtype=False)
+                df = pd.read_json(cli_input, orient=orient, typ=self.typ)
             except ValueError as e:
                 raise BadInput(
                     "Unexpected input format, BentoML DataframeInput expects json "


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

This PR removes the `dtype=False` option in DataframeInput pandas.read_json call - this allow BentoML to follow the `pandas`'s convention on converting JSON to dataframe

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->
See issue #862 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [x] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
