### PR TITLE
JsonInput shouldn't check Content-Type for AWS Lambda functions

### DIFF
--- a/bentoml/adapters/json_input.py
+++ b/bentoml/adapters/json_input.py
@@ -16,6 +16,7 @@ import os
 import json
 import argparse
 from typing import Iterable
+from json import JSONDecodeError
 
 import flask
 
@@ -112,9 +113,9 @@ class JsonInput(BaseInputAdapter):
         return self.output_adapter.to_cli(result, unknown_args)
 
     def handle_aws_lambda_event(self, event, func):
-        if event["headers"]["Content-Type"] == "application/json":
+        try:
             parsed_json = json.loads(event["body"])
-        else:
+        except JSONDecodeError:
             raise BadInput(
                 "Request content-type must be 'application/json' for this "
                 "BentoService API lambda endpoint"

--- a/bentoml/adapters/json_input.py
+++ b/bentoml/adapters/json_input.py
@@ -117,8 +117,7 @@ class JsonInput(BaseInputAdapter):
             parsed_json = json.loads(event["body"])
         except JSONDecodeError:
             raise BadInput(
-                "The input provided is not proper JSON. Please make"
-                "sure to send correctly formatted JSON."
+                "Request body must contain valid json"
             )
 
         result = func([parsed_json])[0]

--- a/bentoml/adapters/json_input.py
+++ b/bentoml/adapters/json_input.py
@@ -117,8 +117,8 @@ class JsonInput(BaseInputAdapter):
             parsed_json = json.loads(event["body"])
         except JSONDecodeError:
             raise BadInput(
-                "Request content-type must be 'application/json' for this "
-                "BentoService API lambda endpoint"
+                "The input provided is not proper JSON. Please make"
+                "sure to send correctly formatted JSON."
             )
 
         result = func([parsed_json])[0]

--- a/bentoml/adapters/json_input.py
+++ b/bentoml/adapters/json_input.py
@@ -116,9 +116,7 @@ class JsonInput(BaseInputAdapter):
         try:
             parsed_json = json.loads(event["body"])
         except JSONDecodeError:
-            raise BadInput(
-                "Request body must contain valid json"
-            )
+            raise BadInput("Request body must contain valid json")
 
         result = func([parsed_json])[0]
         return self.output_adapter.to_aws_lambda_event(result, event)

--- a/tests/adapters/test_json_handler.py
+++ b/tests/adapters/test_json_handler.py
@@ -51,7 +51,7 @@ def test_json_handle_aws_lambda_event():
     error_event_obj = {
         "headers": {"Content-Type": "application/json"},
         "body": "not a valid, json {}"
-    }    
+    }
     with pytest.raises(BadInput) as e:
         input_adapter.handle_aws_lambda_event(error_event_obj, test_func)
 

--- a/tests/adapters/test_json_handler.py
+++ b/tests/adapters/test_json_handler.py
@@ -38,11 +38,21 @@ def test_json_handle_aws_lambda_event():
     assert success_response["statusCode"] == 200
     assert success_response["body"] == '"john"'
 
-    error_event_obj = {
-        "headers": {"Content-Type": "this_will_fail"},
+    success_event_obj = {
+        "headers": {"Content-Type": "this_will_also_work"},
         "body": test_content,
     }
+    success_response = input_adapter.handle_aws_lambda_event(
+        success_event_obj, test_func
+    )
+    assert success_response["statusCode"] == 200
+    assert success_response["body"] == '"john"'
+
+    error_event_obj = {
+        "headers": {"Content-Type": "application/json"},
+        "body": "not a valid, json {}"
+    }    
     with pytest.raises(BadInput) as e:
         input_adapter.handle_aws_lambda_event(error_event_obj, test_func)
 
-    assert "Request content-type must be 'application/json" in str(e.value)
+    assert "Request body must contain valid json" in str(e.value)

--- a/tests/adapters/test_json_handler.py
+++ b/tests/adapters/test_json_handler.py
@@ -50,7 +50,7 @@ def test_json_handle_aws_lambda_event():
 
     error_event_obj = {
         "headers": {"Content-Type": "application/json"},
-        "body": "not a valid, json {}"
+        "body": "not a valid, json {}",
     }
     with pytest.raises(BadInput) as e:
         input_adapter.handle_aws_lambda_event(error_event_obj, test_func)


### PR DESCRIPTION
This addresses an issue with AWS Lambda where sometimes a `Content-Type` header is not being sent to the Lambda function even though it is set by the client. This resolves https://github.com/bentoml/BentoML/issues/893.

<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
With this change the JsonInput adapter will, by default, try to parse the input as JSON without testing for the `Content-Type` header, for AWS Lambda functions. If a JSONDecodeError is raised, it will raise a BadInput error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->
I had problems with AWS Lambda not transferring the correct headers and as a result, a server error was raised because the Content-Type was missing. We also discussed this on Slack.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In a function I use in production, I made this change manually to the lambda function and deployed it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [X] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
