### PR TITLE
Fix containerize CLI tag parameter validation

### DIFF
--- a/bentoml/cli/bento_service.py
+++ b/bentoml/cli/bento_service.py
@@ -63,6 +63,9 @@ def to_valid_docker_image_version(version):
 
 
 def validate_tag(ctx, param, tag):  # pylint: disable=unused-argument
+    if not tag:
+        return tag
+
     if ":" in tag:
         name, version = tag.split(":")[:2]
     else:

--- a/bentoml/cli/bento_service.py
+++ b/bentoml/cli/bento_service.py
@@ -63,7 +63,7 @@ def to_valid_docker_image_version(version):
 
 
 def validate_tag(ctx, param, tag):  # pylint: disable=unused-argument
-    if not tag:
+    if tag is None:
         return tag
 
     if ":" in tag:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -63,7 +63,7 @@ def test_to_valid_docker_image_version(tag, expected_tag):
 
 
 @pytest.mark.parametrize(
-    "tag", ["randomtag", "name:version", "asdf123:" + "A" * 128, "a-a.a__a"]
+    "tag", ["randomtag", "name:version", "asdf123:" + "A" * 128, "a-a.a__a", None]
 )
 def test_validate_tag(tag):
     # check to make sure tag is returned and nothing is raised


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
Fix `validate_tag` function raise exception when the optional`--tag` flag is not specified for command `bentoml containerize`

**Current behavior:**
`bentoml containerize MyBentoService:v1` without adding optional `--tag` flag will raise exception:
```
  value = invoke_param_callback(self.callback, ctx, self, value)
  File "/usr/local/anaconda3/envs/dev/lib/python3.8/site-packages/click/core.py", line 123, in invoke_param_callback
    return callback(ctx, param, value)
  File "/Users/bozhaoyu/src/BentoML/bentoml/cli/bento_service.py", line 69, in validate_tag
    if ":" in tag:
TypeError: argument of type 'NoneType' is not iterable
```

**Expected behavior:**
`bentoml containerize MyBentoService:v1` will build docker image with the tag generated from BentoService name and version, when `--tag` option is not specified. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [x] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
