### PR TITLE
[Fix] ensure ImageInput adapters return numpy array.

### DIFF
--- a/bentoml/adapters/annotated_image_input.py
+++ b/bentoml/adapters/annotated_image_input.py
@@ -192,7 +192,7 @@ class AnnotatedImageInput(MultiFileInput):
                 assert getattr(image_file, "name", None)
                 assert check_file_extension(image_file.name, self.accept_image_formats)
                 image_array = imageio.imread(image_file, pilmode=self.pilmode)
-                image_arrays.append(image_array)
+                image_arrays.append(numpy.array(image_array))
                 if json_file is not None:
                     json_objs.append(json.load(json_file))
                 else:

--- a/bentoml/adapters/image_input.py
+++ b/bentoml/adapters/image_input.py
@@ -182,7 +182,7 @@ class ImageInput(FileInput):
                 continue
             try:
                 img_array = imageio.imread(task.data, pilmode=self.pilmode)
-                img_list.append(img_array)
+                img_list.append(numpy.array(img_array))
             except ValueError as e:
                 task.discard(http_status=400, err_msg=str(e))
 

--- a/bentoml/adapters/multi_image_input.py
+++ b/bentoml/adapters/multi_image_input.py
@@ -169,7 +169,8 @@ class MultiImageInput(MultiFileInput):
                     for f in task.data
                 )
                 image_array_tuple = tuple(
-                    imageio.imread(f, pilmode=self.pilmode) for f in task.data
+                    numpy.array(imageio.imread(f, pilmode=self.pilmode))
+                    for f in task.data
                 )
                 yield image_array_tuple
             except ValueError:

--- a/tests/adapters/test_annotated_image_input.py
+++ b/tests/adapters/test_annotated_image_input.py
@@ -2,6 +2,7 @@
 import os
 import io
 
+import numpy
 import pytest
 from urllib3.filepost import encode_multipart_formdata
 
@@ -53,6 +54,7 @@ def test_anno_image_input_extract_args_custom_extension(
     args = input_adapter.extract_user_func_args([task])
     for img, json_obj in zip(*args):
         assert img.shape == (10, 10, 3)
+        assert isinstance(img, numpy.ndarray)
         assert json_obj['name'] == "kaith"
 
 

--- a/tests/adapters/test_image_input.py
+++ b/tests/adapters/test_image_input.py
@@ -2,6 +2,7 @@
 import base64
 
 import pytest
+import numpy
 
 from bentoml.adapters import ImageInput
 from bentoml.types import HTTPRequest
@@ -86,6 +87,7 @@ def test_image_input_extract(input_adapter, tasks, invalid_tasks):
     api_args = input_adapter.extract_user_func_args(tasks + invalid_tasks)
     obj_list = api_args[0]
     assert len(obj_list) == len(tasks)
+    assert isinstance(obj_list[0], numpy.ndarray)
 
     for out, task in zip(obj_list, tasks + invalid_tasks):
         if not task.is_discarded:

--- a/tests/adapters/test_multi_image_input.py
+++ b/tests/adapters/test_multi_image_input.py
@@ -1,6 +1,7 @@
 # pylint: disable=redefined-outer-name
 import io
 
+import numpy
 import pytest
 
 from bentoml.adapters import MultiImageInput
@@ -36,7 +37,9 @@ def verify_args():
 
         for img1, img2 in zip(*args):
             assert img1.shape == (10, 10, 3)
+            assert isinstance(img1, numpy.ndarray)
             assert img2.shape == (10, 10, 3)
+            assert isinstance(img2, numpy.ndarray)
 
     return _
 


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
* Fix #1157 
* Add testing for the return value for ImageInput, AnnotationImageInput, MultiImageInput

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [x] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
