### PR TITLE
[Fix] Allow delete bento that was previously deleted that share the same name:version. 

### DIFF
--- a/bentoml/yatai/repository/metadata_store.py
+++ b/bentoml/yatai/repository/metadata_store.py
@@ -156,7 +156,7 @@ class BentoMetadataStore(object):
             try:
                 bento_obj = (
                     sess.query(Bento)
-                    .filter_by(name=bento_name, version=bento_version)
+                    .filter_by(name=bento_name, version=bento_version, deleted=False)
                     .one()
                 )
                 if bento_obj.deleted:
@@ -215,7 +215,7 @@ class BentoMetadataStore(object):
             try:
                 bento_obj = (
                     sess.query(Bento)
-                    .filter_by(name=bento_name, version=bento_version)
+                    .filter_by(name=bento_name, version=bento_version, deleted=False)
                     .one()
                 )
                 if bento_obj.deleted:

--- a/tests/yatai/client/test_bento_repository_api.py
+++ b/tests/yatai/client/test_bento_repository_api.py
@@ -9,6 +9,7 @@ from bentoml.yatai.label_store import _validate_labels
 
 logger = logging.getLogger('bentoml.test')
 
+
 def test_validate_labels_fails():
     with pytest.raises(InvalidArgument):
         _validate_labels(


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
Fix #1209 

Issue:
BentoML was getting and deleting records already marked deleted, when users are setting the version to be the same, for example: `svc.save(version="1")`, bentoml will throw error.

Solution:
make sure fetching/deleting records that is not marked deleted.

- [x] Fix bug
- [x] Add tests


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
