### PR TITLE
[ISSUE-998] per Python minor version docker base image

### DIFF
--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -35,9 +35,9 @@ from bentoml.saved_bundle.pip_pkg import (
 
 logger = logging.getLogger(__name__)
 
-PYTHON_SUPPORTED_VERSIONS = [3.6, 3.7, 3.8]
+PYTHON_SUPPORTED_VERSIONS = ["3.6", "3.7", "3.8"]
 
-PYTHON_MINOR_VERSION = "{major}.{minor}.{micro}".format(
+PYTHON_MINOR_VERSION = "{major}.{minor}".format(
     major=version_info.major, minor=version_info.minor)
 
 PYTHON_VERSION = "{minor_version}.{micro}".format(

--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -35,9 +35,15 @@ from bentoml.saved_bundle.pip_pkg import (
 
 logger = logging.getLogger(__name__)
 
-PYTHON_VERSION = "{major}.{minor}.{micro}".format(
-    major=version_info.major, minor=version_info.minor, micro=version_info.micro
+PYTHON_SUPPORTED_VERSIONS = [3.6, 3.7, 3.8]
+
+PYTHON_MINOR_VERSION = "{major}.{minor}.{micro}".format(
+    major=version_info.major, minor=version_info.minor)
+
+PYTHON_VERSION = "{minor_version}.{micro}".format(
+    minor_version=PYTHON_MINOR_VERSION, micro=version_info.micro
 )
+
 
 # Including 'conda-forge' channel in the default channels to ensure newest Python
 # versions can be installed properly via conda when building API server docker image
@@ -178,7 +184,15 @@ class BentoServiceEnv(object):
         if docker_base_image:
             self._docker_base_image = docker_base_image
         else:
-            self._docker_base_image = config('core').get('default_docker_base_image')
+            if PYTHON_MINOR_VERSION not in PYTHON_SUPPORTED_VERSIONS:
+                logger.warning(
+                        f"current python environment uses Python {PYTHON_VERSION} which is unsupported"
+                        f"the docker image used will contain a different version of Python"
+                        f"supported Python versions are: f{', '.join(PYTHON_SUPPORTED_VERSIONS)}"
+                    )
+                self._docker_base_image = config('core').get('default_docker_base_image')
+            else:
+                self._docker_base_image = config('core').get('default_docker_base_image') + "-py" + PYTHON_MINOR_VERSION.replace(".", "")
 
     def add_conda_channels(self, channels: List[str]):
         self._conda_env.add_channels(channels)

--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -38,7 +38,8 @@ logger = logging.getLogger(__name__)
 PYTHON_SUPPORTED_VERSIONS = ["3.6", "3.7", "3.8"]
 
 PYTHON_MINOR_VERSION = "{major}.{minor}".format(
-    major=version_info.major, minor=version_info.minor)
+    major=version_info.major, minor=version_info.minor
+)
 
 PYTHON_VERSION = "{minor_version}.{micro}".format(
     minor_version=PYTHON_MINOR_VERSION, micro=version_info.micro
@@ -186,13 +187,19 @@ class BentoServiceEnv(object):
         else:
             if PYTHON_MINOR_VERSION not in PYTHON_SUPPORTED_VERSIONS:
                 logger.warning(
-                        f"current python environment uses Python {PYTHON_VERSION} which is unsupported"
-                        f"the docker image used will contain a different version of Python"
-                        f"supported Python versions are: f{', '.join(PYTHON_SUPPORTED_VERSIONS)}"
-                    )
-                self._docker_base_image = config('core').get('default_docker_base_image')
+                    f"Python {PYTHON_VERSION} in current environment is unsupported"
+                    f"the docker image used will contain a different version of Python"
+                    f"supported versions are: f{', '.join(PYTHON_SUPPORTED_VERSIONS)}"
+                )
+                self._docker_base_image = config('core').get(
+                    'default_docker_base_image'
+                )
             else:
-                self._docker_base_image = config('core').get('default_docker_base_image') + "-py" + PYTHON_MINOR_VERSION.replace(".", "")
+                self._docker_base_image = (
+                    config('core').get('default_docker_base_image')
+                    + "-py"
+                    + PYTHON_MINOR_VERSION.replace(".", "")
+                )
 
     def add_conda_channels(self, channels: List[str]):
         self._conda_env.add_channels(channels)

--- a/docker/model-server/Dockerfile
+++ b/docker/model-server/Dockerfile
@@ -9,6 +9,12 @@ RUN conda update -n base -c defaults conda
 ARG BENTOML_VERSION
 ENV BENTOML_VERSION=$BENTOML_VERSION
 
+ARG PYTHON_VERSION
+ENV PYTHON_VERSION=$PYTHON_VERSION
+
+## install proper python major version
+RUN conda install python=$PYTHON_VERSION -y
+
 # pre-install BentoML base dependencies
 RUN pip install bentoml==$BENTOML_VERSION --no-cache-dir
 

--- a/docker/model-server/Dockerfile
+++ b/docker/model-server/Dockerfile
@@ -13,7 +13,7 @@ ARG PYTHON_VERSION
 ENV PYTHON_VERSION=$PYTHON_VERSION
 
 ## install proper python major version
-RUN conda install python=$PYTHON_VERSION -y
+RUN conda install pip python=$PYTHON_VERSION -y
 
 # pre-install BentoML base dependencies
 RUN pip install bentoml==$BENTOML_VERSION --no-cache-dir

--- a/docker/model-server/release.sh
+++ b/docker/model-server/release.sh
@@ -11,17 +11,34 @@ fi
 GIT_ROOT=$(git rev-parse --show-toplevel)
 cd "$GIT_ROOT"/docker/model-server
 
-echo "Releasing debian based docker base image.."
-docker build --pull \
-    --build-arg BENTOML_VERSION="$BENTOML_VERSION" \
-    -t bentoml/model-server:"$BENTOML_VERSION" \
-    -t bentoml/model-server:latest \
-    .
-docker push bentoml/model-server:"$BENTOML_VERSION"
+PYTHON_MAJOR_VERSIONS=(3.6 3.7 3.8)
+#which version to tag with latest tag
+PYTHON_LATEST_VERSION=3.7
+
+
+echo "Building debian based docker base images for ${PYTHON_MAJOR_VERSIONS[*]}"
+for version in "${PYTHON_MAJOR_VERSIONS[@]}"
+do
+    echo "Releasing debian based docker base image for Python $version .."
+    docker build --pull \
+        --build-arg BENTOML_VERSION="$BENTOML_VERSION" \
+        --build-arg PYTHON_VERSION="$version" \
+        -t bentoml/model-server:"$BENTOML_VERSION"-py"${version//.}" \
+        -t bentoml/model-server:latest-py"${version//.}" \
+        .
+
+    docker push bentoml/model-server:"$BENTOML_VERSION"-py"${version//.}"
+    docker push bentoml/model-server:latest-py"${version//.}"
+
+done
+
+# tag the default version as both latest and unspecified python version
+docker tag bentoml/model-server:latest-py${PYTHON_LATEST_VERSION//.} bentoml/model-server:latest
 docker push bentoml/model-server:latest
 
+docker tag bentoml/model-server:$BENTOML_VERSION-py${PYTHON_LATEST_VERSION//.} bentoml/model-server:$BENTOML_VERSION
+docker push bentoml/model-server:$BENTOML_VERSION
 
-PYTHON_MAJOR_VERSIONS=(3.6 3.7 3.8)
 echo "Building slim docker base images for ${PYTHON_MAJOR_VERSIONS[*]}"
 for version in "${PYTHON_MAJOR_VERSIONS[@]}"
 do

--- a/tests/test_service_env.py
+++ b/tests/test_service_env.py
@@ -10,7 +10,7 @@ from bentoml.artifact import SklearnModelArtifact
 
 
 def test_pip_packages_env_with_legacy_api():
-    @bentoml.env(pip_dependencies=['numpy', 'pandas', 'torch'])
+    @bentoml.env(pip_packages=['numpy', 'pandas', 'torch'])
     class ServiceWithList(bentoml.BentoService):
         @bentoml.api(input=DataframeInput())
         def predict(self, df):


### PR DESCRIPTION
## Description

The major changes are:
- release docker images for each supported python version, similar to slim images
- use the docker image corresponding to the environment python version, if it is supported

Minor change:
- fix of error in test code (incorrect arg name)

## Motivation and Context

#998 

## How Has This Been Tested?

All tests passed. 

Ran docker release script and confirmed all images built

Tested build with different python versions to confirm the base image changed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

This is a breaking change since it will change the base image used to be different than previous, depending on the environment. This, along with #1084, will no longer install python via conda.

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [x] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
