### PR TITLE
[Refactor] opt auto casting of TfSavedModelArtifact & clearer feedback

### DIFF
--- a/bentoml/frameworks/tensorflow.py
+++ b/bentoml/frameworks/tensorflow.py
@@ -248,7 +248,23 @@ class TensorflowSavedModelArtifact(BentoServiceArtifact):
             self._path = obj
         self._packed = True
         loaded = self.get()
+        logger.warning(
+            f"Due to TensorFlow's save and load mechanism, only methods marked by "
+            f"`tf.function` (and some keras defaults) could be restored after "
+            f"packing & loading.\n"
+            f"You can test the restored model object by referring:\n"
+            f"<bento_svc>.artifacts.{self.name}\n"
+        )
         logger.info(pretty_format_restored_model(loaded))
+        if hasattr(loaded, "keras_api"):
+            logger.warning(
+                f"You may be using `{self.__class__.__name__}` to pack a keras model. "
+                "It works but may cause performance issues. Consider:\n"
+                f" * replacing `{self.__class__.__name__}` with `KerasModelArtifact` "
+                "(relatively good performance)\n"
+                f" * keeping `{self.__class__.__name__}`, wrapping the "
+                "`keras_model.predict` with a `tf.function`. (best performance)\n"
+            )
         return self
 
     def get(self):

--- a/bentoml/frameworks/tensorflow.py
+++ b/bentoml/frameworks/tensorflow.py
@@ -249,21 +249,20 @@ class TensorflowSavedModelArtifact(BentoServiceArtifact):
         self._packed = True
         loaded = self.get()
         logger.warning(
-            f"Due to TensorFlow's save and load mechanism, only methods marked by "
-            f"`tf.function` (and some keras defaults) could be restored after "
-            f"packing & loading.\n"
-            f"You can test the restored model object by referring:\n"
+            "Due to TensorFlow's internal mechanism, only methods wrapped under "
+            "`@tf.function` decorator and Keras model API methods including predict"
+            " and xxxx can be restored after a save & load.\n"
+            "You can test the restored model object by referring:\n"
             f"<bento_svc>.artifacts.{self.name}\n"
         )
         logger.info(pretty_format_restored_model(loaded))
         if hasattr(loaded, "keras_api"):
             logger.warning(
-                f"You may be using `{self.__class__.__name__}` to pack a keras model. "
-                "It works but may cause performance issues. Consider:\n"
-                f" * replacing `{self.__class__.__name__}` with `KerasModelArtifact` "
-                "(relatively good performance)\n"
-                f" * keeping `{self.__class__.__name__}`, wrapping the "
-                "`keras_model.predict` with a `tf.function`. (best performance)\n"
+                f"BentoML detected that {self.__class__.__name__} is being used "
+                "to pack a Keras API based model. "
+                "In order to get optimal serving performance, we recommend "
+                f"either replacing {self.__class__.__name__} with KerasModelArtifact, "
+                "or wrapping the keras_model.predict method with tf.function decorator."
             )
         return self
 

--- a/bentoml/frameworks/tensorflow.py
+++ b/bentoml/frameworks/tensorflow.py
@@ -250,8 +250,8 @@ class TensorflowSavedModelArtifact(BentoServiceArtifact):
         loaded = self.get()
         logger.warning(
             "Due to TensorFlow's internal mechanism, only methods wrapped under "
-            "`@tf.function` decorator and Keras model API methods including predict"
-            " and xxxx can be restored after a save & load.\n"
+            "`@tf.function` decorator and the Keras default function "
+            "`__call__(inputs, training=False)` can be restored after a save & load.\n"
             "You can test the restored model object by referring:\n"
             f"<bento_svc>.artifacts.{self.name}\n"
         )

--- a/bentoml/utils/tensorflow.py
+++ b/bentoml/utils/tensorflow.py
@@ -206,9 +206,10 @@ def pretty_format_restored_model(model):
 
     if not restored_functions and not serving_default:
         return (
-            "Found no avaliable functions. You can use `tf.function` "
-            "to mark the functions you want to keep. See "
-            "https://www.tensorflow.org/api_docs/python/tf/saved_model/save "
-            "for more detail"
+            "No serving function was found in the saved model. "
+            "In the model implementation, use `tf.function` decorator to mark "
+            "the method needed for model serving. \n"
+            "Find more details in related TensorFlow docs here "
+            "https://www.tensorflow.org/api_docs/python/tf/saved_model/save"
         )
     return f"Found restored functions:\n{part_functions}"

--- a/bentoml/utils/tensorflow.py
+++ b/bentoml/utils/tensorflow.py
@@ -1,0 +1,202 @@
+import logging
+from typing import Sequence, Union
+
+from bentoml.exceptions import MissingDependencyException
+
+logger = logging.getLogger(__name__)
+
+
+TF_KERAS_DEFAULT_FUNCTIONS = {
+    "_default_save_signature",
+    "call_and_return_all_conditional_losses",
+}
+
+
+TENSOR_CLASS_NAMES = (
+    "RaggedTensor",
+    "SparseTensor",
+    "TensorArray",
+    "EagerTensor",
+    "Tensor",
+)
+
+
+def _isinstance(obj, klass: Union[str, type, Sequence]):
+    if not klass:
+        return False
+    if isinstance(klass, str):
+        return type(obj).__name__ == klass.split('.')[-1]
+    if isinstance(klass, Sequence):
+        return any(_isinstance(obj, k) for k in klass)
+    return isinstance(obj, klass)
+
+
+def normalize_spec(value):
+    if not _isinstance(value, TENSOR_CLASS_NAMES):
+        return value
+
+    import tensorflow as tf
+
+    if _isinstance(value, "RaggedTensor"):
+        return tf.RaggedTensorSpec.from_value(value)
+    if _isinstance(value, "SparseTensor"):
+        return tf.SparseTensorSpec.from_value(value)
+    if _isinstance(value, "TensorArray"):
+        return tf.TensorArraySpec.from_tensor(value)
+    if _isinstance(value, ("Tensor", "EagerTensor")):
+        return tf.TensorSpec.from_tensor(value)
+    return value
+
+
+def get_input_signatures(func):
+    if hasattr(func, 'function_spec'):  # for RestoredFunction
+        if func.function_spec.input_signature:
+            return ((func.function_spec.input_signature, {}),)
+        else:
+            return tuple(
+                s
+                for conc in func.concrete_functions
+                for s in get_input_signatures(conc)
+            )
+    if hasattr(func, "structured_input_signature"):  # for ConcreteFunction
+        if func.structured_input_signature is not None:
+            return (func.structured_input_signature,)
+        if func._arg_keywords is not None:
+            return (
+                (
+                    tuple(),
+                    {
+                        k: normalize_spec(v)
+                        for k, v in zip(func._arg_keywords, func.inputs)
+                    },
+                ),
+            )
+    return tuple()
+
+
+def get_arg_names(func):
+    if hasattr(func, 'function_spec'):  # for RestoredFunction
+        return func.function_spec.arg_names
+    if hasattr(func, "structured_input_signature"):  # for ConcreteFunction
+        return func._arg_keywords
+    return tuple()
+
+
+def get_output_signature(func):
+    if hasattr(func, 'function_spec'):  # for RestoredFunction
+        # assume all concrete functions have same signature
+        return get_output_signature(func.concrete_functions[0])
+
+    if hasattr(func, "structured_input_signature"):  # for ConcreteFunction
+        if func.structured_outputs is not None:
+            if isinstance(func.structured_outputs, dict):
+                return {
+                    k: normalize_spec(v) for k, v in func.structured_outputs.items()
+                }
+            return func.structured_outputs
+        else:
+            return tuple(normalize_spec(v) for v in func.outputs)
+
+    return tuple()
+
+
+def get_restored_functions(m):
+    function_map = {k: getattr(m, k, None) for k in dir(m)}
+    return {
+        k: v
+        for k, v in function_map.items()
+        if k not in TF_KERAS_DEFAULT_FUNCTIONS and hasattr(v, 'function_spec')
+    }
+
+
+def get_serving_default_function(m):
+    try:
+        import tensorflow as tf
+    except ImportError:
+        raise MissingDependencyException(
+            "Tensorflow package is required to use TfSavedModelArtifact"
+        )
+
+    return m.signatures[tf.compat.v2.saved_model.DEFAULT_SERVING_SIGNATURE_DEF_KEY]
+
+
+def cast_tensor_by_spec(_input, spec):
+    '''
+    transform dtype & shape following spec
+    '''
+    try:
+        import tensorflow as tf
+    except ImportError:
+        raise MissingDependencyException(
+            "Tensorflow package is required to use TfSavedModelArtifact"
+        )
+
+    if not _isinstance(spec, "TensorSpec"):
+        return _input
+
+    if _isinstance(_input, ["Tensor", "EagerTensor"]):
+        return tf.cast(  # pylint: disable=unexpected-keyword-arg, no-value-for-parameter
+            _input, dtype=spec.dtype, name=spec.name
+        )
+    else:
+        return tf.constant(_input, dtype=spec.dtype, name=spec.name)
+
+
+def _pretty_format_function_call(base, name, arg_names):
+    if arg_names:
+        part_sigs = ', '.join(f"{k}" for k in arg_names)
+    else:
+        part_sigs = ''
+
+    if name == "__call__":
+        return f"{base}({part_sigs})"
+    return f"{base}.{name}({part_sigs})"
+
+
+def _pretty_format_positional(positional):
+    return "Positional arguments ({} total):\n    * {}".format(
+        len(positional), "\n    * ".join(str(a) for a in positional)
+    )
+
+
+def pretty_format_function(function, obj="<object>", name="<function>"):
+    ret = ''
+    outs = get_output_signature(function)
+    sigs = get_input_signatures(function)
+    arg_names = get_arg_names(function)
+
+    if hasattr(function, 'function_spec'):
+        arg_names = function.function_spec.arg_names
+    else:
+        arg_names = function._arg_keywords
+
+    ret += _pretty_format_function_call(obj, name, arg_names)
+    ret += '\n------------\n'
+
+    signature_descriptions = []
+
+    for index, sig in enumerate(sigs):
+        positional, keyword = sig
+        signature_descriptions.append(
+            "Arguments Option {}:\n  {}\n  Keyword arguments:\n    {}".format(
+                index + 1, _pretty_format_positional(positional), keyword
+            )
+        )
+
+    ret += '\n\n'.join(signature_descriptions)
+    ret += f"\n\nReturn:\n  {outs}\n\n"
+    return ret
+
+
+def pretty_format_restored_model(model):
+    ret = 'Found restored functions:\n'
+    restored_functions = get_restored_functions(model)
+    for name, func in restored_functions.items():
+        ret += pretty_format_function(func, "model", name)
+        ret += "\n"
+    serving_default = get_serving_default_function(model)
+    ret += pretty_format_function(
+        serving_default, "model", "signature['serving_default']"
+    )
+    ret += "\n"
+    return ret

--- a/bentoml/utils/tensorflow.py
+++ b/bentoml/utils/tensorflow.py
@@ -26,7 +26,7 @@ def _isinstance(obj, klass: Union[str, type, Sequence]):
         return False
     if isinstance(klass, str):
         return type(obj).__name__ == klass.split('.')[-1]
-    if isinstance(klass, Sequence):
+    if isinstance(klass, (tuple, list, set)):
         return any(_isinstance(obj, k) for k in klass)
     return isinstance(obj, klass)
 


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->

When packing a model built with the `tf.keras` API:

```
[2020-11-13 19:06:52,091] WARNING - Due to TensorFlow's save and load mechanism, only methods marked by `tf.function` (and some keras defaults) could be restored after packing & loading.
You can test the restored model object by referring:
<bento_svc>.artifacts.model

[2020-11-13 19:06:52,093] INFO - Found restored functions:
model(inputs, training, mask)
------------
Arguments Option 1:
  Positional arguments (3 total):
    * TensorSpec(shape=(None, None), dtype=tf.float32, name='inputs')
    * False
    * None
  Keyword arguments:
    {}

Arguments Option 2:
  Positional arguments (3 total):
    * TensorSpec(shape=(None, None), dtype=tf.float32, name='embedding_input')
    * True
    * None
  Keyword arguments:
    {}

Arguments Option 3:
  Positional arguments (3 total):
    * TensorSpec(shape=(None, None), dtype=tf.float32, name='inputs')
    * True
    * None
  Keyword arguments:
    {}

Arguments Option 4:
  Positional arguments (3 total):
    * TensorSpec(shape=(None, None), dtype=tf.float32, name='embedding_input')
    * False
    * None
  Keyword arguments:
    {}

Return:
  TensorSpec(shape=(None, 2), dtype=tf.float32, name=None)


model.signature['serving_default'](embedding_input)
------------
Arguments Option 1:
  Positional arguments (0 total):
    * 
  Keyword arguments:
    {'embedding_input': TensorSpec(shape=(None, None), dtype=tf.float32, name='embedding_input')}

Return:
  {'dense_1': TensorSpec(shape=(None, 2), dtype=tf.float32, name='dense_1')}



[2020-11-13 19:06:52,093] WARNING - You may be using `TensorflowSavedModelArtifact` to pack a keras model. It works but may cause performance issues. Consider:
 * replacing `TensorflowSavedModelArtifact` with `KerasModelArtifact` (relatively good performance)
 * keeping `TensorflowSavedModelArtifact`, wrapping the `keras_model.predict` with a `tf.function`. (best performance)
```

<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

- [x] tf2 + native API: integration test
- [x] tf2 + keras API: integration test
- [x] tf1 + native API (non-eager): tested manually on gallery fashion mnist example
- [ ] tf1 + estimator API: none
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [x] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [x] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
