### PR TITLE
[Internal] Refactor Input Adapters

### DIFF
--- a/bentoml/adapters/base_input.py
+++ b/bentoml/adapters/base_input.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable
-
+from typing import Iterable, TypeVar, Generic, Dict
 
 from bentoml.marshal.utils import SimpleResponse, SimpleRequest, BATCH_REQUEST_HEADER
 
+I = TypeVar("I")
 
-class BaseInputAdapter:
-    """InputAdapter is an abstraction layer between user defined API callback function
+
+class BaseInputAdapter(Generic[I]):
+    """
+    InputAdapter is an abstraction layer between user defined API callback function
     and prediction request input in a variety of different forms, such as HTTP request
     body, command line arguments or AWS Lambda event object.
     """
@@ -29,10 +31,10 @@ class BaseInputAdapter:
     BATCH_MODE_SUPPORTED = False
 
     def __init__(self, output_adapter=None, http_input_example=None, **base_config):
-        '''
+        """
         base_configs:
             - is_batch_input
-        '''
+        """
         self._config = base_config
         self._output_adapter = output_adapter
         self._http_input_example = http_input_example
@@ -56,19 +58,19 @@ class BaseInputAdapter:
             self._output_adapter = DefaultOutput()
         return self._output_adapter
 
-    def handle_request(self, request, func):
+    def handle_request(self, headers: Dict[str, str], body) -> I:
         """Handles an HTTP request, convert it into corresponding data
         format that user API function is expecting, and return API
         function result as the HTTP response to client
 
-        :param request: Flask request object
-        :param func: user API function
+        :param headers: The request's HTTP headers
+        :param body: The request's body
         """
         raise NotImplementedError
 
     def handle_batch_request(
         self, requests: Iterable[SimpleRequest], func
-    ) -> Iterable[SimpleResponse]:
+    ) -> Iterable[I]:
         """Handles an HTTP request, convert it into corresponding data
         format that user API function is expecting, and return API
         function result as the HTTP response to client

--- a/bentoml/adapters/base_input.py
+++ b/bentoml/adapters/base_input.py
@@ -16,10 +16,10 @@ from typing import Iterable, TypeVar, Generic, Dict
 
 from bentoml.marshal.utils import SimpleResponse, SimpleRequest, BATCH_REQUEST_HEADER
 
-I = TypeVar("I")
+Input = TypeVar("Input")
 
 
-class BaseInputAdapter(Generic[I]):
+class BaseInputAdapter(Generic[Input]):
     """
     InputAdapter is an abstraction layer between user defined API callback function
     and prediction request input in a variety of different forms, such as HTTP request
@@ -30,13 +30,12 @@ class BaseInputAdapter(Generic[I]):
 
     BATCH_MODE_SUPPORTED = False
 
-    def __init__(self, output_adapter=None, http_input_example=None, **base_config):
+    def __init__(self, http_input_example=None, **base_config):
         """
         base_configs:
             - is_batch_input
         """
         self._config = base_config
-        self._output_adapter = output_adapter
         self._http_input_example = http_input_example
 
     @property
@@ -50,15 +49,7 @@ class BaseInputAdapter(Generic[I]):
             return request.parsed_headers[BATCH_REQUEST_HEADER] != 'false'
         return self.config.get("is_batch_input", False)
 
-    @property
-    def output_adapter(self):
-        if self._output_adapter is None:
-            from .default_output import DefaultOutput
-
-            self._output_adapter = DefaultOutput()
-        return self._output_adapter
-
-    def handle_request(self, headers: Dict[str, str], body) -> I:
+    def handle_request(self, headers: Dict[str, str], body) -> Input:
         """Handles an HTTP request, convert it into corresponding data
         format that user API function is expecting, and return API
         function result as the HTTP response to client
@@ -69,8 +60,8 @@ class BaseInputAdapter(Generic[I]):
         raise NotImplementedError
 
     def handle_batch_request(
-        self, requests: Iterable[SimpleRequest], func
-    ) -> Iterable[I]:
+            self, requests: Iterable[SimpleRequest], func
+    ) -> Iterable[Input]:
         """Handles an HTTP request, convert it into corresponding data
         format that user API function is expecting, and return API
         function result as the HTTP response to client
@@ -106,7 +97,13 @@ class BaseInputAdapter(Generic[I]):
         :return: OpenAPI json schema for the HTTP API endpoint created with this input
                  adapter
         """
-        return {"application/json": {"schema": {"type": "object"}}}
+        return {
+            "application/json": {
+                "schema": {
+                    "type": "object"
+                }
+            }
+        }
 
     @property
     def pip_dependencies(self):

--- a/bentoml/adapters/base_input.py
+++ b/bentoml/adapters/base_input.py
@@ -14,7 +14,7 @@
 
 from typing import Iterable, TypeVar, Generic, Dict
 
-from bentoml.marshal.utils import SimpleResponse, SimpleRequest, BATCH_REQUEST_HEADER
+from bentoml.marshal.utils import SimpleRequest, BATCH_REQUEST_HEADER
 
 Input = TypeVar("Input")
 
@@ -31,10 +31,10 @@ class BaseInputAdapter(Generic[Input]):
     BATCH_MODE_SUPPORTED = False
 
     def __init__(self, http_input_example=None, **base_config):
-        """
+        '''
         base_configs:
             - is_batch_input
-        """
+        '''
         self._config = base_config
         self._http_input_example = http_input_example
 
@@ -44,7 +44,7 @@ class BaseInputAdapter(Generic[Input]):
             self._config = {}
         return self._config
 
-    def is_batch_request(self, request):
+    def is_batch_request(self, request: SimpleRequest):
         if BATCH_REQUEST_HEADER in request.parsed_headers:
             return request.parsed_headers[BATCH_REQUEST_HEADER] != 'false'
         return self.config.get("is_batch_input", False)
@@ -60,7 +60,7 @@ class BaseInputAdapter(Generic[Input]):
         raise NotImplementedError
 
     def handle_batch_request(
-            self, requests: Iterable[SimpleRequest], func
+        self, requests: Iterable[SimpleRequest], func
     ) -> Iterable[Input]:
         """Handles an HTTP request, convert it into corresponding data
         format that user API function is expecting, and return API
@@ -97,13 +97,7 @@ class BaseInputAdapter(Generic[Input]):
         :return: OpenAPI json schema for the HTTP API endpoint created with this input
                  adapter
         """
-        return {
-            "application/json": {
-                "schema": {
-                    "type": "object"
-                }
-            }
-        }
+        return {"application/json": {"schema": {"type": "object"}}}
 
     @property
     def pip_dependencies(self):

--- a/bentoml/adapters/clipper_input.py
+++ b/bentoml/adapters/clipper_input.py
@@ -39,7 +39,7 @@ class ClipperInput(BaseInputAdapter):
         # to a clipper cluster, not required by the API Server itself
         return []
 
-    def handle_request(self, request, func):
+    def handle_request(self, request):
         raise NotImplementedError(
             "ClipperInput does not support handling REST API prediction request"
         )

--- a/bentoml/adapters/dataframe_input.py
+++ b/bentoml/adapters/dataframe_input.py
@@ -144,7 +144,7 @@ class DataframeInput(BaseInputAdapter):
 
         return default
 
-    def handle_request(self, request: flask.Request, func):
+    def handle_request(self, request: flask.Request):
         if request.content_type == "text/csv":
             csv_string = StringIO(request.get_data(as_text=True))
             df = pd.read_csv(csv_string)

--- a/bentoml/adapters/fastai_image_input.py
+++ b/bentoml/adapters/fastai_image_input.py
@@ -156,7 +156,7 @@ class FastaiImageInput(BaseInputAdapter):
     def handle_batch_request(self, requests, func):
         raise NotImplementedError
 
-    def handle_request(self, request, func):
+    def handle_request(self, request):
         input_streams = []
         for filename in self.input_names:
             file = request.files.get(filename)

--- a/bentoml/adapters/file_input.py
+++ b/bentoml/adapters/file_input.py
@@ -113,7 +113,7 @@ class FileInput(BaseInputAdapter):
         results = func(input_datas) if input_datas else []
         return self.output_adapter.to_batch_response(results, ids, requests)
 
-    def handle_request(self, request, func):
+    def handle_request(self, request):
         """Handle http request that has one file. It will convert file into a
         BytesIO object for the function to consume.
 

--- a/bentoml/adapters/image_input.py
+++ b/bentoml/adapters/image_input.py
@@ -183,20 +183,15 @@ class ImageInput(BaseInputAdapter):
         results = func(input_datas) if input_datas else []
         return self.output_adapter.to_batch_response(results, ids, requests)
 
-    def handle_request(self, request, func):
-        """Handle http request that has one image file. It will convert image into a
+    def handle_request(self, headers, body):
+        """
+        Handle http request that has one image file. It will convert image into a
         ndarray for the function to consume.
 
-        Args:
-            request: incoming request object.
-            func: function that will take ndarray as its arg.
-            options: configuration for handling request object.
-        Return:
-            response object
+        :param headers: the request's HTTP HEADERS
+        :param body: the request body
         """
-        input_data = self._load_image_data(request)
-        result = func((input_data,))[0]
-        return self.output_adapter.to_response(result, request)
+        return self._load_image_data(Request.from_values(headers=headers, data=body))
 
     def handle_cli(self, args, func):
         parser = argparse.ArgumentParser()

--- a/bentoml/adapters/image_input.py
+++ b/bentoml/adapters/image_input.py
@@ -26,6 +26,7 @@ from bentoml.utils.lazy_loader import LazyLoader
 from bentoml.marshal.utils import SimpleRequest, SimpleResponse
 from bentoml.exceptions import BadInput
 from bentoml.adapters.base_input import BaseInputAdapter
+from numpy.core import ndarray
 
 # BentoML optional dependencies, using lazy load to avoid ImportError
 imageio = LazyLoader('imageio', globals(), 'imageio')
@@ -55,7 +56,7 @@ def get_default_accept_image_formats():
     ]
 
 
-class ImageInput(BaseInputAdapter):
+class ImageInput(BaseInputAdapter[ndarray]):
     """Transform incoming image data from http request, cli or lambda event into numpy
     array.
 
@@ -184,8 +185,7 @@ class ImageInput(BaseInputAdapter):
         return self.output_adapter.to_batch_response(results, ids, requests)
 
     def handle_request(self, headers, body):
-        """
-        Handle http request that has one image file. It will convert image into a
+        """Handle http request that has one image file. It will convert image into a
         ndarray for the function to consume.
 
         :param headers: the request's HTTP HEADERS

--- a/bentoml/adapters/json_input.py
+++ b/bentoml/adapters/json_input.py
@@ -55,7 +55,7 @@ class JsonInput(BaseInputAdapter):
     def __init__(self, is_batch_input=False, **base_kwargs):
         super(JsonInput, self).__init__(is_batch_input=is_batch_input, **base_kwargs)
 
-    def handle_request(self, request: flask.Request, func):
+    def handle_request(self, request: flask.Request):
         if request.content_type != "application/json":
             raise BadInput(
                 "Request content-type must be 'application/json' for this "

--- a/bentoml/adapters/legacy_image_input.py
+++ b/bentoml/adapters/legacy_image_input.py
@@ -138,7 +138,7 @@ class LegacyImageInput(BaseInputAdapter):
     def handle_batch_request(self, requests, func):
         raise NotImplementedError
 
-    def handle_request(self, request, func):
+    def handle_request(self, request):
         """Handle http request that has image file/s. It will convert image into a
         ndarray for the function to consume.
 

--- a/bentoml/adapters/legacy_json_input.py
+++ b/bentoml/adapters/legacy_json_input.py
@@ -37,7 +37,7 @@ class LegacyJsonInput(BaseInputAdapter):
             is_batch_input=is_batch_input, **base_kwargs
         )
 
-    def handle_request(self, request: flask.Request, func):
+    def handle_request(self, request: flask.Request):
         if request.content_type.lower() == "application/json":
             parsed_json = json.loads(request.get_data(as_text=True))
         else:

--- a/bentoml/adapters/multi_image_input.py
+++ b/bentoml/adapters/multi_image_input.py
@@ -98,7 +98,7 @@ class MultiImageInput(BaseInputAdapter):
             accepted_image_formats or get_default_accept_image_formats()
         )
 
-    def handle_request(self, request: Request, func):
+    def handle_request(self, request: Request):
         files = {
             name: self.read_file(file.filename, file.stream)
             for (name, file) in request.files.items()

--- a/bentoml/adapters/pytorch_tensor_input.py
+++ b/bentoml/adapters/pytorch_tensor_input.py
@@ -20,7 +20,7 @@ class PytorchTensorInput(BaseInputAdapter):
     Tensor input adapter for Pytorch models
     """
 
-    def handle_request(self, request, func):
+    def handle_request(self, request):
         raise NotImplementedError
 
     def handle_cli(self, args, func):

--- a/bentoml/adapters/tensorflow_tensor_input.py
+++ b/bentoml/adapters/tensorflow_tensor_input.py
@@ -141,7 +141,7 @@ class TfTensorInput(BaseInputAdapter):
             merged_result, slices=slices, fallbacks=responses, requests=requests
         )
 
-    def handle_request(self, request, func):
+    def handle_request(self, request):
         """Handle http request that has jsonlized tensorflow tensor. It will convert it
         into a tf tensor for the function to consume.
 

--- a/bentoml/marshal/utils.py
+++ b/bentoml/marshal/utils.py
@@ -10,10 +10,10 @@ BATCH_REQUEST_HEADER = bentoml_config("apiserver").get("batch_request_header")
 
 
 class SimpleRequest(NamedTuple):
-    '''
+    """
     headers: tuple of key value pairs in bytes
     data: str
-    '''
+    """
 
     headers: tuple
     data: str

--- a/bentoml/marshal/utils.py
+++ b/bentoml/marshal/utils.py
@@ -10,10 +10,10 @@ BATCH_REQUEST_HEADER = bentoml_config("apiserver").get("batch_request_header")
 
 
 class SimpleRequest(NamedTuple):
-    """
+    '''
     headers: tuple of key value pairs in bytes
     data: str
-    """
+    '''
 
     headers: tuple
     data: str

--- a/bentoml/saved_bundle/config.py
+++ b/bentoml/saved_bundle/config.py
@@ -45,13 +45,13 @@ def _get_apis_list(bento_service):
         api_obj = {
             "name": api.name,
             "docs": api.doc,
-            "input_type": api.handler.__class__.__name__,
-            "output_type": api.handler.output_adapter.__class__.__name__,
+            "input_type": api.input_adapter.__class__.__name__,
+            "output_type": api.input_adapter.output_adapter.__class__.__name__,
             "mb_max_batch_size": api.mb_max_batch_size,
             "mb_max_latency": api.mb_max_latency,
         }
-        if api.handler.config:
-            api_obj["input_config"] = api.handler.config
+        if api.input_adapter.config:
+            api_obj["input_config"] = api.input_adapter.config
         if api.output_adapter.config:
             api_obj["output_config"] = api.output_adapter.config
         result.append(api_obj)

--- a/bentoml/server/api_server.py
+++ b/bentoml/server/api_server.py
@@ -23,13 +23,13 @@ from flask import Flask, jsonify, Response, request, make_response, send_from_di
 from werkzeug.utils import secure_filename
 from werkzeug.exceptions import BadRequest, NotFound
 
-from bentoml import config
+from bentoml import config, BentoService
 from bentoml.configuration import get_debug_mode
 from bentoml.exceptions import BentoMLException
 from bentoml.server.instruments import InstrumentMiddleware
 from bentoml.server.open_api import get_open_api_spec_json
 from bentoml.server import trace
-
+from bentoml.service import InferenceAPI
 
 CONTENT_TYPE_LATEST = str("text/plain; version=0.0.4; charset=utf-8")
 
@@ -89,7 +89,7 @@ class BentoAPIServer:
     _DEFAULT_PORT = config("apiserver").getint("default_port")
     _MARSHAL_FLAG = config("marshal_server").get("marshal_request_header_flag")
 
-    def __init__(self, bento_service, port=_DEFAULT_PORT, app_name=None):
+    def __init__(self, bento_service: BentoService, port=_DEFAULT_PORT, app_name=None):
         app_name = bento_service.name if app_name is None else app_name
 
         self.port = port
@@ -262,46 +262,10 @@ class BentoAPIServer:
                 rule="/{}".format(api.name),
                 endpoint=api.name,
                 view_func=route_function,
-                methods=api.handler.HTTP_METHODS,
+                methods=api.input_adapter.HTTP_METHODS,
             )
 
-    @staticmethod
-    def log_image(req, request_id):
-        if not config('logging').getboolean('log_request_image_files'):
-            return []
-
-        log_folder = config('logging').get('base_log_dir')
-
-        all_paths = []
-
-        if req.content_type and req.content_type.startswith('image/'):
-            filename = '{timestamp}-{request_id}.{ext}'.format(
-                timestamp=int(time.time()),
-                request_id=request_id,
-                ext=req.content_type[len('image/') :],
-            )
-            path = os.path.join(log_folder, filename)
-            all_paths.append(path)
-            with open(path, 'wb') as f:
-                f.write(req.get_data())
-
-        for name in req.files:
-            file = req.files[name]
-            if file and file.filename:
-                orig_filename = secure_filename(file.filename)
-                filename = '{timestamp}-{request_id}-{orig_filename}'.format(
-                    timestamp=int(time.time()),
-                    request_id=request_id,
-                    orig_filename=orig_filename,
-                )
-                path = os.path.join(log_folder, filename)
-                all_paths.append(path)
-                file.save(path)
-                file.stream.seek(0)
-
-        return all_paths
-
-    def bento_service_api_func_wrapper(self, api):
+    def bento_service_api_func_wrapper(self, api: InferenceAPI):
         """
         Create api function for flask route, it wraps around user defined API
         callback and adapter class, and adds request logging and instrument metrics
@@ -311,20 +275,15 @@ class BentoAPIServer:
         service_version = self.bento_service.version
 
         def api_func():
-            # Log image files in request if there is any
-            image_paths = self.log_image(request, request_id)
-
-            # _request_to_json parses request as JSON; in case errors, it raises
-            # a 400 exception. (consider 4xx before 5xx.)
-            request_for_log = _request_to_json(request)
-
             # handle_request may raise 4xx or 5xx exception.
             try:
                 if request.headers.get(self._MARSHAL_FLAG):
                     response_body = api.handle_batch_request(request)
                     response = make_response(response_body)
                 else:
-                    response = api.handle_request(request)
+                    function_input = api.input_adapter.handle_request(request)
+                    result = api.func(function_input)
+                    response = api.output_adapter.to_response(result, request)
             except BentoMLException as e:
                 log_exception(sys.exc_info())
 
@@ -348,23 +307,6 @@ class BentoAPIServer:
                     'request, find the error details in server logs',
                     500,
                 )
-
-            request_log = {
-                "request_id": request_id,
-                "service_name": service_name,
-                "service_version": service_version,
-                "api": api.name,
-                "request": request_for_log,
-                "response_code": response.status_code,
-            }
-
-            if len(image_paths) > 0:
-                request_log['image_paths'] = image_paths
-
-            if 200 <= response.status_code < 300:
-                request_log['response'] = response.response
-
-            prediction_logger.info(request_log)
 
             response.headers["request_id"] = request_id
 

--- a/bentoml/server/api_server.py
+++ b/bentoml/server/api_server.py
@@ -167,6 +167,7 @@ class BentoAPIServer:
         return Response(response="\n", status=200, mimetype="text/plain")
 
     def metrics_view_func(self):
+        # noinspection PyProtectedMember
         from prometheus_client import generate_latest
 
         return generate_latest()
@@ -269,16 +270,15 @@ class BentoAPIServer:
         if not config('logging').getboolean('log_request_image_files'):
             return []
 
-        img_prefix = 'image/'
         log_folder = config('logging').get('base_log_dir')
 
         all_paths = []
 
-        if req.content_type and req.content_type.startswith(img_prefix):
+        if req.content_type and req.content_type.startswith('image/'):
             filename = '{timestamp}-{request_id}.{ext}'.format(
                 timestamp=int(time.time()),
                 request_id=request_id,
-                ext=req.content_type[len(img_prefix) :],
+                ext=req.content_type[len('image/') :],
             )
             path = os.path.join(log_folder, filename)
             all_paths.append(path)

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -55,7 +55,15 @@ class InferenceAPI(object):
     """
 
     def __init__(
-        self, service, name, doc, input_adapter, func, mb_max_latency, mb_max_batch_size
+        self,
+        service,
+        name,
+        doc,
+        input_adapter,
+        func,
+        output_adapter,
+        mb_max_latency,
+        mb_max_batch_size,
     ):
         """
         :param service: ref to service containing this API
@@ -78,6 +86,7 @@ class InferenceAPI(object):
         self._name = name
         self._handler = input_adapter
         self._func = func
+        self._output_adapter = output_adapter
         self._wrapped_func = None
         self.mb_max_latency = mb_max_latency
         self.mb_max_batch_size = mb_max_batch_size
@@ -113,7 +122,7 @@ class InferenceAPI(object):
         return self._doc
 
     @property
-    def handler(self):
+    def input_adapter(self) -> BaseInputAdapter:
         """
         handler is a deprecated concept, we are moving it to the new input/output
         adapter interface. Currently this `handler` property returns the input adapter
@@ -122,11 +131,11 @@ class InferenceAPI(object):
         return self._handler
 
     @property
-    def output_adapter(self):
+    def output_adapter(self) -> BaseOutputAdapter:
         """
         :return: the output adapter of this inference API
         """
-        return self.handler.output_adapter
+        return self._output_adapter
 
     @cached_property
     def func(self):
@@ -148,13 +157,15 @@ class InferenceAPI(object):
         """
         :return: the HTTP API request schema in OpenAPI/Swagger format
         """
-        schema = self.handler.request_schema
+        schema = self.input_adapter.request_schema
         if schema.get('application/json'):
-            schema.get('application/json')['example'] = self.handler._http_input_example
+            schema.get('application/json')[
+                'example'
+            ] = self.input_adapter._http_input_example
         return schema
 
     def handle_request(self, request: flask.Request):
-        return self.handler.handle_request(request, self.func)
+        return self.input_adapter.handle_request(request)
 
     def handle_batch_request(self, request: flask.Request):
         from bentoml.marshal.utils import DataLoader
@@ -163,23 +174,23 @@ class InferenceAPI(object):
 
         with trace(
             service_name=self.__class__.__name__,
-            span_name=f"call `{self.handler.__class__.__name__}`",
+            span_name=f"call `{self.input_adapter.__class__.__name__}`",
         ):
-            responses = self.handler.handle_batch_request(requests, self.func)
+            responses = self.input_adapter.handle_batch_request(requests, self.func)
 
         return DataLoader.merge_responses(responses)
 
     def handle_cli(self, args):
-        return self.handler.handle_cli(args, self.func)
+        return self.input_adapter.handle_cli(args, self.func)
 
     def handle_aws_lambda_event(self, event):
-        return self.handler.handle_aws_lambda_event(event, self.func)
+        return self.input_adapter.handle_aws_lambda_event(event, self.func)
 
 
 def validate_inference_api_name(api_name):
     if not isidentifier(api_name):
         raise InvalidArgument(
-            "Invalid API name: '{}', a valid identifier must contains only letters,"
+            "Invalid API name: '{}', a valid identifier may only contain letters,"
             " numbers, underscores and not starting with a number.".format(api_name)
         )
 
@@ -534,7 +545,9 @@ class BentoService:
         self._env = self.__class__._env or BentoServiceEnv(self.name)
 
         for api in self._inference_apis:
-            self._env.add_pip_dependencies_if_missing(api.handler.pip_dependencies)
+            self._env.add_pip_dependencies_if_missing(
+                api.input_adapter.pip_dependencies
+            )
             self._env.add_pip_dependencies_if_missing(
                 api.output_adapter.pip_dependencies
             )

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -386,6 +386,9 @@ def ver_decorator(major, minor):
     'Patch' is provided(or auto generated) when calling BentoService#save,
     while 'Major' and 'Minor' can be defined with '@ver' decorator
 
+    >>>  from bentoml import ver, artifacts
+    >>>  from bentoml.artifact import PickleArtifact
+    >>>
     >>>  @ver(major=1, minor=4)
     >>>  @artifacts([PickleArtifact('model')])
     >>>  class MyMLService(BentoService):
@@ -407,7 +410,7 @@ def ver_decorator(major, minor):
     return decorator
 
 
-def _validate_version_str(version_str):
+def validate_version_str(version_str):
     """
     Validate that version str format is either a simple version string that:
         * Consist of only ALPHA / DIGIT / "-" / "." / "_"
@@ -549,7 +552,7 @@ class BentoService:
             if hasattr(function, "_is_api"):
                 api_name = getattr(function, "_api_name")
                 api_doc = getattr(function, "_api_doc")
-                handler = getattr(function, "_handler")
+                input_adapter = getattr(function, "_input_adapter")
                 mb_max_latency = getattr(function, "_mb_max_latency")
                 mb_max_batch_size = getattr(function, "_mb_max_batch_size")
 
@@ -561,7 +564,7 @@ class BentoService:
                         self,
                         api_name,
                         api_doc,
-                        input_adapter=handler,
+                        input_adapter=input_adapter,
                         func=func,
                         mb_max_latency=mb_max_latency,
                         mb_max_batch_size=mb_max_batch_size,
@@ -671,7 +674,7 @@ class BentoService:
                 [str(self._version_major), str(self._version_minor), version_str]
             )
 
-        _validate_version_str(version_str)
+        validate_version_str(version_str)
 
         if self.__class__._bento_service_bundle_version is not None:
             logger.warning(

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -31,7 +31,7 @@ from bentoml.utils import isidentifier
 from bentoml.utils.hybridmethod import hybridmethod
 from bentoml.exceptions import NotFound, InvalidArgument, BentoMLException
 from bentoml.server import trace
-
+from bentoml.adapters import BaseInputAdapter, BaseOutputAdapter, DefaultOutput
 
 ARTIFACTS_DIR_NAME = "artifacts"
 DEFAULT_MAX_LATENCY = config("marshal_server").getint("default_max_latency")
@@ -55,14 +55,14 @@ class InferenceAPI(object):
     """
 
     def __init__(
-        self, service, name, doc, handler, func, mb_max_latency, mb_max_batch_size
+        self, service, name, doc, input_adapter, func, mb_max_latency, mb_max_batch_size
     ):
         """
         :param service: ref to service containing this API
         :param name: API name
         :param doc: the user facing document of this inference API, default to the
             docstring of the inference API function
-        :param handler: A InputAdapter that transforms HTTP Request and/or
+        :param input_adapter: A InputAdapter that transforms HTTP Request and/or
             CLI options into parameters for API func
         :param func: the user-defined API callback function, this is
             typically the 'predict' method on a model
@@ -76,7 +76,7 @@ class InferenceAPI(object):
         """
         self._service = service
         self._name = name
-        self._handler = handler
+        self._handler = input_adapter
         self._func = func
         self._wrapped_func = None
         self.mb_max_latency = mb_max_latency
@@ -86,8 +86,8 @@ class InferenceAPI(object):
             # generate a default doc string for this inference API
             doc = (
                 f"BentoService inference API '{self.name}', input: "
-                f"'{type(handler).__name__}', output: "
-                f"'{type(handler.output_adapter).__name__}'"
+                f"'{type(input_adapter).__name__}', output: "
+                f"'{type(input_adapter.output_adapter).__name__}'"
             )
         self._doc = doc
 
@@ -191,12 +191,12 @@ def validate_inference_api_name(api_name):
 
 def api_decorator(
     *args,
-    input=None,
-    output=None,
-    api_name=None,
-    api_doc=None,
-    mb_max_batch_size=DEFAULT_MAX_BATCH_SIZE,
-    mb_max_latency=DEFAULT_MAX_LATENCY,
+    input: BaseInputAdapter = None,
+    output: BaseOutputAdapter = None,
+    api_name: str = None,
+    api_doc: str = None,
+    mb_max_batch_size: int = DEFAULT_MAX_BATCH_SIZE,
+    mb_max_latency: int = DEFAULT_MAX_LATENCY,
     **kwargs,
 ):  # pylint: disable=redefined-builtin
     """
@@ -231,52 +231,38 @@ def api_decorator(
     >>>     @api(input=DataframeInput(input_json_orient='records'))
     >>>     def identity(self, df):
     >>>         # user-defined callback function that process inference requests
-
-
-    Deprecated syntax before version 0.8.0:
-
-    >>> from bentoml import BentoService, api
-    >>> from bentoml.handlers import JsonHandler, DataframeHandler  # deprecated
-    >>>
-    >>> class FraudDetectionAndIdentityService(BentoService):
-    >>>
-    >>>     @api(JsonHandler)  # deprecated
-    >>>     def fraud_detect(self, parsed_json):
-    >>>         # do something
-    >>>
-    >>>     @api(DataframeHandler, input_json_orient='records')  # deprecated
-    >>>     def identity(self, df):
-    >>>         # do something
-
     """
-
-    from bentoml.adapters import BaseInputAdapter
 
     def decorator(func):
         _api_name = func.__name__ if api_name is None else api_name
         validate_inference_api_name(_api_name)
 
         if input is None:
-            # support bentoml<=0.7
+            # Support passing the desired adapter without instantiation
             if not args or not (
                 inspect.isclass(args[0]) and issubclass(args[0], BaseInputAdapter)
             ):
                 raise InvalidArgument(
                     "BentoService @api decorator first parameter must "
-                    "be class derived from bentoml.adapters.BaseInputAdapter"
+                    "be an instance of a class derived from "
+                    "bentoml.adapters.BaseInputAdapter "
                 )
 
-            handler = args[0](*args[1:], output_adapter=output, **kwargs)
+            # noinspection PyPep8Naming
+            InputAdapter = args[0]
+            input_adapter = InputAdapter(*args[1:], **kwargs)
+            output_adapter = DefaultOutput()
         else:
             assert isinstance(input, BaseInputAdapter), (
-                "API input parameter must be an instance of any classes inherited from "
+                "API input parameter must be an instance of a class derived from "
                 "bentoml.adapters.BaseInputAdapter"
             )
-            handler = input
-            handler._output_adapter = output
+            input_adapter = input
+            output_adapter = output
 
         setattr(func, "_is_api", True)
-        setattr(func, "_handler", handler)
+        setattr(func, "_input_adapter", input_adapter)
+        setattr(func, "_output_adapter", output_adapter)
         setattr(func, "_api_name", _api_name)
         setattr(func, "_api_doc", api_doc)
         setattr(func, "_mb_max_batch_size", mb_max_batch_size)
@@ -437,7 +423,7 @@ def _validate_version_str(version_str):
         raise InvalidArgument(
             'Invalid BentoService version: "{}", it can only consist'
             ' ALPHA / DIGIT / "-" / "." / "_", and must be less than'
-            "128 characthers".format(version_str)
+            "128 characters".format(version_str)
         )
 
     if version_str.lower() == "latest":
@@ -575,7 +561,7 @@ class BentoService:
                         self,
                         api_name,
                         api_doc,
-                        handler=handler,
+                        input_adapter=handler,
                         func=func,
                         mb_max_latency=mb_max_latency,
                         mb_max_batch_size=mb_max_batch_size,

--- a/bentoml/utils/benchmark.py
+++ b/bentoml/utils/benchmark.py
@@ -43,9 +43,9 @@ def percentile(data, pers):
 
 
 class DynamicBucketMerge:
-    """
+    '''
     real time speed stat
-    """
+    '''
 
     def __init__(self, sample_range=1, bucket_num=10):
         self.bucket_num = bucket_num

--- a/bentoml/utils/benchmark.py
+++ b/bentoml/utils/benchmark.py
@@ -43,16 +43,16 @@ def percentile(data, pers):
 
 
 class DynamicBucketMerge:
-    '''
+    """
     real time speed stat
-    '''
+    """
 
     def __init__(self, sample_range=1, bucket_num=10):
         self.bucket_num = bucket_num
         self.sample_range = sample_range
-        self.bucket = [0] * (bucket_num)
-        self.bucket_sample = [0] * (bucket_num)
-        self.bucket_ver = [0] * (bucket_num)
+        self.bucket = [0] * bucket_num
+        self.bucket_sample = [0] * bucket_num
+        self.bucket_ver = [0] * bucket_num
 
     def put(self, timestamp, num):
         timestamp = timestamp / self.sample_range
@@ -198,7 +198,7 @@ class Stat:
         if health < 90:
             print(
                 """
-                *** WARNNING ***
+                *** WARNING ***
                 The client health rate is low. The benchmark result is not reliable.
                 Possible solutions:
                 * check the failure_rate and avoid request failures
@@ -229,8 +229,8 @@ class BenchmarkClient:
     """
     A locust-like benchmark tool with asyncio.
     Features:
-    * Very effcient, low CPU cost
-    * Could be embeded into other asyncio APPs, like jupyter notebook
+    * Very efficient, low CPU cost
+    * Could be embedded into other asyncio apps, like jupyter notebook
 
     Paras:
     * request_producer: The test case producer, a function with return value
@@ -298,6 +298,7 @@ class BenchmarkClient:
                 req_url = self.url_override or url
                 err = ''
                 group = ''
+                # noinspection PyUnresolvedReferences
                 try:
                     async with sess.request(
                         method,
@@ -417,7 +418,7 @@ class BenchmarkClient:
         Paras:
         * session_time: session time in sec
         * total_user: user count need to be spawned
-        * spawn_speed: user spawnning speed, in user/sec
+        * spawn_speed: user spawning speed, in user/sec
         """
         if spawn_speed is None:
             spawn_speed = total_user

--- a/bentoml/utils/benchmark.py
+++ b/bentoml/utils/benchmark.py
@@ -310,7 +310,7 @@ class BenchmarkClient:
                         if not self.verify_response(r.status, msg):
                             group = f"{r.status}"
                             err = f"<status: {r.status}>\n{msg}"
-                except asyncio.CancelledError:
+                except asyncio.CancelledError:  # pylint: disable=try-except-raise
                     raise
                 except (
                     aiohttp.client_exceptions.ServerDisconnectedError,

--- a/tests/adapters/test_dataframe_handler.py
+++ b/tests/adapters/test_dataframe_handler.py
@@ -122,7 +122,7 @@ def test_dataframe_handle_request_csv():
     request.content_type = 'text/csv'
     request.get_data.return_value = csv_data
 
-    result = input_adapter.handle_request(request, test_function)
+    result = input_adapter.handle_request(request)
     assert result.get_data().decode('utf-8') == '"john"'
 
 

--- a/tests/adapters/test_file_handler.py
+++ b/tests/adapters/test_file_handler.py
@@ -62,7 +62,7 @@ def test_file_input_http_request_post_binary(bin_file):
     request.headers = {}
     request.get_data.return_value = open(str(bin_file), 'rb').read()
 
-    response = test_file_input.handle_request(request, predict)
+    response = test_file_input.handle_request(request)
 
     assert response.status_code == 200
     assert b'{"b64": "gTCJOQ=="}' in response.data
@@ -90,7 +90,7 @@ def test_file_input_http_request_multipart_form(bin_file):
     request.headers = {}
     request.get_data.return_value = None
 
-    response = test_file_input.handle_request(request, predict)
+    response = test_file_input.handle_request(request)
 
     assert response.status_code == 200
     assert b'{"b64": "gTCJOQ=="}' in response.data
@@ -112,7 +112,7 @@ def test_file_input_http_request_single_file_different_name(bin_file):
     request.headers = {}
     request.get_data.return_value = None
 
-    response = test_file_input.handle_request(request, predict)
+    response = test_file_input.handle_request(request)
 
     assert response.status_code == 200
     assert b'{"b64": "gTCJOQ=="}' in response.data
@@ -128,7 +128,7 @@ def test_file_input_http_request_malformatted_input_missing_file_file():
     request.get_data.return_value = None
 
     with pytest.raises(BadInput) as e:
-        test_file_input.handle_request(request, predict)
+        test_file_input.handle_request(request)
 
     assert "unexpected HTTP request format" in str(e.value)
 
@@ -143,6 +143,6 @@ def test_file_input_http_request_malformatted_input_wrong_input_name():
     request.get_data.return_value = None
 
     with pytest.raises(BadInput) as e:
-        test_file_input.handle_request(request, predict)
+        test_file_input.handle_request(request)
 
     assert "unexpected HTTP request format" in str(e.value)

--- a/tests/adapters/test_image_handler.py
+++ b/tests/adapters/test_image_handler.py
@@ -62,7 +62,7 @@ def test_image_input_http_request_post_binary(img_file):
     request.headers = {}
     request.get_data.return_value = open(str(img_file), 'rb').read()
 
-    response = test_image_input.handle_request(request, predict)
+    response = test_image_input.handle_request(request)
 
     assert response.status_code == 200
     assert "[10, 10, 3]" in str(response.response)
@@ -90,7 +90,7 @@ def test_image_input_http_request_multipart_form(img_file):
     request.headers = {}
     request.get_data.return_value = None
 
-    response = test_image_input.handle_request(request, predict)
+    response = test_image_input.handle_request(request)
 
     assert response.status_code == 200
     assert "[10, 10, 3]" in str(response.response)
@@ -112,7 +112,7 @@ def test_image_input_http_request_single_image_different_name(img_file):
     request.headers = {}
     request.get_data.return_value = None
 
-    response = test_image_input.handle_request(request, predict)
+    response = test_image_input.handle_request(request)
 
     assert response.status_code == 200
     assert "[10, 10, 3]" in str(response.response)
@@ -128,7 +128,7 @@ def test_image_input_http_request_malformatted_input_missing_image_file():
     request.get_data.return_value = None
 
     with pytest.raises(BadInput) as e:
-        test_image_input.handle_request(request, predict)
+        test_image_input.handle_request(request)
 
     assert "unexpected HTTP request format" in str(e.value)
 
@@ -143,6 +143,6 @@ def test_image_input_http_request_malformatted_input_wrong_input_name():
     request.get_data.return_value = None
 
     with pytest.raises(BadInput) as e:
-        test_image_input.handle_request(request, predict)
+        test_image_input.handle_request(request)
 
     assert "unexpected HTTP request format" in str(e.value)

--- a/tests/adapters/test_legacy_image_handler.py
+++ b/tests/adapters/test_legacy_image_handler.py
@@ -48,7 +48,7 @@ def test_image_input_http_request_post_binary(img_file):
     request.headers = {}
     request.get_data.return_value = open(str(img_file), 'rb')
 
-    response = test_image_input.handle_request(request, predict)
+    response = test_image_input.handle_request(request)
 
     assert response.status_code == 200
     assert "[10, 10, 3]" in str(response.response)
@@ -68,7 +68,7 @@ def test_image_input_http_request_multipart_form(img_file):
     request.headers = {}
     request.get_data.return_value = None
 
-    response = test_image_input.handle_request(request, predict)
+    response = test_image_input.handle_request(request)
 
     assert response.status_code == 200
     assert "[10, 10, 3]" in str(response.response)
@@ -88,7 +88,7 @@ def test_image_input_http_request_single_image_different_name(img_file):
     request.headers = {}
     request.get_data.return_value = None
 
-    response = test_image_input.handle_request(request, predict)
+    response = test_image_input.handle_request(request)
 
     assert response.status_code == 200
     assert "[10, 10, 3]" in str(response.response)
@@ -104,7 +104,7 @@ def test_image_input_http_request_malformatted_input_missing_image_file():
     request.get_data.return_value = None
 
     with pytest.raises(BadInput) as e:
-        test_image_input.handle_request(request, predict)
+        test_image_input.handle_request(request)
 
     assert "unexpected HTTP request format" in str(e.value)
 
@@ -119,6 +119,6 @@ def test_image_input_http_request_malformatted_input_wrong_input_name():
     request.get_data.return_value = None
 
     with pytest.raises(BadInput) as e:
-        test_image_input.handle_request(request, predict)
+        test_image_input.handle_request(request)
 
     assert "unexpected HTTP request format" in str(e.value)

--- a/tests/adapters/test_multi_image_input_adapter.py
+++ b/tests/adapters/test_multi_image_input_adapter.py
@@ -43,7 +43,7 @@ def test_multi_image_input_request(img_file):
         content_length=headers['Content-Length'],
     )
 
-    response = adapter.handle_request(request, predict)
+    response = adapter.handle_request(request)
     assert response.status_code == 200
     assert response.data == b'[[10, 10, 3], [10, 10, 3]]'
 

--- a/tests/adapters/test_tf_tensor_handler.py
+++ b/tests/adapters/test_tf_tensor_handler.py
@@ -113,7 +113,7 @@ def test_tf_tensor_handle_request(test_cases):
     input_data, headers, except_result = test_cases
     request.get_data.return_value = json.dumps(input_data).encode('utf-8')
     request.headers = headers
-    response = input_adapter.handle_request(request, lambda i: i)
+    response = input_adapter.handle_request(request)
 
     prediction = json.loads(response.get_data())
     assert_eq_or_both_nan(except_result, prediction)

--- a/tests/test_auto_pip_dependency.py
+++ b/tests/test_auto_pip_dependency.py
@@ -17,7 +17,7 @@ def test_auto_adapter_dependencies(bento_bundle_path):
     assert 'imageio' in dependencies
     assert 'bentoml' in dependencies
 
-    # Test that dependencies also wrote to BentoServiceMetadat config file
+    # Test that dependencies also wrote to BentoServiceMetadata config file
 
 
 def test_auto_artifact_dependencies():

--- a/tests/test_save_and_load.py
+++ b/tests/test_save_and_load.py
@@ -40,7 +40,7 @@ def test_save_and_load_model(tmpdir, example_bento_service_class):
     assert api.name == "predict"
     assert api.mb_max_latency == 1000
     assert api.mb_max_batch_size == 2000
-    assert isinstance(api.handler, DataframeInput)
+    assert isinstance(api.input_adapter, DataframeInput)
     assert api.func(1) == 2
 
     # Check api methods are available
@@ -82,7 +82,7 @@ def test_pack_on_bento_service_instance(tmpdir, example_bento_service_class):
 
     api = model_service.get_inference_api('predict')
     assert api.name == "predict"
-    assert isinstance(api.handler, DataframeInput)
+    assert isinstance(api.input_adapter, DataframeInput)
     assert api.func(1) == 2
     # Check api methods are available
     assert model_service.predict(1) == 2

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -43,8 +43,10 @@ def test_fastai_image_input_pip_dependencies():
 def test_invalid_artifact_type():
     with pytest.raises(InvalidArgument) as e:
 
-        @bentoml.artifacts(["Not A Artifact"])  # pylint: disable=unused-variable
-        class ExampleBentoService(bentoml.BentoService):
+        @bentoml.artifacts(["Not A Artifact"])
+        class ExampleBentoService(  # pylint: disable=unused-variable
+            bentoml.BentoService
+        ):
             pass
 
     assert "only accept list of type BentoServiceArtifact" in str(e.value)
@@ -53,10 +55,10 @@ def test_invalid_artifact_type():
 def test_duplicated_artifact_name():
     with pytest.raises(InvalidArgument) as e:
 
-        @bentoml.artifacts(  # pylint: disable=unused-variable
-            [PickleArtifact("model"), PickleArtifact("model")]
-        )
-        class ExampleBentoService(bentoml.BentoService):
+        @bentoml.artifacts([PickleArtifact("model"), PickleArtifact("model")])
+        class ExampleBentoService(  # pylint: disable=unused-variable
+            bentoml.BentoService
+        ):
             pass
 
     assert "Duplicated artifact name `model` detected" in str(e.value)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3,7 +3,7 @@ import pytest
 import bentoml
 from bentoml.artifact import PickleArtifact
 from bentoml.adapters import DataframeInput, FastaiImageInput, ImageInput
-from bentoml.service import _validate_version_str
+from bentoml.service import validate_version_str
 from bentoml.exceptions import InvalidArgument
 
 
@@ -40,6 +40,7 @@ def test_fastai_image_input_pip_dependencies():
     assert 'fastai' in service._env._pip_dependencies
 
 
+# noinspection PyUnusedLocal
 def test_invalid_artifact_type():
     with pytest.raises(InvalidArgument) as e:
 
@@ -52,6 +53,7 @@ def test_invalid_artifact_type():
     assert "only accept list of type BentoServiceArtifact" in str(e.value)
 
 
+# noinspection PyUnusedLocal
 def test_duplicated_artifact_name():
     with pytest.raises(InvalidArgument) as e:
 
@@ -64,18 +66,20 @@ def test_duplicated_artifact_name():
     assert "Duplicated artifact name `model` detected" in str(e.value)
 
 
+# noinspection PyUnusedLocal
 def test_invalid_api_input():
     with pytest.raises(InvalidArgument) as e:
 
-        class ExampleBentoService(
+        class ExampleBentoService(  # pylint: disable=unused-variable
             bentoml.BentoService
-        ):  # pylint: disable=unused-variable
+        ):
             @bentoml.api("Not A InputAdapter")
             def test(self):
                 pass
 
-    assert "must be class derived from bentoml.adapters.BaseInputAdapter" in str(
-        e.value
+    assert (
+        "must be an instance of a class derived from "
+        "bentoml.adapters.BaseInputAdapter" in str(e.value)
     )
 
 
@@ -91,20 +95,20 @@ def test_image_input_pip_dependencies():
 
 def test_validate_version_str_fails():
     with pytest.raises(InvalidArgument):
-        _validate_version_str("44&")
+        validate_version_str("44&")
 
     with pytest.raises(InvalidArgument):
-        _validate_version_str("44 123")
+        validate_version_str("44 123")
 
     with pytest.raises(InvalidArgument):
-        _validate_version_str("")
+        validate_version_str("")
 
 
 def test_validate_version_str_pass():
-    _validate_version_str("abc_123")
-    _validate_version_str("1")
-    _validate_version_str("a_valid_version")
-    _validate_version_str("AValidVersion")
-    _validate_version_str("_AValidVersion")
-    _validate_version_str("1.3.4")
-    _validate_version_str("1.3.4-g375a71b")
+    validate_version_str("abc_123")
+    validate_version_str("1")
+    validate_version_str("a_valid_version")
+    validate_version_str("AValidVersion")
+    validate_version_str("_AValidVersion")
+    validate_version_str("1.3.4")
+    validate_version_str("1.3.4-g375a71b")


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
This pull request will add a lot more documentation and IDE auto-completion support to the input and output adapters. It will make it much simpler to implement input adapters by making specialized (optimized) batch request processing, and custom Lambda event processing opt-in instead of the default behavior.

This pull request aims not to have any breaking changes, but users with custom adapters may need to update parts of their code to reflect new method signatures.
<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
Right now, you have to implement 4 methods when writing an input adapter, `handle_request`, `handle_batch_request`, `handle_cli`, and `handle_aws_lambda_event`. This often results in a lot of duplicated code between `handle_request`, `handle_batch_request`, and `handle_aws_lambda_event`. To resolve this issue, [this new architecture](https://app.lucidchart.com/documents/edit/74d25a51-2b73-448a-aac0-c9b814b5b618/0_0) was proposed. 

It was noted that certain input adapters, such as the `DataframeInputAdapter` take advantage of optimized processing, and this yields significant performance boosts. As such, a provision was made to have batch processing opt-in.

This solution is not without its faults, however. The post-batch processing means we cannot guarantee that all requests in a batch are valid, meaning that some optimizations will not be as consistent as they might otherwise be. This is also visible as part of  #940. Ideally, this will be supported by adding a `validate` parameter to the `@api` decorator, which will be a function that can run a lightweight validation of the input.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
The changes in this pull request will be unit tested and any existing code samples should function as currently written.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code Refactoring (an internal change which is not user-facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [x] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [x] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [x] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [x] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
