### PR TITLE
Fix git clone depth travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,14 @@ install:
   - "pip install ."
   - "pip install --upgrade .[test]"
 
+git:
+  # BentoML uses the python-versioneer to manage release version tags. On dev branches, as well as
+  # testing environments, the BentoML version specified in the saved bundle, including the
+  # dockerfile and requirements.txt, will be pointing to the last PyPI release, determined by the
+  # latest git tag. Having a shallow git clone depth may lead to problem where it failedto fetch
+  # the commit/tag of the latest BentoML PyPI release.
+  depth: 200
+
 matrix:
   include:
     - os: windows


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

We are seeing some tests falling on Travis, due to the fact that we had over 50 commits on master since last PyPI release.(a new release is coming out soon!)

Here is why we made the change:
```
git:
  # BentoML uses the python-versioneer to manage release version tags. On dev branches, as well as
  # testing environments, the BentoML version specified in the saved bundle, including the
  # dockerfile and requirements.txt, will be pointing to the last PyPI release, determined by the
  # latest git tag. Having a shallow git clone depth may lead to problem where it failedto fetch
  # the commit/tag of the latest BentoML PyPI release.
```

We may want to eventually set this config to `false` to avoid the git clone depth flag completely. This works fine for now as we have a pretty fast release cycle. (sorry we have been a bit slow on making releases the past a few weeks!)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [x] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
