### PR TITLE
Add multipart/form-data support for StringInput

### DIFF
--- a/bentoml/adapters/string_input.py
+++ b/bentoml/adapters/string_input.py
@@ -88,7 +88,7 @@ class StringInput(BaseInputAdapter):
         for input_ in parse_cli_input(cli_args):
             try:
                 bytes_ = input_.read()
-                charset = chardet.detect(bytes_)['encoding']  # charset for cli input
+                charset = chardet.detect(bytes_)['encoding'] or "utf-8"
                 yield InferenceTask(
                     cli_args=cli_args, data=bytes_.decode(charset),
                 )

--- a/bentoml/adapters/string_input.py
+++ b/bentoml/adapters/string_input.py
@@ -14,6 +14,8 @@
 
 from typing import Iterable, Iterator, Sequence, Tuple
 
+import chardet
+
 from bentoml.adapters.base_input import BaseInputAdapter, parse_cli_input
 from bentoml.adapters.utils import decompress_gzip_request
 from bentoml.types import AwsLambdaEvent, HTTPRequest, InferenceTask
@@ -52,11 +54,22 @@ class StringInput(BaseInputAdapter):
 
     @decompress_gzip_request
     def from_http_request(self, req: HTTPRequest) -> InferenceTask[str]:
+        if req.headers.content_type == 'multipart/form-data':
+            _, _, files = HTTPRequest.parse_form_data(req)
+            if len(files) != 1:
+                return InferenceTask().discard(
+                    http_status=400,
+                    err_msg=f"BentoML#{self.__class__.__name__} accepts one text file "
+                    "at a time",
+                )
+            input_file = next(iter(files.values()))
+            bytes_ = input_file.read()
+            charset = chardet.detect(bytes_)['encoding'] or "utf-8"
+        else:
+            bytes_ = req.body
+            charset = req.headers.charset or "utf-8"
         try:
-            return InferenceTask(
-                http_headers=req.headers,
-                data=req.body.decode(req.headers.charset or "utf-8"),
-            )
+            return InferenceTask(http_headers=req.headers, data=bytes_.decode(charset),)
         except UnicodeDecodeError:
             return InferenceTask().discard(
                 http_status=400,
@@ -74,14 +87,21 @@ class StringInput(BaseInputAdapter):
     def from_cli(self, cli_args: Tuple[str]) -> Iterator[InferenceTask[str]]:
         for input_ in parse_cli_input(cli_args):
             try:
+                bytes_ = input_.read()
+                charset = chardet.detect(bytes_)['encoding']  # charset for cli input
                 yield InferenceTask(
-                    cli_args=cli_args,
-                    data=input_.read().decode(),  # charset for cli input
+                    cli_args=cli_args, data=bytes_.decode(charset),
                 )
             except UnicodeDecodeError:
                 yield InferenceTask().discard(
                     http_status=400,
-                    err_msg=f"{self.__class__.__name__}: UnicodeDecodeError",
+                    err_msg=f"{self.__class__.__name__}: "
+                    f"Try decoding with {charset} but failed with DecodeError.",
+                )
+            except LookupError:
+                return InferenceTask().discard(
+                    http_status=400,
+                    err_msg=f"{self.__class__.__name__}: Unsupported charset {charset}",
                 )
 
     def extract_user_func_args(

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ install_requires = [
     'contextvars;python_version < "3.7"',
     'dataclasses;python_version < "3.7"',
     "multidict",
+    "chardet",
 ]
 
 test_requires = [


### PR DESCRIPTION
- Add multipart/form-data support for StringInput
- Update string_input.py

<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
Add multipart/form-data support for StringInput
<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [x] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
