### PR TITLE
Handle multiple IAM principals

### DIFF
--- a/bentoml/yatai/deployment/sagemaker/operator.py
+++ b/bentoml/yatai/deployment/sagemaker/operator.py
@@ -85,10 +85,10 @@ def get_arn_role_from_current_aws_user():
         for role in role_list["Roles"]:
             policy_document = role["AssumeRolePolicyDocument"]
             statement = policy_document["Statement"][0]
-            if (
-                statement["Effect"] == "Allow"
-                and statement["Principal"].get("Service", None)
-                == "sagemaker.amazonaws.com"
+            if statement[
+                "Effect"
+            ] == "Allow" and "sagemaker.amazonaws.com" in statement["Principal"].get(
+                "Service", None
             ):
                 arn = role["Arn"]
         if arn is None:

--- a/tests/deployment/sagemaker/test_sagemaker.py
+++ b/tests/deployment/sagemaker/test_sagemaker.py
@@ -68,7 +68,12 @@ def test_get_arn_from_aws_user():
                             "Statement": [
                                 {
                                     "Effect": "Allow",
-                                    "Principal": {"Service": "sagemaker.amazonaws.com"},
+                                    "Principal": {
+                                        "Service": [
+                                            "sagemaker.amazonaws.com",
+                                            "redshift.amazonaws.com",
+                                        ]
+                                    },
                                 }
                             ]
                         },


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
There are cases where an IAM role can have more than one IAM principal in addition to the SageMaker principal. Handle cases where this is true. Experienced this first hand while attempting to deploy to SageMaker in an account where none of the roles had a singular principal in its `AssumeRolePolicyDocument`.

If this condition is unchecked, the following error is produced:
```
Error: sagemaker deploy failed: INTERNAL:Can't find proper Arn role for Sagemaker, please create one and try again
```

## Motivation and Context
Example of an IAM role where this is true:
```
{
        "Path": "/",
        "RoleName": "dummy",
        "RoleId": "ABCDEFGHIJK1234",
        "Arn": "arn:aws:iam::0000111112222:role/dummy",
        "CreateDate": datetime.datetime(2020, 10, 10, 10, 10, 10, tzinfo=tzutc()),
        "AssumeRolePolicyDocument": {
            "Version": "2012-10-17",
            "Statement": [
                {
                    "Effect": "Allow",
                    "Principal": {
                        "Service": ["redshift.amazonaws.com", "sagemaker.amazonaws.com"]
                    },
                    "Action": "sts:AssumeRole",
                }
            ],
        },
        "MaxSessionDuration": 3600,
}
```

## How Has This Been Tested?
Built package+CLI locally and tested in existing environment.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


## Component(s) if applicable
- [x] YataiService gRPC server (model registry, cloud deployment automation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [x] I have added unit tests covering my code change

