### PR TITLE
Faster image rebuilding when only model artifacts are updated

### DIFF
--- a/bentoml/saved_bundle/bentoml-init.sh
+++ b/bentoml/saved_bundle/bentoml-init.sh
@@ -42,6 +42,7 @@ if command -v conda >/dev/null 2>&1; then
 
   echo "Updating conda base environment with environment.yml"
   conda env update -n base -f ./environment.yml
+  conda clean --all
 else
   echo "WARNING: conda command not found, skipping conda dependencies in environment.yml"
 fi


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Slack thread:
> Hi there! I assume bentoml is intended to create docker images that contain all of the dependencies. Are there any plans on injecting model weights dynamically after the docker is already created? Maybe it's already possible? This would dramatically reduce the size of the docker image when the model files are big.

There are two ways to achieve this:
1. Inject model weights directly into the container and hot reload the service without a restart.
1. Inject model weights into the image and restart a new container.

For [1], the hot-updating of weights highly relies on frameworks' API. Since `bentoml` supports more than just one framework, it's not consistent to just support some of them.

And [2] is hardly the same as:
* Build a new image with the new model weights without rebuilding the full image.

And also, model files are not bigger than so-called _weights_ much. In fact, **weights account for 99% of the size of a saved model.**
Take TensorFlow saved model as an example. There are `saved_model` and `checkpoint` for tf [official docs](https://www.tensorflow.org/guide/saved_model):
> A SavedModel contains a complete TensorFlow program, including weights and computation. If you just want to save/load weights during training see the guide to training checkpoints.

Try to save a tf model as both of them, you will find them hardly the same on size (the difference is about 100K).

Therefore I think leaving saved models (artifacts) as a separate layer is enough.

## Description
<!--- Describe your changes in detail -->
Make the copy operation of artifacts (models in most cases) the last step in the docker build, thereby saving artifacts as a separate layer.

Also reduced image size by calling `conda clean --all` in `bentoml-init.sh`
```
(py36) git:bojiang(docker) ➜  bentoml docker history 76ff00c17411
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
76ff00c17411        26 seconds ago      /bin/sh -c #(nop)  CMD ["bentoml" "serve-gun…   0B
b6b0ff3a0f00        26 seconds ago      /bin/sh -c #(nop)  ENTRYPOINT ["docker-entry…   0B
d2a190b08ac2        26 seconds ago      /bin/sh -c #(nop)  EXPOSE 5000                  0B
8d15d9caf6a3        26 seconds ago      /bin/sh -c #(nop)  ENV PORT=5000                0B
98e5920dc1c2        26 seconds ago      /bin/sh -c #(nop) COPY dir:a13e2e0bc61e4515d…   1.86MB
c1c2781a9086        27 seconds ago      /bin/sh -c if [ -d /bento/bundled_pip_depend…   0B
77ed248c4a8f        27 seconds ago      /bin/sh -c #(nop) COPY multi:29273dad2100153…   537kB
6bf475223430        28 seconds ago      /bin/sh -c if [ -f /bento/bentoml-init.sh ];…   968MB
a80dbb5db084        12 minutes ago      /bin/sh -c chmod +x /bento/bentoml-init.sh /…   3.04kB
72e7263541db        12 minutes ago      /bin/sh -c #(nop) COPY file:268f29c046e12bc7…   699B
456f438a91e4        12 minutes ago      /bin/sh -c #(nop) WORKDIR /bento                0B
371730e1ccdf        12 minutes ago      /bin/sh -c #(nop) COPY multi:e78a88d8d2bd58a…   2.51kB
658d204a1d06        17 hours ago        /bin/sh -c #(nop)  ENV EXTRA_PIP_INSTALL_ARG…   0B
e43597df26ca        17 hours ago        /bin/sh -c #(nop)  ARG EXTRA_PIP_INSTALL_ARG…   0B
1685aadc028b        3 weeks ago         /bin/sh -c #(nop)  CMD ["bentoml" "serve-gun…   0B
<missing>           3 weeks ago         /bin/sh -c #(nop)  ENTRYPOINT ["entrypoint.s…   0B
<missing>           3 weeks ago         /bin/sh -c #(nop) COPY file:183fc6d06e11b722…   741B
<missing>           3 weeks ago         /bin/sh -c pip install bentoml==$BENTOML_VER…   167MB
<missing>           3 weeks ago         /bin/sh -c conda install pip python=$PYTHON_…   212MB
<missing>           3 weeks ago         /bin/sh -c #(nop)  ENV PYTHON_VERSION=3.6       0B
<missing>           3 weeks ago         /bin/sh -c #(nop)  ARG PYTHON_VERSION           0B
<missing>           3 weeks ago         /bin/sh -c #(nop)  ENV BENTOML_VERSION=0.9.0    0B
<missing>           8 weeks ago         /bin/sh -c #(nop)  ARG BENTOML_VERSION          0B
<missing>           8 weeks ago         /bin/sh -c conda update -n base -c defaults …   114MB
<missing>           4 months ago        /bin/sh -c apt-get update --fix-missing &&  …   184MB
<missing>           7 months ago        /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>           7 months ago        /bin/sh -c wget --quiet https://repo.anacond…   149MB
<missing>           7 months ago        /bin/sh -c apt-get update --fix-missing &&  …   210MB
<missing>           7 months ago        /bin/sh -c #(nop)  ENV PATH=/opt/conda/bin:/…   0B
<missing>           7 months ago        /bin/sh -c #(nop)  ENV LANG=C.UTF-8 LC_ALL=C…   0B
<missing>           7 months ago        /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>           7 months ago        /bin/sh -c #(nop) ADD file:e5a364615e0f69616…   69.2MB
```
A docker image of a typical MNIST classifier service by this change. The artifacts coping is in the top layer 98e5920dc1c2 now. This layer is small enough.


<!--- Attach screenshots here if appropriate. -->

<!--- If it is based on a conversation in the Slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested with an MNIST classifier example.
**It only takes a few seconds to build newly trained models into docker images now (if the requirements don't change).**
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (an internal change which is not user-facing)
- [ ] Documentation
- [x] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [x] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
