### PR TITLE
Fix local py module tests and pip_pkg/py_module_util refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ __bentoml_tmp_sdist_build
 
 # vscode config
 .vscode/
+
+# temp sdist build generated when bundling local dev branch of BentoML
+__bentoml_tmp_sdist_build

--- a/bentoml/saved_bundle/bundler.py
+++ b/bentoml/saved_bundle/bundler.py
@@ -21,7 +21,7 @@ import logging
 from bentoml.configuration import _is_pip_installed_bentoml
 
 from bentoml.exceptions import BentoMLException
-from bentoml.saved_bundle.py_module_utils import copy_used_py_modules
+from bentoml.saved_bundle.py_module_utils import copy_local_py_modules
 from bentoml.saved_bundle.templates import (
     BENTO_SERVICE_BUNDLE_SETUP_PY_TEMPLATE,
     MANIFEST_IN_TEMPLATE,
@@ -106,7 +106,7 @@ def save_to_dir(bento_service, path, version=None, silent=False):
     # TODO: add bentoml.find_packages helper for more fine grained control over this
     # process, e.g. packages=find_packages(base, [], exclude=[], used_module_only=True)
     # copy over all custom model code
-    module_name, module_file = copy_used_py_modules(
+    module_name, module_file = copy_local_py_modules(
         bento_service.__class__.__module__, os.path.join(path, bento_service.name)
     )
 
@@ -213,8 +213,8 @@ def _bundle_local_bentoml_if_installed_from_source(target_path):
     # development mode via "pip install --editable ."
     if not _is_pip_installed_bentoml() and os.path.isfile(bentoml_setup_py):
         logger.info(
-            "Detect BentoML installed in development model, copying local BentoML "
-            "module file to target saved bundle path"
+            "Detected non-PyPI-released BentoML installed, copying local BentoML module"
+            "files to target saved bundle path.."
         )
 
         # Create tmp directory inside bentoml module for storing the bundled
@@ -232,7 +232,7 @@ def _bundle_local_bentoml_if_installed_from_source(target_path):
 
         sandbox.run_setup(
             bentoml_setup_py,
-            ['sdist', '--format', 'gztar', '--dist-dir', bundle_dir_name],
+            ['-q', 'sdist', '--format', 'gztar', '--dist-dir', bundle_dir_name],
         )
 
         # copy the generated targz to saved bundle directory and remove it from

--- a/bentoml/saved_bundle/pip_pkg.py
+++ b/bentoml/saved_bundle/pip_pkg.py
@@ -82,7 +82,10 @@ class ModuleManager(object):
         import pkg_resources
 
         for dist in pkg_resources.working_set:  # pylint: disable=not-an-iterable
-            self.nonlocal_package_path.add(dist.module_path)
+            if os.path.realpath(dist.module_path) != os.getcwd():
+                # add to nonlocal_package path only if it's not current directory
+                self.nonlocal_package_path.add(dist.module_path)
+
             self.pip_pkg_map[dist._key] = dist._version
             for mn in dist._get_metadata("top_level.txt"):
                 if dist._key != "setuptools":

--- a/bentoml/saved_bundle/py_module_utils.py
+++ b/bentoml/saved_bundle/py_module_utils.py
@@ -65,11 +65,11 @@ def _get_module_relative_file_path(module_name, module_file):
     return relative_path
 
 
-def copy_used_py_modules(target_module, destination):
-    """
-    bundle given module, and all its dependencies within top level package,
-    and copy all source files to destination path, essentially creating
-    a source distribution of target_module
+def copy_local_py_modules(target_module, destination):
+    """Find all local python module dependencies of target_module, and copy all the
+    local module python files to the destination directory while maintaining the module
+    structure unchanged to ensure all imports in target_module still works when loading
+    from the destination directory again
     """
 
     # When target_module is a string, try import it
@@ -95,7 +95,7 @@ def copy_used_py_modules(target_module, destination):
 
     target_module_file = _get_module_src_file(target_module)
     logger.debug(
-        "copy_used_py_modules target_module_name: %s, target_module_file: %s",
+        "copy_local_py_modules target_module_name: %s, target_module_file: %s",
         target_module_name,
         target_module_file,
     )
@@ -112,13 +112,12 @@ def copy_used_py_modules(target_module, destination):
         )
 
     # Find all non pip installed modules must be packaged for target module to run
-    finder = modulefinder.ModuleFinder(
-        excludes=['bentoml'] + get_all_pip_installed_modules()
-    )
-    # NOTE: This method could take a few seconds to run
+    exclude_modules = ['bentoml'] + get_all_pip_installed_modules()
+    finder = modulefinder.ModuleFinder(excludes=exclude_modules)
+
     try:
         logger.debug(
-            "Searching for dependant modules of %s:%s",
+            "Searching for local dependant modules of %s:%s",
             target_module_name,
             target_module_file,
         )
@@ -148,51 +147,20 @@ def copy_used_py_modules(target_module, destination):
         # with current python version. And that may result in SyntaxError.
         pass
 
-    # extra site-packages or dist-packages directory
-    site_or_dist_package_path = []
-
-    for path in sys.path:
-        folder_name = os.path.split(path)[1]
-        # exclude pypi/conda/system installed packages
-        if (
-            "site-packages" in path
-            or "anaconda" in path
-            or path.endswith("packages")
-            or folder_name == "bin"
-            or folder_name.startswith("lib")
-            or folder_name.startswith("python")
-            or folder_name.startswith("plat")
-        ):
-            site_or_dist_package_path.append(path)
-    # prefix used to find installed Python library
-    site_or_dist_package_path.append(sys.prefix)
-    # prefix used to find machine-specific Python library
-    try:
-        site_or_dist_package_path.append(sys.base_prefix)
-    except AttributeError:
-        # ignore when in PY2 there is no sys.base_prefix
-        pass
-    logger.debug(
-        "Ignoring deps within local site-packages path: %s", site_or_dist_package_path
-    )
+    if finder.badmodules:
+        logger.debug(
+            "Find bad module imports that can not be parsed properly: %s",
+            finder.badmodules.keys(),
+        )
 
     # Look for dependencies that are not distributed python package, but users'
     # local python code, all other dependencies must be defined with @env
     # decorator when creating a new BentoService class
     user_packages_and_modules = {}
     for name, module in finder.modules.items():
+        logger.debug(f"### {name}, {module.__file__}")
         if hasattr(module, "__file__") and module.__file__ is not None:
-            module_src_file = _get_module_src_file(module)
-
-            is_module_in_site_or_dist_package = False
-            for path in site_or_dist_package_path:
-                if module_src_file.startswith(path):
-                    is_module_in_site_or_dist_package = True
-                    break
-
-            if not is_module_in_site_or_dist_package:
-                logger.debug("User local module deps found: %s", name)
-                user_packages_and_modules[name] = module
+            user_packages_and_modules[name] = module
 
     # Remove "__main__" module, if target module is loaded as __main__, it should
     # be in module_files as (module_name, module_file) in current context

--- a/bentoml/saved_bundle/py_module_utils.py
+++ b/bentoml/saved_bundle/py_module_utils.py
@@ -158,7 +158,6 @@ def copy_local_py_modules(target_module, destination):
     # decorator when creating a new BentoService class
     user_packages_and_modules = {}
     for name, module in finder.modules.items():
-        logger.debug(f"### {name}, {module.__file__}")
         if hasattr(module, "__file__") and module.__file__ is not None:
             user_packages_and_modules[name] = module
 


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

Fix the unit test `pytest  tests/test_bundle_local_dependencies.py` where BentoML failed to package local dependencies under the `tests` module.

This means that users defining their BentoService within a python package may run into the same problem, due to BentoML ignoring modules found in current directory, which is recognized as a distribution in `pkg_resources.working_set`.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [x] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
