### PR TITLE
[Enhancement]Use latest tag for bentoml containerize command

### DIFF
--- a/bentoml/cli/bento_service.py
+++ b/bentoml/cli/bento_service.py
@@ -392,11 +392,10 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
             tag = f"{name}:{version}"
         if ":" not in tag:
             _echo(
-                "Image version not specified, using version parsed "
-                f"from BentoService: '{version}'",
+                "Image version not specified, using 'latest` tag instead",
                 CLI_COLOR_WARNING,
             )
-            tag = f"{tag}:{version}"
+            tag = f"{tag}:latest"
 
         docker_build_args = {}
         if build_arg:

--- a/bentoml/cli/bento_service.py
+++ b/bentoml/cli/bento_service.py
@@ -426,13 +426,19 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
                     _echo(line)
 
             if tag_latest:
-                image_name = f'{tag.split(":")[0]}'
-                _echo(f'Tagging latest: {image_name}:latest')
-                try:
-                    docker_api.tag(image=tag, repository=image_name, tag='latest')
-                    _echo(f'Finished tagging {image_name}:lateset')
-                except docker.errors.APIError as error:
-                    _echo(f'Failed to tag "latest" for {tag}: {error}', CLI_COLOR_ERROR)
+                image_name, current_tag = tag.split(":")
+                if current_tag == "latest":
+                    _echo('Skipping building "latest" tag.')
+                else:
+                    _echo(f'Tagging latest: {image_name}:latest')
+                    try:
+                        docker_api.tag(image=tag, repository=image_name, tag='latest')
+                        _echo(f'Finished tagging {image_name}:lateset')
+                    except docker.errors.APIError as error:
+                        _echo(
+                            f'Failed to tag "latest" for {tag}: {error}',
+                            CLI_COLOR_ERROR,
+                        )
         except docker.errors.APIError as error:
             raise CLIException(f'Could not build Docker image: {error}')
 


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

Current behavior:
If a user provides a docker image tag value without `:` for `bentoml containerize` command, BentoML will use the bento's version instead for the tag
```
$ bentoml containerize irisclassifier:version123 -t my_custom_image
> Docker image ->  my_custom_image:version123
```

This PR will add an option `--tag-latest/--do-not-tag-latest` to `bentoml containerize` command

```
$ bentoml containerize irisclassifier:latest
> Docker image ->  irisclassifier:actual_version,   irisclassifier:latest

$ bentoml containerize irisclassifier:latest --tag my_image
> Docker image-> my_image:actual_version, my_image:latest

$ bentoml containerize irisclassifier:latest --do-not-tag-latest
> Docker image -> irisclassifier:actual_version
```



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [x] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
