### PR TITLE
[Fix] Condition for IAM principal check

### DIFF
--- a/bentoml/yatai/deployment/sagemaker/operator.py
+++ b/bentoml/yatai/deployment/sagemaker/operator.py
@@ -85,10 +85,10 @@ def get_arn_role_from_current_aws_user():
         for role in role_list["Roles"]:
             policy_document = role["AssumeRolePolicyDocument"]
             statement = policy_document["Statement"][0]
-            if statement[
-                "Effect"
-            ] == "Allow" and "sagemaker.amazonaws.com" in statement["Principal"].get(
-                "Service", None
+            if (
+                "Service" in statement["Principal"]
+                and statement["Effect"] == "Allow"
+                and "sagemaker.amazonaws.com" in statement["Principal"]["Service"]
             ):
                 arn = role["Arn"]
         if arn is None:


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
Bugfix for issue stemming from https://github.com/bentoml/BentoML/pull/987

Ran into this error
```
[2020-08-13 22:31:47,711] ERROR - URPC ERROR ApplyDeployment: argument of type 'NoneType' is not iterable
Error: sagemaker deploy failed: INTERNAL:argument of type 'NoneType' is not iterable
```

The issue was that when `statement["Principal"].get("Service", None)` is executed for a policy statement which does not have the `"Service"` key and returns a `None`, the string comparison fails with the `'NoneType' is not iterable` exception. 

*Bonus*: Add unit test for the `Can't find proper Arn role for Sagemaker, please create one and try again` `YataiDeploymentException` exception.

## Motivation and Context
Bug from [previous PR](https://github.com/bentoml/BentoML/pull/987), fixing it here.

## How Has This Been Tested?
Tested this out in an AWS development environment by installing this version of BentoML locally and running the deployment
```
$ pip install --upgrade git+https://github.com/dinakar29/BentoML.git@fix-principal-condition-check
$ bentoml sagemaker deploy <args>
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


## Component(s) if applicable
- [x] YataiService gRPC server (model registry, cloud deployment automation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [x] I have added unit tests covering my code change

