### PR TITLE
AnnotatedImageAdapter for Image file plus additional JSON data

### DIFF
--- a/bentoml/adapters/__init__.py
+++ b/bentoml/adapters/__init__.py
@@ -18,6 +18,7 @@ from bentoml.adapters.tensorflow_tensor_input import TfTensorInput
 from bentoml.adapters.json_input import JsonInput
 from bentoml.adapters.legacy_json_input import LegacyJsonInput
 from bentoml.adapters.image_input import ImageInput
+from bentoml.adapters.annotated_image_input import AnnotatedImageInput
 from bentoml.adapters.multi_image_input import MultiImageInput
 from bentoml.adapters.legacy_image_input import LegacyImageInput
 from bentoml.adapters.fastai_image_input import FastaiImageInput
@@ -57,6 +58,7 @@ __all__ = [
     "LegacyImageInput",
     "FastaiImageInput",
     "FileInput",
+    "AnnotatedImageInput",
     "ClipperBytesInput",
     "ClipperDoublesInput",
     "ClipperFloatsInput",

--- a/bentoml/adapters/annotated_image_input.py
+++ b/bentoml/adapters/annotated_image_input.py
@@ -119,8 +119,6 @@ class AnnotatedImageInput(BaseInputAdapter):
     ):
         assert imageio, "`imageio` dependency can be imported"
 
-        if is_batch_input:
-            raise ValueError('AnnotatedImageInput can not accpept batch inputs')
         super(AnnotatedImageInput, self).__init__(
             is_batch_input=is_batch_input, **base_kwargs
         )
@@ -239,6 +237,7 @@ class AnnotatedImageInput(BaseInputAdapter):
         """
         input_datas = []
         ids = []
+
         for i, req in enumerate(requests):
             if not req.data:
                 ids.append(None)
@@ -257,7 +256,7 @@ class AnnotatedImageInput(BaseInputAdapter):
             input_datas.append(input_data)
             ids.append(i)
 
-        results = func(input_datas) if input_datas else []
+        results = [func(*d) for d in input_datas] if input_datas else []
         return self.output_adapter.to_batch_response(results, ids, requests)
 
     def handle_request(self, request, func):
@@ -333,7 +332,7 @@ class AnnotatedImageInput(BaseInputAdapter):
             )
 
             input_data = self._load_image_and_json_data(request)
-            result = func(*input_data)  # TODO: Ensure we don't need a [0] here
+            result = func(*input_data)
 
             return self.output_adapter.to_aws_lambda_event(result, event)
         else:

--- a/bentoml/adapters/annotated_image_input.py
+++ b/bentoml/adapters/annotated_image_input.py
@@ -86,11 +86,13 @@ def get_default_accept_image_formats():
 
 
 class AnnotatedImageInput(BaseInputAdapter):
-    """Transform incoming image data from http request, cli or lambda event into numpy
-    array.
+    """Transform incoming image data from http request, cli or lambda event into a
+    numpy array, while allowing an optional JSON file for image annotations (such
+    as object bounding boxes, class labels, etc.)
 
-    Handle incoming image data from different sources, transform them into numpy array
-    and pass down to user defined API functions
+    Transforms input image file into a numpy array, and loads JSON file as
+    a JSON serializable Python object, providing them to user-defined
+    API functions.
 
     Args:
         accept_image_formats (string[]):  A list of acceptable image formats.
@@ -105,6 +107,23 @@ class AnnotatedImageInput(BaseInputAdapter):
 
     Raises:
         ImportError: imageio package is required to use AnnotatedImageInput
+
+    Example:
+
+        >>> python
+        >>> from bentoml import BentoService, api, artifacts
+        >>> from bentoml.artifact import TensorflowArtifact
+        >>> from bentoml.adapters import AnnotatedImageInput
+        >>>
+        >>> CLASS_NAMES = ['cat', 'dog']
+        >>>
+        >>> @artifacts([TensorflowArtifact('classifer')])
+        >>> class PetClassification(BentoService):
+        >>>    @api(input=AnnotatedImageInput())
+        >>>    def predict(self, image_ndarrays, annotations):
+        >>>        cropped_pets = some_pet_finder(image_ndarrays, annotations)
+        >>>        results = self.artifacts.classifer.predict(cropped_pets)
+        >>>        return [CLASS_NAMES[r] for r in results]
     """
 
     HTTP_METHODS = ["POST"]
@@ -278,6 +297,10 @@ class AnnotatedImageInput(BaseInputAdapter):
         """Handles an CLI command call, convert CLI arguments into
         corresponding data format that user API function is expecting, and
         prints the API function result to console output
+
+        Processes one image file, or one image file with associated JSON
+        annotations
+
         :param args: CLI arguments
         :param func: user API function
         """

--- a/bentoml/adapters/annotated_image_input.py
+++ b/bentoml/adapters/annotated_image_input.py
@@ -217,15 +217,16 @@ class AnnotatedImageInput(BaseInputAdapter):
         verify_image_format_or_raise(image_file_name, self.accept_image_formats)
         input_stream = image_file.stream
         input_image = imageio.imread(input_stream, pilmode=self.pilmode)
-        input_json = {}
 
         if json_file:
+            input_json = {}
             try:
                 input_json = json.load(json_file)
             except (json.JSONDecodeError, UnicodeDecodeError):
                 raise BadInput("BentoML#AnnotatedImageInput received invalid JSON file")
+            return (input_image, input_json)
 
-        return (input_image, input_json)
+        return (input_image,)
 
     def handle_batch_request(
         self, requests: Iterable[SimpleRequest], func: callable
@@ -268,7 +269,7 @@ class AnnotatedImageInput(BaseInputAdapter):
             response object
         """
         input_data = self._load_image_and_json_data(request)
-        result = func(*input_data)[0] # TODO: Should we remove the [0]?
+        result = func(*input_data)
         return self.output_adapter.to_response(result, request)
 
     def handle_cli(self, args, func):

--- a/bentoml/adapters/annotated_image_input.py
+++ b/bentoml/adapters/annotated_image_input.py
@@ -252,7 +252,6 @@ class AnnotatedImageInput(BaseInputAdapter):
 
         return (input_image,)
 
-
     def handle_batch_request(
         self, requests: Iterable[SimpleRequest], func: callable
     ) -> Iterable[SimpleResponse]:
@@ -284,8 +283,12 @@ class AnnotatedImageInput(BaseInputAdapter):
 
         results = [func(*d) if d else {} for d in input_datas]
 
-        return self.output_adapter.to_batch_response(result_conc=results,
-                slices=slices, fallbacks=[None]*len(slices), requests=requests)
+        return self.output_adapter.to_batch_response(
+            result_conc=results,
+            slices=slices,
+            fallbacks=[None] * len(slices),
+            requests=requests,
+        )
 
     def handle_request(self, request, func):
         """Handle http request that has one image file. It will convert image into a

--- a/bentoml/adapters/annotated_image_input.py
+++ b/bentoml/adapters/annotated_image_input.py
@@ -130,10 +130,27 @@ class AnnotatedImageInput(BaseInputAdapter):
         >>> @artifacts([TensorflowArtifact('classifer')])
         >>> class PetClassification(BentoService):
         >>>    @api(input=AnnotatedImageInput())
-        >>>    def predict(self, image, annotations):
+        >>>    def predict(self, image: Numpy.array, annotations: JsonSerializable):
         >>>        cropped_pets = some_pet_finder(image, annotations)
         >>>        results = self.artifacts.classifer.predict(cropped_pets)
         >>>        return [CLASS_NAMES[r] for r in results]
+        >>>
+
+        The endpoint could then be used with an HTML form that sends multipart data,
+        like the example below
+
+        >>> <form action="http://localhost:8000" method="POST"
+        >>>       enctype="multipart/form-data">
+        >>>     <input name="image" type="file">
+        >>>     <input name="annotations" type="file">
+        >>>     <input type="submit">
+        >>> </form>
+
+        Or the following cURL command
+
+        >>> curl -F image=@image.png
+        >>>      -F annotations=@annotations.json
+        >>>      http://localhost:8000/predict
     """
 
     HTTP_METHODS = ["POST"]
@@ -153,12 +170,6 @@ class AnnotatedImageInput(BaseInputAdapter):
         super(AnnotatedImageInput, self).__init__(
             is_batch_input=is_batch_input, **base_kwargs
         )
-        if 'input_names' in base_kwargs:
-            raise TypeError(
-                "AnnotatedImageInput takes specific arguments for image_input_name "
-                "and annotation_input_name.  This adapter supports a single image "
-                "with an optional JSON annotation file"
-            )
 
         self.pilmode = pilmode
         self.image_input_name = image_input_name

--- a/bentoml/adapters/annotated_image_input.py
+++ b/bentoml/adapters/annotated_image_input.py
@@ -118,7 +118,6 @@ class AnnotatedImageInput(BaseInputAdapter):
 
     Example:
 
-        >>> python
         >>> from bentoml import BentoService, api, artifacts
         >>> from bentoml.artifact import TensorflowArtifact
         >>> from bentoml.adapters import AnnotatedImageInput

--- a/bentoml/adapters/annotated_image_input.py
+++ b/bentoml/adapters/annotated_image_input.py
@@ -1,0 +1,239 @@
+# Copyright 2019 Atalaya Tech, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import argparse
+import base64
+from io import BytesIO
+from typing import Iterable
+
+from werkzeug.utils import secure_filename
+from werkzeug.wrappers import Request
+
+from bentoml import config
+from bentoml.utils.lazy_loader import LazyLoader
+from bentoml.marshal.utils import SimpleRequest, SimpleResponse
+from bentoml.exceptions import BadInput
+from bentoml.adapters.base_input import BaseInputAdapter
+
+# BentoML optional dependencies, using lazy load to avoid ImportError
+imageio = LazyLoader('imageio', globals(), 'imageio')
+
+
+def verify_image_format_or_raise(file_name, accept_format_list):
+    """
+    Raise error if file's extension is not in the accept_format_list
+    """
+    if accept_format_list:
+        _, extension = os.path.splitext(file_name)
+        if extension.lower() not in accept_format_list:
+            raise BadInput(
+                "Input file not in supported format list: {}".format(accept_format_list)
+            )
+
+
+def get_default_accept_image_formats():
+    """With default bentoML config, this returns:
+        ['.jpg', '.png', '.jpeg', '.tiff', '.webp', '.bmp']
+    """
+    return [
+        extension.strip()
+        for extension in config("apiserver")
+        .get("default_image_input_accept_file_extensions")
+        .split(",")
+    ]
+
+
+class AnnotatedImageInput(BaseInputAdapter):
+    """Transform incoming image data from http request, cli or lambda event into numpy
+    array.
+
+    Handle incoming image data from different sources, transform them into numpy array
+    and pass down to user defined API functions
+
+    Args:
+        accept_image_formats (string[]):  A list of acceptable image formats.
+            Default value is loaded from bentoml config
+            'apiserver/default_image_input_accept_file_extensions', which is
+            set to ['.jpg', '.png', '.jpeg', '.tiff', '.webp', '.bmp'] by default.
+            List of all supported format can be found here:
+            https://imageio.readthedocs.io/en/stable/formats.html
+        pilmode (string): The pilmode to be used for reading image file into numpy
+            array. Default value is 'RGB'.  Find more information at:
+            https://imageio.readthedocs.io/en/stable/format_png-pil.html
+
+    Raises:
+        ImportError: imageio package is required to use AnnotatedImageInput
+    """
+
+    HTTP_METHODS = ["POST"]
+    BATCH_MODE_SUPPORTED = True
+
+    def __init__(
+        self,
+        accept_image_formats=None,
+        pilmode="RGB",
+        is_batch_input=False,
+        **base_kwargs,
+    ):
+        assert imageio, "`imageio` dependency can be imported"
+
+        if is_batch_input:
+            raise ValueError('AnnotatedImageInput can not accpept batch inputs')
+        super(AnnotatedImageInput, self).__init__(is_batch_input=is_batch_input, **base_kwargs)
+        if 'input_names' in base_kwargs:
+            raise TypeError(
+                "AnnotatedImageInput doesn't take input_names as parameters since bentoml 0.8."
+                "Update your Service definition "
+                "or use LegacyAnnotatedImageInput instead(not recommended)."
+            )
+
+        self.pilmode = pilmode
+        self.accept_image_formats = (
+            accept_image_formats or get_default_accept_image_formats()
+        )
+
+    @property
+    def config(self):
+        return {
+            # Converting to list, google.protobuf.Struct does not work with tuple type
+            "accept_image_formats": self.accept_image_formats,
+            "pilmode": self.pilmode,
+        }
+
+    @property
+    def request_schema(self):
+        return {
+            "multipart/form-data": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "image_file": {"type": "string", "format": "binary"},
+                        "json_file": {"type": "string", "format": "binary", "required": "false"}
+                    },
+                }
+            },
+        }
+
+    @property
+    def pip_dependencies(self):
+        return ["imageio"]
+
+    def _load_image_data(self, request: Request):
+        if len(request.files):
+            if len(request.files) > 2:
+                raise BadInput(
+                    "Too many files. AnnotatedImageInput takes one image file and an \
+                    optional JSON annotation file"
+                )
+
+            input_files = []
+
+            for f in iter(request.files.values()):
+                print(f)
+                input_files.append(f)
+
+            if not input_file:
+                raise BadInput("BentoML#AnnotatedImageInput unexpected HTTP request format")
+            file_name = secure_filename(input_file.filename)
+            verify_image_format_or_raise(file_name, self.accept_image_formats)
+            input_stream = input_file.stream
+        else:
+            raise BadInput("BentoML#AnnotatedImageInput unexpected HTTP request format")
+
+        input_data = imageio.imread(input_stream, pilmode=self.pilmode)
+        return input_data
+
+    def handle_batch_request(
+        self, requests: Iterable[SimpleRequest], func: callable
+    ) -> Iterable[SimpleResponse]:
+        """
+        Batch version of handle_request
+        """
+        input_datas = []
+        ids = []
+        for i, req in enumerate(requests):
+            if not req.data:
+                ids.append(None)
+                continue
+            request = Request.from_values(
+                input_stream=BytesIO(req.data),
+                content_length=len(req.data),
+                headers=req.headers,
+            )
+            try:
+                input_data = self._load_image_data(request)
+            except BadInput:
+                ids.append(None)
+                continue
+
+            input_datas.append(input_data)
+            ids.append(i)
+
+        results = func(input_datas) if input_datas else []
+        return self.output_adapter.to_batch_response(results, ids, requests)
+
+    def handle_request(self, request, func):
+        """Handle http request that has one image file. It will convert image into a
+        ndarray for the function to consume.
+
+        Args:
+            request: incoming request object.
+            func: function that will take ndarray as its arg.
+            options: configuration for handling request object.
+        Return:
+            response object
+        """
+        input_data = self._load_image_data(request)
+        result = func((input_data,))[0]
+        return self.output_adapter.to_response(result, request)
+
+    def handle_cli(self, args, func):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--input", required=True, nargs='+')
+        parser.add_argument("--batch-size", default=None, type=int)
+        parsed_args, unknown_args = parser.parse_known_args(args)
+        file_paths = parsed_args.input
+
+        batch_size = (
+            parsed_args.batch_size if parsed_args.batch_size else len(file_paths)
+        )
+
+        for i in range(0, len(file_paths), batch_size):
+            step_file_paths = file_paths[i : i + batch_size]
+            image_arrays = []
+            for file_path in step_file_paths:
+                verify_image_format_or_raise(file_path, self.accept_image_formats)
+                if not os.path.isabs(file_path):
+                    file_path = os.path.abspath(file_path)
+
+                image_arrays.append(imageio.imread(file_path, pilmode=self.pilmode))
+
+            results = func(image_arrays)
+            for result in results:
+                return self.output_adapter.to_cli(result, unknown_args)
+
+    def handle_aws_lambda_event(self, event, func):
+        if event["headers"].get("Content-Type", "").startswith("images/"):
+            image = imageio.imread(
+                base64.decodebytes(event["body"]), pilmode=self.pilmode
+            )
+        else:
+            raise BadInput(
+                "BentoML currently doesn't support Content-Type: {content_type} for "
+                "AWS Lambda".format(content_type=event["headers"]["Content-Type"])
+            )
+
+        result = func((image,))[0]
+        return self.output_adapter.to_aws_lambda_event(result, event)

--- a/bentoml/adapters/dataframe_input.py
+++ b/bentoml/adapters/dataframe_input.py
@@ -78,7 +78,7 @@ class DataframeInput(BaseInputAdapter):
                 import pandas as pd  # pylint: disable=redefined-outer-name
             except ImportError:
                 raise MissingDependencyException(
-                    "Missing required dependency 'pandas' for DataframeInput, install"
+                    "Missing required dependency 'pandas' for DataframeInput, install "
                     "with `pip install pandas`"
                 )
 

--- a/bentoml/adapters/image_input.py
+++ b/bentoml/adapters/image_input.py
@@ -81,7 +81,6 @@ class ImageInput(BaseInputAdapter):
 
     Example:
 
-        >>> python
         >>> from bentoml import BentoService, api, artifacts
         >>> from bentoml.artifact import TensorflowArtifact
         >>> from bentoml.adapters import ImageInput

--- a/bentoml/adapters/image_input.py
+++ b/bentoml/adapters/image_input.py
@@ -81,20 +81,19 @@ class ImageInput(BaseInputAdapter):
 
     Example:
 
-        ```python
-        from bentoml import BentoService, api, artifacts
-        from bentoml.artifact import TensorflowArtifact
-        from bentoml.adapters import ImageInput
-
-        CLASS_NAEMS = ['cat', 'dog']
-
-        @artifacts([TensorflowArtifact('classifer')])
-        class PetClassification(BentoService):
-            @api(input=ImageInput())
-            def predict(self, image_ndarrays):
-                results = self.artifacts.classifer.predict(image_ndarrays)
-                return [CLASS_NAEMS[r] for r in results]
-        ```
+        >>> python
+        >>> from bentoml import BentoService, api, artifacts
+        >>> from bentoml.artifact import TensorflowArtifact
+        >>> from bentoml.adapters import ImageInput
+        >>>
+        >>> CLASS_NAMES = ['cat', 'dog']
+        >>>
+        >>> @artifacts([TensorflowArtifact('classifer')])
+        >>> class PetClassification(BentoService):
+        >>>     @api(input=ImageInput())
+        >>>     def predict(self, image_ndarrays):
+        >>>         results = self.artifacts.classifer.predict(image_ndarrays)
+        >>>         return [CLASS_NAMES[r] for r in results]
     """
 
     HTTP_METHODS = ["POST"]

--- a/docs/source/api/adapters.rst
+++ b/docs/source/api/adapters.rst
@@ -27,6 +27,10 @@ MultiImageInput
 +++++++++++++++
 .. autoclass:: bentoml.adapters.MultiImageInput
 
+AnnotatedImageInput
++++++++++++++++++++
+.. autoclass:: bentoml.adapters.AnnotatedImageInput
+
 LegacyImageInput
 ++++++++++++++++
 .. autoclass:: bentoml.adapters.LegacyImageInput

--- a/tests/adapters/test_annotated_image_handler.py
+++ b/tests/adapters/test_annotated_image_handler.py
@@ -61,11 +61,21 @@ def test_anno_image_input_cli_image_and_json(capsys, img_file, json_file):
 def test_anno_image_input_cli_relative_paths(capsys, img_file, json_file):
     test_anno_image_input = AnnotatedImageInput()
 
+    try:
+        # This fails on Windows if our file is on a different drive
+        relative_image_path = os.path.relpath(img_file)
+        relative_annotation_path = os.path.relpath(json_file)
+    except ValueError:
+        # Switch to the drive with the files image on it, and try again
+        os.chdir(img_file[:2])
+        relative_image_path = os.path.relpath(img_file)
+        relative_annotation_path = os.path.relpath(json_file)
+
     test_args = [
         "--image",
-        os.path.relpath(img_file),
+        relative_image_path,
         "--annotations",
-        os.path.relpath(json_file),
+        relative_annotation_path,
     ]
     test_anno_image_input.handle_cli(test_args, predict_image_and_json)
     out, _ = capsys.readouterr()

--- a/tests/adapters/test_annotated_image_handler.py
+++ b/tests/adapters/test_annotated_image_handler.py
@@ -10,7 +10,6 @@ from urllib3.filepost import encode_multipart_formdata
 
 from bentoml.exceptions import BadInput
 from bentoml.adapters import AnnotatedImageInput
-from bentoml.adapters.annotated_image_input import has_image_extension
 from bentoml.marshal.utils import SimpleRequest
 
 
@@ -35,8 +34,8 @@ def predict_image_only(image):
     return image.shape
 
 
-def predict_image_and_json(image, json_input):
-    return (image.shape, json_input["name"])
+def predict_image_and_json(image, annotations):
+    return (image.shape, annotations["name"])
 
 
 def test_anno_image_input_cli_image_only(capsys, img_file):
@@ -52,7 +51,7 @@ def test_anno_image_input_cli_image_only(capsys, img_file):
 def test_anno_image_input_cli_image_and_json(capsys, img_file, json_file):
     test_anno_image_input = AnnotatedImageInput()
 
-    test_args = ["--image", img_file, "--json", json_file]
+    test_args = ["--image", img_file, "--annotations", json_file]
     test_anno_image_input.handle_cli(test_args, predict_image_and_json)
     out, _ = capsys.readouterr()
 
@@ -65,7 +64,7 @@ def test_anno_image_input_cli_relative_paths(capsys, img_file, json_file):
     test_args = [
         "--image",
         os.path.relpath(img_file),
-        "--json",
+        "--annotations",
         os.path.relpath(json_file),
     ]
     test_anno_image_input.handle_cli(test_args, predict_image_and_json)
@@ -474,11 +473,9 @@ def test_anno_image_input_custom_accept_extension_not_accepted(img_file):
 def test_anno_image_input_input_names_invalid():
     with pytest.raises(TypeError) as e:
         AnnotatedImageInput(input_names=["anything"])
-    assert "AnnotatedImageInput doesn't take input_names" in str(e.value)
-
-
-def test_anno_image_input_has_image_extension_no_format_list():
-    assert has_image_extension("image.jpg", None) is True
+    assert "AnnotatedImageInput takes specific arguments for image_input_name" in str(
+        e.value
+    )
 
 
 def test_anno_image_input_octet_stream_json(img_file):

--- a/tests/adapters/test_annotated_image_handler.py
+++ b/tests/adapters/test_annotated_image_handler.py
@@ -4,17 +4,21 @@ import mock
 import flask
 import pytest
 
+from werkzeug import Request
 from urllib3.filepost import encode_multipart_formdata
 
 from bentoml.exceptions import BadInput
 from bentoml.adapters import AnnotatedImageInput
+from bentoml.marshal.utils import SimpleRequest
 
 
-def generate_multipart_body(image_file, json_file):
+def generate_multipart_body(image_file, json_file=None):
     image = ("image.jpg", open(image_file, "rb").read())
-    json = ("annotations.json", open(json_file, "rb").read())
+    files = {"image.jpg": image}
 
-    files = {"image.jpg": image, "annotations.json": json}
+    if json_file:
+        json = ("annotations.json", open(json_file, "rb").read())
+        files["annotations.json"] = json
 
     body, content_type = encode_multipart_formdata(files)
 
@@ -67,7 +71,39 @@ def test_anno_image_input_aws_lambda_event(img_file, json_file):
     assert aws_result["body"] == '[[10, 10, 3], "kaith"]'
 
 
-def test_anno_image_input_http_request_multipart_form(img_file):
+def test_anno_image_input_http_request_multipart_form(img_file, json_file):
+    test_anno_image_input = AnnotatedImageInput()
+    request = mock.MagicMock(spec=flask.Request)
+    image_file_bytes = open(str(img_file), 'rb').read()
+    image_file_attr = {
+        'filename': 'test_img.png',
+        'read.return_value': image_file_bytes,
+        'mimetype': 'image/png',
+        'stream': io.BytesIO(image_file_bytes),
+    }
+    image_file = mock.Mock(**image_file_attr)
+
+    json_file_bytes = open(str(json_file), 'rb').read()
+    json_file_attr = {
+        'filename': 'annotations.json',
+        'read.return_value': json_file_bytes,
+        'mimetype': 'application/json',
+        'stream': io.BytesIO(json_file_bytes),
+    }
+    json_file = mock.Mock(**json_file_attr)
+
+    request.method = "POST"
+    request.files = {"image_file": image_file, "json_file": json_file}
+
+    request.get_data.return_value = None
+
+    response = test_anno_image_input.handle_request(request, predict_image_and_json)
+
+    assert response.status_code == 200
+    assert '[10, 10, 3], "kaith"' in str(response.response)
+
+
+def test_anno_image_input_http_request_multipart_form_image_only(img_file):
     test_anno_image_input = AnnotatedImageInput()
     request = mock.MagicMock(spec=flask.Request)
     file_bytes = open(str(img_file), 'rb').read()
@@ -90,6 +126,42 @@ def test_anno_image_input_http_request_multipart_form(img_file):
     assert "[10, 10, 3]" in str(response.response)
 
 
+def test_anno_image_input_batch_request(img_file, json_file):
+    adapter = AnnotatedImageInput(is_batch_input=True)
+
+    multipart_data, headers = generate_multipart_body(img_file, json_file)
+    request = SimpleRequest.from_flask_request(
+        Request.from_values(
+            data=multipart_data,
+            content_type=headers['Content-Type'],
+            content_length=headers['Content-Length'],
+        )
+    )
+
+    responses = adapter.handle_batch_request([request] * 5, predict_image_and_json)
+    for response in responses:
+        assert response.status == 200
+        assert response.data == '[[10, 10, 3], "kaith"]'
+
+
+def test_anno_image_input_batch_request_image_only(img_file):
+    adapter = AnnotatedImageInput(is_batch_input=True)
+
+    multipart_data, headers = generate_multipart_body(img_file)
+    request = SimpleRequest.from_flask_request(
+        Request.from_values(
+            data=multipart_data,
+            content_type=headers['Content-Type'],
+            content_length=headers['Content-Length'],
+        )
+    )
+
+    responses = adapter.handle_batch_request([request] * 5, predict_image_only)
+    for response in responses:
+        assert response.status == 200
+        assert response.data == '[10, 10, 3]'
+
+
 def test_anno_image_input_http_request_single_image_different_name(img_file):
     test_anno_image_input = AnnotatedImageInput()
     request = mock.MagicMock(spec=flask.Request)
@@ -103,7 +175,7 @@ def test_anno_image_input_http_request_single_image_different_name(img_file):
     file = mock.Mock(**file_attr)
 
     request.method = "POST"
-    request.files = {"a_differnt_name_used": file}
+    request.files = {"a_different_name_used": file}
     request.headers = {}
     request.get_data.return_value = None
 
@@ -141,6 +213,3 @@ def test_anno_image_input_http_request_malformatted_input_wrong_input_name():
         test_anno_image_input.handle_request(request, predict_image_only)
 
     assert "unexpected HTTP request format" in str(e.value)
-
-
-# TODO: Add tests for handle_batch_request

--- a/tests/adapters/test_annotated_image_handler.py
+++ b/tests/adapters/test_annotated_image_handler.py
@@ -1,5 +1,3 @@
-import base64
-import glob
 import io
 import mock
 
@@ -10,7 +8,6 @@ from urllib3.filepost import encode_multipart_formdata
 
 from bentoml.exceptions import BadInput
 from bentoml.adapters import AnnotatedImageInput
-from bentoml.marshal.utils import SimpleRequest
 
 
 def generate_multipart_body(image_file, json_file):
@@ -26,6 +23,7 @@ def generate_multipart_body(image_file, json_file):
         'Content-Length': len(body),
     }
     return body, headers
+
 
 def predict_image_only(image):
     return image.shape
@@ -62,7 +60,8 @@ def test_anno_image_input_aws_lambda_event(img_file, json_file):
 
     aws_lambda_event = {"body": multipart_data, "headers": headers}
     aws_result = test_anno_image_input.handle_aws_lambda_event(
-            aws_lambda_event, predict_image_and_json)
+        aws_lambda_event, predict_image_and_json
+    )
 
     assert aws_result["statusCode"] == 200
     assert aws_result["body"] == '[[10, 10, 3], "kaith"]'
@@ -145,4 +144,3 @@ def test_anno_image_input_http_request_malformatted_input_wrong_input_name():
 
 
 # TODO: Add tests for handle_batch_request
-

--- a/tests/adapters/test_annotated_image_handler.py
+++ b/tests/adapters/test_annotated_image_handler.py
@@ -1,0 +1,148 @@
+import base64
+import glob
+import io
+import mock
+
+import flask
+import pytest
+
+from urllib3.filepost import encode_multipart_formdata
+
+from bentoml.exceptions import BadInput
+from bentoml.adapters import AnnotatedImageInput
+from bentoml.marshal.utils import SimpleRequest
+
+
+def generate_multipart_body(image_file, json_file):
+    image = ("image.jpg", open(image_file, "rb").read())
+    json = ("annotations.json", open(json_file, "rb").read())
+
+    files = {"image.jpg": image, "annotations.json": json}
+
+    body, content_type = encode_multipart_formdata(files)
+
+    headers = {
+        'Content-Type': content_type,
+        'Content-Length': len(body),
+    }
+    return body, headers
+
+def predict_image_only(image):
+    return image.shape
+
+
+def predict_image_and_json(image, json_input):
+    return (image.shape, json_input["name"])
+
+
+def test_anno_image_input_cli_image_only(capsys, img_file):
+    test_anno_image_input = AnnotatedImageInput()
+
+    test_args = ["--image", img_file]
+    test_anno_image_input.handle_cli(test_args, predict_image_only)
+    out, _ = capsys.readouterr()
+
+    assert out.strip() == "(10, 10, 3)"
+
+
+def test_anno_image_input_cli_image_and_json(capsys, img_file, json_file):
+    test_anno_image_input = AnnotatedImageInput()
+
+    test_args = ["--image", img_file, "--json", json_file]
+    test_anno_image_input.handle_cli(test_args, predict_image_and_json)
+    out, _ = capsys.readouterr()
+
+    assert out.strip() == "((10, 10, 3), 'kaith')"
+
+
+def test_anno_image_input_aws_lambda_event(img_file, json_file):
+    test_anno_image_input = AnnotatedImageInput()
+
+    multipart_data, headers = generate_multipart_body(img_file, json_file)
+
+    aws_lambda_event = {"body": multipart_data, "headers": headers}
+    aws_result = test_anno_image_input.handle_aws_lambda_event(
+            aws_lambda_event, predict_image_and_json)
+
+    assert aws_result["statusCode"] == 200
+    assert aws_result["body"] == '[[10, 10, 3], "kaith"]'
+
+
+def test_anno_image_input_http_request_multipart_form(img_file):
+    test_anno_image_input = AnnotatedImageInput()
+    request = mock.MagicMock(spec=flask.Request)
+    file_bytes = open(str(img_file), 'rb').read()
+    file_attr = {
+        'filename': 'test_img.png',
+        'read.return_value': file_bytes,
+        'mimetype': 'image/png',
+        'stream': io.BytesIO(file_bytes),
+    }
+    file = mock.Mock(**file_attr)
+
+    request.method = "POST"
+    request.files = {"image_file": file}
+    request.headers = {}
+    request.get_data.return_value = None
+
+    response = test_anno_image_input.handle_request(request, predict_image_only)
+
+    assert response.status_code == 200
+    assert "[10, 10, 3]" in str(response.response)
+
+
+def test_anno_image_input_http_request_single_image_different_name(img_file):
+    test_anno_image_input = AnnotatedImageInput()
+    request = mock.MagicMock(spec=flask.Request)
+    file_bytes = open(str(img_file), 'rb').read()
+    file_attr = {
+        'filename': 'test_img.png',
+        'read.return_value': file_bytes,
+        'mimetype': 'image/png',
+        'stream': io.BytesIO(file_bytes),
+    }
+    file = mock.Mock(**file_attr)
+
+    request.method = "POST"
+    request.files = {"a_differnt_name_used": file}
+    request.headers = {}
+    request.get_data.return_value = None
+
+    response = test_anno_image_input.handle_request(request, predict_image_only)
+
+    assert response.status_code == 200
+    assert "[10, 10, 3]" in str(response.response)
+
+
+def test_anno_image_input_http_request_malformatted_input_missing_image_file():
+    test_anno_image_input = AnnotatedImageInput()
+    request = mock.MagicMock(spec=flask.Request)
+
+    request.method = "POST"
+    request.files = {}
+    request.headers = {}
+    request.get_data.return_value = None
+
+    with pytest.raises(BadInput) as e:
+        test_anno_image_input.handle_request(request, predict_image_only)
+
+    assert "unexpected HTTP request format" in str(e.value)
+
+
+def test_anno_image_input_http_request_malformatted_input_wrong_input_name():
+    test_anno_image_input = AnnotatedImageInput()
+    request = mock.MagicMock(spec=flask.Request)
+
+    request.method = "POST"
+    request.files = {"abc": None}
+    request.headers = {}
+    request.get_data.return_value = None
+
+    with pytest.raises(BadInput) as e:
+        test_anno_image_input.handle_request(request, predict_image_only)
+
+    assert "unexpected HTTP request format" in str(e.value)
+
+
+# TODO: Add tests for handle_batch_request
+

--- a/tests/adapters/test_annotated_image_handler.py
+++ b/tests/adapters/test_annotated_image_handler.py
@@ -62,8 +62,12 @@ def test_anno_image_input_cli_image_and_json(capsys, img_file, json_file):
 def test_anno_image_input_cli_relative_paths(capsys, img_file, json_file):
     test_anno_image_input = AnnotatedImageInput()
 
-    test_args = ["--image", os.path.relpath(img_file),
-            "--json", os.path.relpath(json_file)]
+    test_args = [
+        "--image",
+        os.path.relpath(img_file),
+        "--json",
+        os.path.relpath(json_file),
+    ]
     test_anno_image_input.handle_cli(test_args, predict_image_and_json)
     out, _ = capsys.readouterr()
 
@@ -98,7 +102,6 @@ def test_anno_image_input_aws_lambda_event_bad_content_type(img_file, json_file)
         )
 
     assert "only supports multipart/form-data" in str(e.value)
-
 
 
 def test_anno_image_input_http_request_multipart_form(img_file, json_file):
@@ -146,7 +149,7 @@ def test_anno_image_input_http_request_invalid_json(img_file, json_file):
     image_file = mock.Mock(**image_file_attr)
 
     json_file_bytes = open(str(json_file), 'rb').read()
-    json_file_bytes = json_file_bytes[:int(len(json_file_bytes)/2)]
+    json_file_bytes = json_file_bytes[: int(len(json_file_bytes) / 2)]
     json_file_attr = {
         'filename': 'annotations.json',
         'read.return_value': json_file_bytes,
@@ -211,8 +214,11 @@ def test_anno_image_input_http_request_too_many_files(img_file, json_file):
     json_file = mock.Mock(**json_file_attr)
 
     request.method = "POST"
-    request.files = {"image_file": image_file,
-            "json_file": json_file, "image_file_2": image_file}
+    request.files = {
+        "image_file": image_file,
+        "json_file": json_file,
+        "image_file_2": image_file,
+    }
     request.headers = {}
     request.get_data.return_value = None
 
@@ -312,8 +318,9 @@ def test_anno_image_input_batch_request(img_file, json_file):
 def test_anno_image_input_check_config():
     adapter = AnnotatedImageInput()
     config = adapter.config
-    assert (isinstance(config["accept_image_formats"], list) and
-            isinstance(config["pilmode"], str))
+    assert isinstance(config["accept_image_formats"], list) and isinstance(
+        config["pilmode"], str
+    )
 
 
 def test_anno_image_input_check_request_schema():
@@ -331,7 +338,7 @@ def test_anno_image_input_batch_request_skip_bad(img_file, json_file):
 
     multipart_data, headers = generate_multipart_body(img_file, json_file)
 
-    empty_request = SimpleRequest(headers=headers, data = None)
+    empty_request = SimpleRequest(headers=headers, data=None)
 
     request = SimpleRequest.from_flask_request(
         Request.from_values(
@@ -348,26 +355,24 @@ def test_anno_image_input_batch_request_skip_bad(img_file, json_file):
 
     bad_request = SimpleRequest.from_flask_request(
         Request.from_values(
-            data=bad_data,
-            content_type=content_type,
-            content_length=len(bad_data),
+            data=bad_data, content_type=content_type, content_length=len(bad_data),
         )
     )
 
     responses = adapter.handle_batch_request(
-            [empty_request, request, bad_request],
-            predict_image_and_json)
+        [empty_request, request, bad_request], predict_image_and_json
+    )
 
-    assert(len(responses) == 3)
-    assert(responses[0] == None)
-    assert(responses[1].status == 200 
-            and responses[1].data == '[[10, 10, 3], "kaith"]')
-    assert(responses[2] == None)
+    assert len(responses) == 3
+    assert responses[0] is None
+    assert responses[1].status == 200 and responses[1].data == '[[10, 10, 3], "kaith"]'
+    assert responses[2] is None
 
     bad_responses = adapter.handle_batch_request(
-            [empty_request], predict_image_and_json)
+        [empty_request], predict_image_and_json
+    )
     assert len(bad_responses) == 1
-    assert bad_responses[0] == None
+    assert bad_responses[0] is None
 
 
 def test_anno_image_input_batch_request_image_only(img_file):
@@ -468,7 +473,7 @@ def test_anno_image_input_custom_accept_extension_not_accepted(img_file):
 
 def test_anno_image_input_input_names_invalid():
     with pytest.raises(TypeError) as e:
-        test_anno_image_input = AnnotatedImageInput(input_names=["anything"])
+        AnnotatedImageInput(input_names=["anything"])
     assert "AnnotatedImageInput doesn't take input_names" in str(e.value)
 
 

--- a/tests/adapters/test_annotated_image_handler.py
+++ b/tests/adapters/test_annotated_image_handler.py
@@ -480,14 +480,6 @@ def test_anno_image_input_custom_accept_extension_not_accepted(img_file):
     assert "Input file not in supported format list" in str(e.value)
 
 
-def test_anno_image_input_input_names_invalid():
-    with pytest.raises(TypeError) as e:
-        AnnotatedImageInput(input_names=["anything"])
-    assert "AnnotatedImageInput takes specific arguments for image_input_name" in str(
-        e.value
-    )
-
-
 def test_anno_image_input_octet_stream_json(img_file):
     test_anno_image_input = AnnotatedImageInput(accept_image_formats=[".custom"])
     request = mock.MagicMock(spec=flask.Request)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,14 @@ def img_file(tmpdir):
 
 
 @pytest.fixture()
+def json_file(tmpdir):
+    json_file_ = tmpdir.join("test_json.json")
+    with open(json_file_, "w") as of:
+        of.write('{"name": "kaith", "game": "morrowind"}')
+    return str(json_file_)
+
+
+@pytest.fixture()
 def bin_file(tmpdir):
     bin_file_ = tmpdir.join("bin_file")
     with open(bin_file_, "wb") as of:


### PR DESCRIPTION
## Description
Further to [Issue #934](https://github.com/bentoml/BentoML/issues/934)

Added an AnnotatedImageInput adapter that uses multipart/form-data to read in an image file and JSON file at the same time.  This is to handle the common use-case for models that require additional information about an image (such as object detection bounding boxes, segmentation masks, class labels, face keypoints, etc.) 

Unit tests and documentation are included!

## Motivation and Context
See the conversation in [the issue here](https://github.com/bentoml/BentoML/issues/934)

A common use-case for models that take image input is to also include additional information about the image (such as object detection bounding boxes, segmentation masks, class labels, face keypoints, etc.) ImageInput does not allow you to include this kind of information.

## How Has This Been Tested?
Wrote and ran unit tests under all environments using tox.  Successfully using the AnnotatedImageAdapter for my own project for work.

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [x] Documentation
- [x] Test, CI, or build

## Component(s) if applicable
- [x] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (micro-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [x] My change reduces project test coverage and requires unit tests to be added
- [x] I have added unit tests covering my code change
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly

Thanks for reviewing my changes!  As far as areas of concern may go, I'm not sure if my allowance of `is_batch_input` is correct, or if I should instead be raising an error if this is set to True.  I'm not that familiar with AWS lambda (I modeled the corresponding unit tests after MultiImageInput), so that may also be of interest.  Finally, I've been running into some errors stemming from an undefined BentoService repository path after rebasing and running tox (which I don't think these are related to my changes, but I want to be sure).

Thanks again, let me know what needs to be fixed up!
-Evan