### PR TITLE
Deprecate old style 'pack'

### DIFF
--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -28,7 +28,7 @@ from bentoml.saved_bundle.config import SavedBundleConfig
 from bentoml.service_env import BentoServiceEnv
 from bentoml.utils import isidentifier
 from bentoml.utils.hybridmethod import hybridmethod
-from bentoml.exceptions import NotFound, InvalidArgument
+from bentoml.exceptions import NotFound, InvalidArgument, BentoMLException
 from bentoml.server import trace
 
 
@@ -794,31 +794,12 @@ class BentoService:
     @pack.classmethod
     def pack(cls, *args, **kwargs):  # pylint: disable=no-self-argument
         """
-        **Deprecated**: Legacy `BentoService#pack` class method, which can be used to
-        initialize a BentoService instance along with trained model artifacts. This will
-        be deprecated soon:
-
-        :param args: args passing to the BentoService class
-        :param kwargs: kwargs passing to the BentoService class and (artifact_name,
-            args) pair for creating declared model artifacts
-        :return: a new BentoService instance
+        **Deprecated**: Legacy `BentoService#pack` class method, no longer supported
         """
-        logger.warning(
+        raise BentoMLException(
             "BentoService#pack class method is deprecated, use instance method `pack` "
             "instead. e.g.: svc = MyBentoService(); svc.pack('model', model_object)"
         )
-
-        packed_artifacts = []
-        for artifact in cls._artifacts:
-            if artifact.name in kwargs:
-                artifact_args = kwargs.pop(artifact.name)
-                packed_artifacts.append(artifact.pack(artifact_args))
-
-        bento_svc = cls(*args, **kwargs)  # pylint: disable=not-callable
-        for packed_artifact in packed_artifacts:
-            bento_svc.artifacts.add(packed_artifact)
-
-        return bento_svc
 
     def _load_artifacts(self, path):
         # For pip installed BentoService, artifacts directory is located at

--- a/tests/test_save_and_load.py
+++ b/tests/test_save_and_load.py
@@ -23,7 +23,8 @@ def test_save_and_load_model(tmpdir, example_bento_service_class):
     )
 
     test_model = TestModel()
-    svc = example_bento_service_class.pack(model=test_model)
+    svc = example_bento_service_class()
+    svc.pack('model', test_model)
 
     assert svc.predict(1000) == 2000
     version = "test_" + uuid.uuid4().hex


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

In early BentoML releases(before Nov 2019), the artifact `pack` is invoked from BentoService class' class method:

 ```python
@artifact([PytorchModelArtifact('model')])
class ImageClassifier(BentoService):

    @api(inpud=ImageInput)
    def classify(image_list):
        ...

import torchvision.models as models
resnet18 = models.resnet18()
svc = ImageClassifier.pack(model=resnet18)
```

This syntax was then changed to:

```python
svc = ImageClassifier()
svc.pack('model', resnet18)
```

We've been providing backward compatibility for the old syntax for over 6 months now and have updated all the documentation and examples over to the new syntax ever since.  As we continue to improve the artifacts API, it is time for us to get rid of this older syntax now.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [x] BentoService (service definition, dependency management, API input/output adapters)
- [x] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
