### PR TITLE
Optimize image build time

### DIFF
--- a/bentoml/saved_bundle/bentoml-init.sh
+++ b/bentoml/saved_bundle/bentoml-init.sh
@@ -27,9 +27,3 @@ fi
 
 # Install PyPI packages specified in requirements.txt
 pip install -r ./requirements.txt --no-cache-dir
-
-# install sdist or wheel format archives stored under bundled_pip_dependencies directory
-for filename in ./bundled_pip_dependencies/*.tar.gz; do
-  [ -e "$filename" ] || continue
-  pip install -U "$filename" --no-cache-dir
-done

--- a/bentoml/saved_bundle/templates.py
+++ b/bentoml/saved_bundle/templates.py
@@ -71,21 +71,27 @@ graft {service_name}/artifacts
 MODEL_SERVER_DOCKERFILE_CPU = """\
 FROM {docker_base_image}
 
-# copy over model files
-COPY . /bento
-WORKDIR /bento
-
 # Configuring PyPI index
 ARG PIP_INDEX_URL=https://pypi.python.org/simple/
 ARG PIP_TRUSTED_HOST=pypi.python.org
 ENV PIP_INDEX_URL $PIP_INDEX_URL
 ENV PIP_TRUSTED_HOST $PIP_TRUSTED_HOST
 
+# copy over files needed for init script
+COPY environment.yml requirements.txt setup.sh* bentoml-init.sh /bento/
+WORKDIR /bento
+
 # Execute permission for bentoml-init.sh
 RUN chmod +x /bento/bentoml-init.sh
 
 # Install conda, pip dependencies and run user defined setup script
 RUN if [ -f /bento/bentoml-init.sh ]; then bash -c /bento/bentoml-init.sh; fi
+
+# copy over model files
+COPY . /bento
+
+# Install bundled bentoml if it exists (used for development)
+RUN if [ -d /bento/bundled_pip_dependencies ]; then pip install -U bundled_pip_dependencies/* ;fi
 
 # the env var $PORT is required by heroku container runtime
 ENV PORT 5000

--- a/bentoml/service.py
+++ b/bentoml/service.py
@@ -459,7 +459,6 @@ def env_decorator(
 
     def decorator(bento_service_cls):
         bento_service_cls._env = BentoServiceEnv(
-            bento_service_name=bento_service_cls.name(),
             pip_dependencies=pip_dependencies,
             auto_pip_dependencies=auto_pip_dependencies,
             requirements_txt_file=requirements_txt_file,
@@ -638,7 +637,7 @@ class BentoService:
         self._config_environments()
 
     def _config_environments(self):
-        self._env = self.__class__._env or BentoServiceEnv(self.name)
+        self._env = self.__class__._env or BentoServiceEnv()
 
         for api in self._inference_apis:
             self._env.add_pip_dependencies_if_missing(

--- a/bentoml/service_env.py
+++ b/bentoml/service_env.py
@@ -113,7 +113,6 @@ class BentoServiceEnv(object):
 
 
     Args:
-        bento_service_name: name of the BentoService name bundled with this Env
         pip_dependencies: list of pip_dependencies required, specified by package name
             or with specified version `{package_name}=={package_version}`
         auto_pip_dependencies: (Beta) whether to automatically find all the required
@@ -129,7 +128,6 @@ class BentoServiceEnv(object):
 
     def __init__(
         self,
-        bento_service_name: str,
         pip_dependencies: List[str] = None,
         auto_pip_dependencies: bool = False,
         requirements_txt_file: str = None,
@@ -141,7 +139,7 @@ class BentoServiceEnv(object):
         self._python_version = PYTHON_VERSION
 
         self._conda_env = CondaEnv(
-            "bentoml-" + bento_service_name,
+            CONDA_ENV_DEFAULT_NAME,
             self._python_version,
             conda_channels,
             conda_dependencies,


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
I split the copying of the service files in the Dockerfile into two parts:
1. Files required for bento-init.sh
2. The rest of the service files

This allows docker to cache the service dependencies effectively (Copying the whole directory at the beginning invalidates cache each time), thus the same or other services would now be able to reuse this cached layer if they have the same dependencies.

NOTE: I had to keep the conda environment name fixed to avoid cache invalidation when copying it over. (I don't think this is the best way, maybe just offer it as the default?? and allow changing it)

<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
I have a use case where I run celery tasks to build custom bentoml service images very frequently, and push them to a private docker repository. I found that each build was taking too much time, nearly 7 minutes, and was pushing all this to the private repository. I tracked the slowdown to cache invalidation at the very start of the image build (Copying the whole service directory). As a workaround I built a custom base image with all my dependencies.

The build and push time decreased drastically down to ~50 seconds, and also the private repository was using much less storage as it was just saving the changed layers.

If this was built in, I would have got this performance boost out of the box, this would have saved a lot of debugging time and allow changing the dependencies easily as I won't have to rebuild the base image each time, it will just invalidate the cache when the dependencies change. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [x] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [x] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [x] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
