### PR TITLE
Add artifact loaded, packed, is_ready state check

### DIFF
--- a/bentoml/artifact/artifact.py
+++ b/bentoml/artifact/artifact.py
@@ -13,8 +13,12 @@
 # limitations under the License.
 
 import os
+import logging
 
-from bentoml.exceptions import InvalidArgument
+from bentoml.exceptions import InvalidArgument, FailedPrecondition
+from bentoml.service_env import BentoServiceEnv
+
+logger = logging.getLogger(__name__)
 
 ARTIFACTS_DIR_NAME = "artifacts"
 
@@ -34,10 +38,22 @@ class BentoServiceArtifact:
                 A valid identifier cannot start with a number, or contain any spaces."
             )
         self._name = name
+        self._packed = False
+        self._loaded = False
 
     @property
     def pip_dependencies(self):
         return []
+
+    @property
+    def packed(self):
+        return self._packed
+
+    @property
+    def loaded(self):
+    @property
+    def is_ready(self):
+        return self.packed or self.loaded
 
     @property
     def name(self):
@@ -47,7 +63,7 @@ class BentoServiceArtifact:
         """
         return self._name
 
-    def pack(self, data):
+    def pack(self, model):
         """
         Pack the in-memory trained model object to this BentoServiceArtifact
 
@@ -70,10 +86,83 @@ class BentoServiceArtifact:
         """
 
 
+    def __getattribute__(self, item):
+        if item == 'pack':
+            original = object.__getattribute__(self, item)
+
+            def wrapped_pack(*args, **kwargs):
+                if self.packed:
+                    logger.warning(
+                        "`pack` an artifact multiple times may lead to unexpected "
+                        "behaviors"
+                    )
+                ret = original(*args, **kwargs)
+                # do not set `self._pack` if `pack` has failed with an exception raised
+                self._packed = True
+                return ret
+
+            return wrapped_pack
+
+        elif item == 'load':
+            original = object.__getattribute__(self, item)
+
+            def wrapped_load(*args, **kwargs):
+                if self.packed:
+                    logger.warning(
+                        "`load` on a 'packed' artifact may lead to unexpected behaviors"
+                    )
+                if self.loaded:
+                    logger.warning(
+                        "`load` an artifact multiple times may lead to unexpected "
+                        "behaviors"
+                    )
+                ret = original(*args, **kwargs)
+                # do not set self._loaded if `load` has failed with an exception raised
+                self._loaded = True
+                return ret
+
+            return wrapped_load
+
+        elif item == 'save':
+
+            def wrapped_save(*args, **kwargs):
+                if not self.is_ready:
+                    raise FailedPrecondition(
+                        "Trying to save empty artifact. An artifact needs to be `pack` "
+                        "with model instance or `load` from saved path before saving"
+                    )
+                original = object.__getattribute__(self, item)
+                return original(*args, **kwargs)
+
+            return wrapped_save
+
+        elif item == 'get':
+
+            def wrapped_get(*args, **kwargs):
+                if not self.is_ready:
+                    raise FailedPrecondition(
+                        "Trying to access empty artifact. An artifact needs to be "
+                        "`pack` with model instance or `load` from saved path before "
+                        "it can be used for inference"
+                    )
+                original = object.__getattribute__(self, item)
+                return original(*args, **kwargs)
+
+            return wrapped_get
+
+        return object.__getattribute__(self, item)
+
+
 class BentoServiceArtifactWrapper:
     """
     Deprecated: use only the BentoServiceArtifact to define artifact operations
     """
+
+    def __init__(self):
+        logger.warning(
+            "BentoServiceArtifactWrapper is deprecated now, use BentoServiceArtifact "
+            "to define artifact operations"
+        )
 
 
 class ArtifactCollection(dict):

--- a/bentoml/artifact/artifact.py
+++ b/bentoml/artifact/artifact.py
@@ -16,7 +16,6 @@ import os
 import logging
 
 from bentoml.exceptions import InvalidArgument, FailedPrecondition
-from bentoml.service_env import BentoServiceEnv
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +85,6 @@ class BentoServiceArtifact:
         """
         Get returns a reference to the artifact being packed or loaded from path
         """
-
 
     def __getattribute__(self, item):
         if item == 'pack':

--- a/bentoml/artifact/artifact.py
+++ b/bentoml/artifact/artifact.py
@@ -51,6 +51,8 @@ class BentoServiceArtifact:
 
     @property
     def loaded(self):
+        return self._loaded
+
     @property
     def is_ready(self):
         return self.packed or self.loaded

--- a/tests/artifact/test_bento_service_artifact.py
+++ b/tests/artifact/test_bento_service_artifact.py
@@ -1,5 +1,6 @@
 import pytest
-from bentoml.artifact import BentoServiceArtifact
+from bentoml.artifact import BentoServiceArtifact, SklearnModelArtifact
+from bentoml.exceptions import FailedPrecondition
 
 
 def test_valid_artifact_name():
@@ -52,3 +53,53 @@ def test_unvalid_artifact_name():
     with pytest.raises(ValueError) as e:
         BentoServiceArtifact(name)
     assert "Artifact name must be a valid python identifier" in str(e.value)
+
+
+def test_artifact_states(tmp_path):
+    from sklearn import svm
+    from sklearn import datasets
+
+    # Load training data
+    iris = datasets.load_iris()
+    X, y = iris.data, iris.target
+    # Model Training
+    clf = svm.SVC(gamma='scale')
+    clf.fit(X, y)
+
+    artifact_name = 'test_model'
+    a1 = SklearnModelArtifact(artifact_name)
+
+    # verify initial states
+    assert not a1.loaded
+    assert not a1.packed
+    assert not a1.is_ready
+
+    # verify that get will fail
+    with pytest.raises(FailedPrecondition):
+        a1.get()
+    # verify that save will fail
+    with pytest.raises(FailedPrecondition):
+        a1.save('anywhere')
+
+    # verify states after pack
+    a1.pack(clf)
+    assert not a1.loaded
+    assert a1.packed
+    assert a1.is_ready
+    assert isinstance(a1.get(), svm.SVC)
+
+    # Test save and load artifact
+    # 1. save the packed artifact to tempdir
+    a1.save(tmp_path)
+    # 2. create a new artifact with same name
+    a2 = SklearnModelArtifact(artifact_name)
+    # 3. load a2 from tempdir
+    a2.load(tmp_path)
+
+    # verify states after load
+    assert a2.loaded
+    assert a2.is_ready
+    assert a2.packed  # this dependes on the artifact implementation, in the case of
+    # Sklearn artifact, the `load` method invokes `pack` internally
+    assert isinstance(a2.get(), svm.SVC)
+    assert all(a1.get().predict(X) == a2.get().predict(X))


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

Before #911, we used a slightly restricted pattern to ensure an artifact can only be accessed or saved after it has been packed or loaded from disk. #911 refactored the interface to make it cleaner to implement although it now missed the enforcement of packed or loaded state check before accessing the model. This PR adds that back by wrapping those methods and setting the internal state when `pack` or `load` is invoked.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

This is part of an effort to provide a more flexible artifacts API that will allow custom model training workflows to integrate better with BentoML's model serving workflow https://github.com/bentoml/BentoML/issues/758

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [x] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
