### PR TITLE
Remove $ from port default argument message

### DIFF
--- a/bentoml/cli/bento_service.py
+++ b/bentoml/cli/bento_service.py
@@ -215,7 +215,7 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         type=click.INT,
         default=BentoAPIServer._DEFAULT_PORT,
         help=f"The port to listen on for the REST api server, "
-        f"default is ${BentoAPIServer._DEFAULT_PORT}",
+        f"default is {BentoAPIServer._DEFAULT_PORT}",
         envvar='BENTOML_PORT',
     )
     @click.option(
@@ -249,7 +249,7 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         type=click.INT,
         default=BentoAPIServer._DEFAULT_PORT,
         help=f"The port to listen on for the REST api server, "
-        f"default is ${BentoAPIServer._DEFAULT_PORT}",
+        f"default is {BentoAPIServer._DEFAULT_PORT}",
         envvar='BENTOML_PORT',
     )
     @click.option(


### PR DESCRIPTION
Just a typo:

```diff
$ bentoml serve --help
...
-  --port INTEGER       The port to listen on for the REST api server, default is $5000
+  --port INTEGER       The port to listen on for the REST api server, default is 5000
...
```

So the diff is basically removing the `$` sign off `serve` and `serve-gunicorn`:

```diff
@@ -215,0 +215,0 @@ def open_api_spec(bento=None):
-        f"default is ${BentoAPIServer._DEFAULT_PORT}",
+       f"default is {BentoAPIServer._DEFAULT_PORT}",

 @@ -249,0 +249,0 @@ def serve(port, bento=None, enable_microbatch=False, run_with_ngrok=False):
-        f"default is ${BentoAPIServer._DEFAULT_PORT}",
+        f"default is {BentoAPIServer._DEFAULT_PORT}",
```