### PR TITLE
[Refactor] rename JsonSerializableOutput to JsonOutput

### DIFF
--- a/bentoml/adapters/__init__.py
+++ b/bentoml/adapters/__init__.py
@@ -28,7 +28,7 @@ from bentoml.adapters.default_output import DefaultOutput
 from bentoml.adapters.file_input import FileInput
 from bentoml.adapters.image_input import ImageInput
 from bentoml.adapters.json_input import JsonInput
-from bentoml.adapters.json_output import JsonSerializableOutput
+from bentoml.adapters.json_output import JsonOutput
 from bentoml.adapters.multi_file_input import MultiFileInput
 from bentoml.adapters.multi_image_input import MultiImageInput
 from bentoml.adapters.string_input import StringInput
@@ -44,7 +44,7 @@ __all__ = [
     'TfTensorOutput',
     "JsonInput",
     "StringInput",
-    'JsonSerializableOutput',
+    'JsonOutput',
     "ImageInput",
     "MultiImageInput",
     "FileInput",

--- a/bentoml/adapters/dataframe_output.py
+++ b/bentoml/adapters/dataframe_output.py
@@ -1,7 +1,7 @@
 import json
 from typing import Sequence
 
-from bentoml.adapters.json_output import JsonSerializableOutput
+from bentoml.adapters.json_output import JsonOutput
 from bentoml.types import InferenceError, InferenceResult, InferenceTask
 from bentoml.utils.dataframe_util import PANDAS_DATAFRAME_TO_JSON_ORIENT_OPTIONS
 
@@ -21,7 +21,7 @@ def df_to_json(result, pandas_dataframe_orient="records"):
     return json.dumps(result)
 
 
-class DataframeOutput(JsonSerializableOutput):
+class DataframeOutput(JsonOutput):
     """
     Converts result of user defined API function into specific output.
 

--- a/bentoml/adapters/default_output.py
+++ b/bentoml/adapters/default_output.py
@@ -46,9 +46,9 @@ def detect_suitable_adapter(result) -> Type[BaseOutputAdapter]:
     except ImportError:
         pass
 
-    from .json_output import JsonSerializableOutput
+    from .json_output import JsonOutput
 
-    return JsonSerializableOutput
+    return JsonOutput
 
 
 class DefaultOutput(BaseOutputAdapter):

--- a/bentoml/adapters/json_output.py
+++ b/bentoml/adapters/json_output.py
@@ -33,7 +33,7 @@ from bentoml.types import (
 ApiFuncReturnValue = Sequence[JsonSerializable]
 
 
-class JsonSerializableOutput(BaseOutputAdapter):
+class JsonOutput(BaseOutputAdapter):
     """
     Converts result of user defined API function into specific output.
 

--- a/bentoml/adapters/tensorflow_tensor_output.py
+++ b/bentoml/adapters/tensorflow_tensor_output.py
@@ -16,7 +16,7 @@ import json
 from typing import Sequence
 
 from bentoml.adapters.base_output import regroup_return_value
-from bentoml.adapters.json_output import JsonSerializableOutput
+from bentoml.adapters.json_output import JsonOutput
 from bentoml.adapters.utils import TfTensorJsonEncoder
 from bentoml.types import InferenceError, InferenceResult, InferenceTask
 from bentoml.utils.lazy_loader import LazyLoader
@@ -41,7 +41,7 @@ def tf_to_numpy(tensor):
         return tensor.numpy()
 
 
-class TfTensorOutput(JsonSerializableOutput):
+class TfTensorOutput(JsonOutput):
     """
     Converts result of user defined API function into specific output.
 

--- a/docs/source/api/adapters.rst
+++ b/docs/source/api/adapters.rst
@@ -70,9 +70,9 @@ TfTensorOutput
 ++++++++++++++
 .. autoclass:: bentoml.adapters.TfTensorOutput
 
-JsonSerializableOutput
+JsonOutput
 ++++++++++++++++++++++
-.. autoclass:: bentoml.adapters.JsonSerializableOutput
+.. autoclass:: bentoml.adapters.JsonOutput
 
 
 Adapter Roadmap


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
Rename JsonSerializableOutput to JsonOutput to fit the JsonInput
<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [x] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [x] I have added unit tests covering my code change
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
