### PR TITLE
Update import paths to reflect fastai2->fastai rename

### DIFF
--- a/bentoml/frameworks/fastai.py
+++ b/bentoml/frameworks/fastai.py
@@ -26,7 +26,7 @@ def _import_fastai2_module():
     except ImportError:
         raise MissingDependencyException(
             "fastai2 package is required to use "
-            "bentoml.artifacts.Fastai2ModelArtifact"
+            "bentoml.artifacts.FastaiModelArtifact"
         )
 
     return fastai
@@ -134,7 +134,7 @@ class FastaiModelArtifact(BentoServiceArtifact):
 
     Example usage:
 
-    >>> from fastai2.vision.learner import cnn_learner
+    >>> from fastai.vision.learner import cnn_learner
     >>>
     >>> learner = cnn_learner(...)
     >>> # train model
@@ -186,7 +186,7 @@ class FastaiModelArtifact(BentoServiceArtifact):
     def set_dependencies(self, env: BentoServiceEnv):
         logger.warning(
             "BentoML by default does not include spacy and torchvision package when "
-            "using Fastai2ModelArtifact. To make sure BentoML bundle those packages if "
+            "using FastaiModelArtifact. To make sure BentoML bundle those packages if "
             "they are required for your model, either import those packages in "
             "BentoService definition file or manually add them via "
             "`@env(pip_packages=['torchvision'])` when defining a BentoService"


### PR DESCRIPTION
# Description
Going through the code comments made it pretty confusing since the import paths across projects vary.

This just updates those comments with what works.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [x] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
