### PR TITLE
Change the default value of mb_max_latency

### DIFF
--- a/bentoml/configuration/default_bentoml.cfg
+++ b/bentoml/configuration/default_bentoml.cfg
@@ -77,7 +77,7 @@ batch_request_header = Bentoml-Is-Batch-Request
 
 [marshal_server]
 marshal_request_header_flag = BentoML-Is-Merged-Request
-default_max_latency = 300
+default_max_latency = 10000
 default_max_batch_size = 2000
 
 

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -66,7 +66,7 @@ class BentoServiceAPI(object):
         :param func: API func contains the actual API callback, this is
             typically the 'predict' method on a model
         :param mb_max_latency: The latency goal of your service in milliseconds.
-            Default: 300.
+            Default: 10000.
         :param mb_max_batch_size: The maximum size of any batch. This parameter
             governs the throughput/latency tradeoff, and also avoids having
             batches that are so large they exceed some resource constraint (e.g.

--- a/docs/source/deployment/azure_functions.rst
+++ b/docs/source/deployment/azure_functions.rst
@@ -88,7 +88,7 @@ above
               "cors": "*"
             },
             "outputType": "DefaultOutput",
-            "mbMaxLatency": 300,
+            "mbMaxLatency": 10000,
             "mbMaxBatchSize": 2000
           }
         ]

--- a/docs/source/guides/micro_batching.rst
+++ b/docs/source/guides/micro_batching.rst
@@ -33,7 +33,7 @@ preprocessing procedure will also benefit from micro-batching.
    batches that are so large they exceed some resource constraint (e.g.
    GPU memory to hold a batch's data). Default: 1000.
 -  ``mb_max_latency`` The latency goal of your service in milliseconds.
-   Default: 300.
+   Default: 10000.
 -  **outbound semaphore:** The semaphore represents the degree of
    parallelism, i.e. the maximum number of batches processed
    concurrently. **It is set automatically** when launching the bento
@@ -95,11 +95,11 @@ latency. It will respond to the fluctuations of server loading.
 
     class MovieReviewService(bentoml.BentoService):
         @bentoml.api(input=DataframeInput(),
-                     mb_max_latency=300, mb_max_batch_size=1000)
+                     mb_max_latency=10000, mb_max_batch_size=1000)
         def predict(self, inputs):
                     pass
 
-``mb_max_batch_size`` is 1000 by default and ``mb_max_latency`` is 300
+``mb_max_batch_size`` is 1000 by default and ``mb_max_latency`` is 10000
 by default.
 
 -  If the RAM of GPU only allowed input with 100 batch size, then you


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
It assumed that more users prefer less 429 error than faster response.
<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
