### PR TITLE
Artifacts refactoring: moving BentoService base class to new API

### DIFF
--- a/bentoml/saved_bundle/bundler.py
+++ b/bentoml/saved_bundle/bundler.py
@@ -70,8 +70,8 @@ def save_to_dir(bento_service, path, version=None, silent=False):
     if not os.path.exists(path):
         raise BentoMLException("Directory '{}' not found".format(path))
 
-    for artifact in bento_service._artifacts:
-        if artifact.name not in bento_service._packed_artifacts:
+    for artifact in bento_service.artifacts.get_artifact_list():
+        if not artifact.packed:
             logger.warning(
                 "Missing declared artifact '%s' for BentoService '%s'",
                 artifact.name,
@@ -98,8 +98,7 @@ def save_to_dir(bento_service, path, version=None, silent=False):
         f.write(saved_bundle_readme)
 
     # save all model artifacts to 'base_path/name/artifacts/' directory
-    if bento_service.artifacts:
-        bento_service.artifacts.save(module_base_path)
+    bento_service.artifacts.save(module_base_path)
 
     # write conda environment, requirement.txt
     bento_service.env.save(path, bento_service)

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -31,6 +31,8 @@ from bentoml.utils import isidentifier
 from bentoml.utils.hybridmethod import hybridmethod
 from bentoml.exceptions import NotFound, InvalidArgument, BentoMLException
 from bentoml.server import trace
+from bentoml.artifact import BentoServiceArtifact, ArtifactCollection
+from bentoml.adapters import BaseInputAdapter, BaseOutputAdapter
 
 
 ARTIFACTS_DIR_NAME = "artifacts"
@@ -191,8 +193,8 @@ def validate_inference_api_name(api_name):
 
 def api_decorator(
     *args,
-    input=None,
-    output=None,
+    input: BaseInputAdapter = None,
+    output: BaseOutputAdapter = None,
     api_name=None,
     api_doc=None,
     mb_max_batch_size=DEFAULT_MAX_BATCH_SIZE,
@@ -241,7 +243,7 @@ def api_decorator(
     >>> class FraudDetectionAndIdentityService(BentoService):
     >>>
     >>>     @api(JsonHandler)  # deprecated
-    >>>     def fraud_detect(self, parsed_json):
+    >>>     def fraud_detect(self, parsed_json_list):
     >>>         # do something
     >>>
     >>>     @api(DataframeHandler, input_json_orient='records')  # deprecated
@@ -249,8 +251,6 @@ def api_decorator(
     >>>         # do something
 
     """
-
-    from bentoml.adapters import BaseInputAdapter
 
     def decorator(func):
         _api_name = func.__name__ if api_name is None else api_name
@@ -305,22 +305,22 @@ def web_static_content_decorator(web_static_content):
     return decorator
 
 
-def artifacts_decorator(artifacts):
+def artifacts_decorator(artifacts: List[BentoServiceArtifact]):
     """Define artifacts required to be bundled with a BentoService
 
     Args:
         artifacts (list(bentoml.artifact.BentoServiceArtifact)): A list of desired
             artifacts required by this BentoService
     """
-    from bentoml.artifact import BentoServiceArtifact
 
     def decorator(bento_service_cls):
         artifact_names = set()
         for artifact in artifacts:
             if not isinstance(artifact, BentoServiceArtifact):
                 raise InvalidArgument(
-                    "BentoService @artifacts decorator only accept list of type "
-                    "BentoServiceArtifact, instead got type: '%s'" % type(artifact)
+                    "BentoService @artifacts decorator only accept list of "
+                    "BentoServiceArtifact instances, instead got type: '%s'"
+                    % type(artifact)
                 )
 
             if artifact.name in artifact_names:
@@ -331,7 +331,7 @@ def artifacts_decorator(artifacts):
 
             artifact_names.add(artifact.name)
 
-        bento_service_cls._artifacts = artifacts
+        bento_service_cls._declared_artifacts = artifacts
         return bento_service_cls
 
     return decorator
@@ -510,8 +510,13 @@ class BentoService:
     # installed site-package location of current python environment
     _bento_service_bundle_path = None
 
-    # A list of artifacts required by this BentoService
-    _artifacts = []
+    # List of artifacts required by this BentoService class, declared via the `@env`
+    # decorator. This list is used for initializing an empty ArtifactCollection when
+    # the BentoService class is instantiated
+    _declared_artifacts: List[BentoServiceArtifact] = []
+
+    # An instance of ArtifactCollection, containing all required trained model artifacts
+    _artifacts: ArtifactCollection = None
 
     #  A `BentoServiceEnv` instance specifying the required dependencies and all system
     #  environment setups
@@ -529,15 +534,11 @@ class BentoService:
     _web_static_content = None
 
     def __init__(self):
-        from bentoml.artifact import ArtifactCollection
-
+        # When creating BentoService instance from a saved bundle, set version to the
+        # version specified in the saved bundle
         self._bento_service_version = self.__class__._bento_service_bundle_version
-        self._packed_artifacts = ArtifactCollection()
 
-        if self._bento_service_bundle_path:
-            # load artifacts from saved BentoService bundle
-            self._load_artifacts(self._bento_service_bundle_path)
-
+        self._config_artifacts()
         self._config_inference_apis()
         self._config_environments()
 
@@ -550,7 +551,7 @@ class BentoService:
                 api.output_adapter.pip_dependencies
             )
 
-        for artifact in self._artifacts:
+        for artifact in self.artifacts.get_artifact_list():
             artifact.set_dependencies(self.env)
 
     def _config_inference_apis(self):
@@ -581,6 +582,28 @@ class BentoService:
                         mb_max_batch_size=mb_max_batch_size,
                     )
                 )
+
+    def _config_artifacts(self):
+        self._artifacts = ArtifactCollection.from_artifact_list(
+            self._declared_artifacts
+        )
+
+        if self._bento_service_bundle_path:
+            # For pip installed BentoService, artifacts directory is located at
+            # 'package_path/artifacts/', but for loading from bundle directory, it is
+            # in 'path/{service_name}/artifacts/'
+            if os.path.isdir(
+                os.path.join(self._bento_service_bundle_path, ARTIFACTS_DIR_NAME)
+            ):
+                artifacts_path = os.path.join(
+                    self._bento_service_bundle_path, ARTIFACTS_DIR_NAME
+                )
+            else:
+                artifacts_path = os.path.join(
+                    self._bento_service_bundle_path, self.name, ARTIFACTS_DIR_NAME
+                )
+
+            self.artifacts.load_all(artifacts_path)
 
     @property
     def inference_apis(self):
@@ -616,13 +639,14 @@ class BentoService:
 
     @property
     def artifacts(self):
-        """ Returns all packed artifacts in an ArtifactCollection object
+        """ Returns the ArtifactCollection instance specified with this BentoService
+        class
 
         Returns:
             artifacts(ArtifactCollection): A dictionary of packed artifacts from the
-            artifact name to the loaded artifact model instance in its native form
+            artifact name to the BentoServiceArtifact instance
         """
-        return self._packed_artifacts
+        return self._artifacts
 
     @property
     def env(self):
@@ -780,19 +804,7 @@ class BentoService:
         :param kwargs: kwargs passing to the target model artifact to be packed
         :return: this BentoService instance
         """
-        if name in self.artifacts:
-            logger.warning(
-                "BentoService '%s' #pack overriding existing artifact '%s'",
-                self.name,
-                name,
-            )
-            del self.artifacts[name]
-
-        artifact = next(
-            artifact for artifact in self._artifacts if artifact.name == name
-        )
-        packed_artifact = artifact.pack(*args, **kwargs)
-        self._packed_artifacts.add(packed_artifact)
+        self.artifacts.get(name).pack(*args, **kwargs)
         return self
 
     @pack.classmethod
@@ -804,19 +816,6 @@ class BentoService:
             "BentoService#pack class method is deprecated, use instance method `pack` "
             "instead. e.g.: svc = MyBentoService(); svc.pack('model', model_object)"
         )
-
-    def _load_artifacts(self, path):
-        # For pip installed BentoService, artifacts directory is located at
-        # 'package_path/artifacts/', but for loading from bundle directory, it is
-        # in 'path/{service_name}/artifacts/'
-        if not os.path.isdir(os.path.join(path, ARTIFACTS_DIR_NAME)):
-            artifacts_path = os.path.join(path, self.name, ARTIFACTS_DIR_NAME)
-        else:
-            artifacts_path = os.path.join(path, ARTIFACTS_DIR_NAME)
-
-        for artifact in self._artifacts:
-            packed_artifact = artifact.load(artifacts_path)
-            self._packed_artifacts.add(packed_artifact)
 
     def get_bento_service_metadata_pb(self):
         return SavedBundleConfig(self).get_bento_service_metadata_pb()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -47,7 +47,7 @@ def test_invalid_artifact_type():
         class ExampleBentoService(bentoml.BentoService):
             pass
 
-    assert "only accept list of type BentoServiceArtifact" in str(e.value)
+    assert "only accept list of BentoServiceArtifact" in str(e.value)
 
 
 def test_duplicated_artifact_name():


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

As a follow up to #911, #921, #915, this PR refactored the BentoService base class to adopt the new BentoServiceArtifact API. This enables a couple of ways for users to change BentoService's artifacts, in a more flexible way. This unlocks two key use cases:

The first use case is a faster development workflow with BentoML: save model with artifact class in training pipeline and load it later for creating BentoService class for serving. This makes debugging BentoML code a lot easier:

Step 1, model training:
```python
from sklearn import svm
from sklearn import datasets
from bentoml.artifact import SklearnModelArtifact

if __name__ == "__main__":
    # Load training data
    iris = datasets.load_iris()
    X, y = iris.data, iris.target

    # Model Training
    clf = svm.SVC(gamma='scale')
    clf.fit(X, y)

    btml_model_artifact = SklearnModelArtifact('model')
    btml_model_artifact.pack(clf)
    btml_model_artifact.save('/tmp/temp_bentoml_artifact')
```

Step 2: Build BentoService class with the saved artifact:
```python
from bentoml import env, artifacts, api, BentoService
from bentoml.adapters import DataframeInput
from bentoml.artifact import SklearnModelArtifact

@env(auto_pip_dependencies=True)
@artifacts([SklearnModelArtifact('model')])
class IrisClassifier(BentoService):

    @api(input=DataframeInput())
    def predict(self, df):
        # Optional pre-processing, post-processing code goes here
        return self.artifacts.model.predict(df)

if __name__ == "__main__":
    # Create a iris classifier service instance
    iris_classifier_service = IrisClassifier()

    # load the previously saved artifact
    iris_classifier_service.artifacts.get('model').load('/tmp/temp_bentoml_artifact')

    saved_path = iris_classifier_service.save()
```

The second use case is online learning. There is still some work that needs to be done to make this work properly, especially we need to add a `unload` callback function for each artifact class to implement. But here's what it may look like:

```python
...
    @api(input=DataframeInput())
    def predict(self, df):
           model = svm.SVC(gamma='scale')
           model.fit(df)
           self.artifacts.get('model').pack('model')
           return self.artifacts.model.predict(df)
...
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [x] BentoService (service definition, dependency management, API input/output adapters)
- [x] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
