### PR TITLE
[Fix] adapter is not set for DefaultOutput, when user function returns InferenceResult

### DIFF
--- a/bentoml/adapters/default_output.py
+++ b/bentoml/adapters/default_output.py
@@ -79,28 +79,19 @@ class DefaultOutput(BaseOutputAdapter):
         raise NotImplementedError()
 
     def to_http_response(self, result) -> HTTPResponse:
-        # If the actual_adapter is still None, use the base output adapter (JsonOutput).
         if self.actual_adapter is None:
-            from .json_output import JsonOutput
-
-            self.actual_adapter = JsonOutput()
+            self.actual_adapter = detect_suitable_adapter(result)()
 
         return self.actual_adapter.to_http_response(result)
 
     def to_cli(self, results) -> int:
-        # If actual_adapter is not set, use the base output adapter (JsonOutput).
         if self.actual_adapter is None:
-            from .json_output import JsonOutput
-
-            self.actual_adapter = JsonOutput()
+            self.actual_adapter = detect_suitable_adapter(results)()
 
         return self.actual_adapter.to_cli(results)
 
     def to_aws_lambda_event(self, result) -> AwsLambdaEvent:
-        # If actual_adapter is not set, use the base output adapter (JsonOutput).
         if self.actual_adapter is None:
-            from .json_output import JsonOutput
-
-            self.actual_adapter = JsonOutput()
+            self.actual_adapter = detect_suitable_adapter(result)()
 
         return self.actual_adapter.to_aws_lambda_event(result)

--- a/bentoml/adapters/default_output.py
+++ b/bentoml/adapters/default_output.py
@@ -79,10 +79,28 @@ class DefaultOutput(BaseOutputAdapter):
         raise NotImplementedError()
 
     def to_http_response(self, result) -> HTTPResponse:
+        # If the actual_adapter is still None, use the base output adapter (JsonOutput).
+        if self.actual_adapter is None:
+            from .json_output import JsonOutput
+
+            self.actual_adapter = JsonOutput()
+
         return self.actual_adapter.to_http_response(result)
 
     def to_cli(self, results) -> int:
+        # If actual_adapter is not set, use the base output adapter (JsonOutput).
+        if self.actual_adapter is None:
+            from .json_output import JsonOutput
+
+            self.actual_adapter = JsonOutput()
+
         return self.actual_adapter.to_cli(results)
 
     def to_aws_lambda_event(self, result) -> AwsLambdaEvent:
+        # If actual_adapter is not set, use the base output adapter (JsonOutput).
+        if self.actual_adapter is None:
+            from .json_output import JsonOutput
+
+            self.actual_adapter = JsonOutput()
+
         return self.actual_adapter.to_aws_lambda_event(result)

--- a/tests/adapters/test_default_output.py
+++ b/tests/adapters/test_default_output.py
@@ -1,0 +1,67 @@
+import json
+import pytest
+
+import flask
+
+from bentoml.adapters import DataframeInput
+from bentoml.types import InferenceResult
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+
+@pytest.fixture()
+def api_returns_inference_result(make_api):
+    def test_func_inference_result(df):
+        return [
+            InferenceResult(
+                data=json.dumps({'name': 'john'}),
+                http_status=200,
+                http_headers={
+                    'Content-Type': 'application/json',
+                    'Access-Control-Allow-Origin': '*',
+                },
+            )
+        ]
+
+    api = make_api(DataframeInput(), test_func_inference_result)
+    return api
+
+
+def test_default_output_http_requests(api_returns_inference_result):
+    csv_data = b'name,game,city\njohn,mario,sf'
+    request = MagicMock(spec=flask.Request)
+    request.headers = {'Content-Type': 'text/csv'}
+    request.get_data.return_value = csv_data
+
+    result = api_returns_inference_result.handle_request(request)
+    assert result.get_data().decode('utf-8') == '{"name": "john"}'
+    assert result.headers['Content-Type'] == 'application/json'
+    assert result.headers['Access-Control-Allow-Origin'] == '*'
+
+
+def test_default_output_cli(capsys, api_returns_inference_result, tmpdir):
+    json_file = tmpdir.join("test.csv")
+    with open(str(json_file), "w") as f:
+        f.write('name,game,city\njohn,mario,sf')
+
+    test_args = ["--input-file", str(json_file), "--format", "csv"]
+    api_returns_inference_result.handle_cli(test_args)
+    out, _ = capsys.readouterr()
+    assert "john" in out
+
+
+def test_default_output_aws_lambda(api_returns_inference_result):
+    test_content = '[{"name": "john","game": "mario","city": "sf"}]'
+
+    event_without_content_type_header = {
+        "headers": {},
+        "body": test_content,
+    }
+    response = api_returns_inference_result.handle_aws_lambda_event(
+        event_without_content_type_header
+    )
+    assert response["statusCode"] == 200
+    assert response["body"] == '{"name": "john"}'

--- a/tests/adapters/test_default_output.py
+++ b/tests/adapters/test_default_output.py
@@ -13,7 +13,7 @@ except ImportError:
 
 
 @pytest.fixture(name='inference_result_api')
-def inference_result_api(make_api):
+def api_returns_inference_result(make_api):
     def test_func_inference_result(df):
         return [
             InferenceResult(

--- a/tests/adapters/test_default_output.py
+++ b/tests/adapters/test_default_output.py
@@ -12,12 +12,12 @@ except ImportError:
     from mock import MagicMock
 
 
-@pytest.fixture()
-def api_returns_inference_result(make_api):
+@pytest.fixture(name='inference_result_api')
+def inference_result_api(make_api):
     def test_func_inference_result(df):
         return [
             InferenceResult(
-                data=json.dumps({'name': 'john'}),
+                data=json.dumps({'name': df['name'][0]}),
                 http_status=200,
                 http_headers={
                     'Content-Type': 'application/json',
@@ -30,37 +30,37 @@ def api_returns_inference_result(make_api):
     return api
 
 
-def test_default_output_http_requests(api_returns_inference_result):
+def test_default_output_http_requests(inference_result_api):
     csv_data = b'name,game,city\njohn,mario,sf'
     request = MagicMock(spec=flask.Request)
     request.headers = {'Content-Type': 'text/csv'}
     request.get_data.return_value = csv_data
 
-    result = api_returns_inference_result.handle_request(request)
+    result = inference_result_api.handle_request(request)
     assert result.get_data().decode('utf-8') == '{"name": "john"}'
     assert result.headers['Content-Type'] == 'application/json'
     assert result.headers['Access-Control-Allow-Origin'] == '*'
 
 
-def test_default_output_cli(capsys, api_returns_inference_result, tmpdir):
+def test_default_output_cli(capsys, inference_result_api, tmpdir):
     json_file = tmpdir.join("test.csv")
     with open(str(json_file), "w") as f:
         f.write('name,game,city\njohn,mario,sf')
 
     test_args = ["--input-file", str(json_file), "--format", "csv"]
-    api_returns_inference_result.handle_cli(test_args)
+    inference_result_api.handle_cli(test_args)
     out, _ = capsys.readouterr()
     assert "john" in out
 
 
-def test_default_output_aws_lambda(api_returns_inference_result):
+def test_default_output_aws_lambda(inference_result_api):
     test_content = '[{"name": "john","game": "mario","city": "sf"}]'
 
     event_without_content_type_header = {
         "headers": {},
         "body": test_content,
     }
-    response = api_returns_inference_result.handle_aws_lambda_event(
+    response = inference_result_api.handle_aws_lambda_event(
         event_without_content_type_header
     )
     assert response["statusCode"] == 200


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
Fix #1158 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
