### PR TITLE
[FIX] force start batching server with fork method

### DIFF
--- a/bentoml/cli/bento_service.py
+++ b/bentoml/cli/bento_service.py
@@ -285,7 +285,7 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
     ):
         if not psutil.POSIX:
             _echo(
-                "The `bentoml server-gunicon` command is only supported on POSIX. "
+                "The `bentoml serve-gunicon` command is only supported on POSIX. "
                 "On windows platform, use `bentoml serve` for local API testing and "
                 "docker for running production API endpoint: "
                 "https://docs.docker.com/docker-for-windows/ "

--- a/bentoml/server/marshal_server.py
+++ b/bentoml/server/marshal_server.py
@@ -15,11 +15,23 @@
 import logging
 import multiprocessing
 
+import psutil
 from gunicorn.app.base import Application
 
 from bentoml import config
 from bentoml.marshal.marshal import MarshalService
 from bentoml.server.instruments import setup_prometheus_multiproc_dir
+
+
+if psutil.POSIX:
+    # After Python 3.8, the default start method of multiprocessing for MacOS changed to
+    # spawn, which would cause RecursionError when launching Gunicorn Application.
+    # Ref:
+    # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+    #
+    # Note: https://bugs.python.org/issue33725 claims that fork method may cause crashes
+    # on MacOS.
+    multiprocessing.set_start_method('fork')
 
 marshal_logger = logging.getLogger("bentoml.marshal")
 


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
For MacOS, before Python3.8, the multiprocessing module starts new processes in fork mode by default, and starts new processes in spawn mode by default since 3.8.
The latter will use pickle to pass objects between processes.

And because of the use of `__getattr__` in https://github.com/benoitc/gunicorn/blob/20.0.4/gunicorn/config.py#L54, the magic methods `__getstate__` and `__setstate__` required by pickle to reconstruct the Config object was covered, Which in turn caused the RecursionError.

This PR closes https://github.com/bentoml/BentoML/issues/989
<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [x] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
