### PR TITLE
[FIX] TfSavedModelArtifact packed model behavior

### DIFF
--- a/tests/integration/test_tensorflow_v2_2_savedmodel_artifact.py
+++ b/tests/integration/test_tensorflow_v2_2_savedmodel_artifact.py
@@ -2,9 +2,9 @@
 import json
 
 import pytest
+import tensorflow as tf
 
 import bentoml
-import tensorflow as tf
 from tests.bento_service_examples.tensorflow_classifier import Tensorflow2Classifier
 from tests.integration.api_server.conftest import (
     build_api_server_docker_image,
@@ -41,6 +41,7 @@ def tf2_svc():
 
     svc = Tensorflow2Classifier()
     model = Tensorflow2Model()
+    model.predict(test_data)
     svc.pack('model', model)
 
     return svc


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->

```python
class Tensorflow2Model(tf.keras.Model):
    def __init__(self):
          super(Tensorflow2Model, self).__init__()
          # Simple linear layer which sums the inputs
          self.dense = tf.keras.layers.Dense(
              units=1,
              input_shape=(5,),
              use_bias=False,
              kernel_initializer=tf.keras.initializers.Ones(),
          )

    def call(self, inputs):
          return self.dense(inputs)


model = Tensorflow2Model()

svc = Tensorflow2Classifier()
svc.pack('model', model)
```

The behavior of `svc.artifacts.model` before save/load and after are inconsistent.

This PR should fix this.

Breaking change:
* it may break some tests that rely on the original model behavior before save/load.

<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in the Slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (an internal change which is not user-facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [x] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [x] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
