### PR TITLE
[New Feature] Add authentication token at grpc requests

### DIFF
--- a/bentoml/configuration/default_bentoml.cfg
+++ b/bentoml/configuration/default_bentoml.cfg
@@ -60,6 +60,7 @@ db_url = sqlite:///{BENTOML_HOME}/storage.db
 s3_endpoint_url =
 default_namespace = dev
 client_certificate_file =
+access_token =
 
 [apiserver]
 default_port = 5000

--- a/bentoml/yatai/client/interceptor/generic_client_interceptor.py
+++ b/bentoml/yatai/client/interceptor/generic_client_interceptor.py
@@ -1,0 +1,64 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Base class for interceptors that operate on all RPC types."""
+
+import grpc
+
+# pylint: disable=super-init-not-called
+
+
+class _GenericClientInterceptor(
+    grpc.UnaryUnaryClientInterceptor,
+    grpc.UnaryStreamClientInterceptor,
+    grpc.StreamUnaryClientInterceptor,
+    grpc.StreamStreamClientInterceptor,
+):
+    def __init__(self, interceptor_function):
+        self._fn = interceptor_function
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        new_details, new_request_iterator, postprocess = self._fn(
+            client_call_details, iter((request,)), False, False
+        )
+        response = continuation(new_details, next(new_request_iterator))
+        return postprocess(response) if postprocess else response
+
+    def intercept_unary_stream(self, continuation, client_call_details, request):
+        new_details, new_request_iterator, postprocess = self._fn(
+            client_call_details, iter((request,)), False, True
+        )
+        response_it = continuation(new_details, next(new_request_iterator))
+        return postprocess(response_it) if postprocess else response_it
+
+    def intercept_stream_unary(
+        self, continuation, client_call_details, request_iterator
+    ):
+        new_details, new_request_iterator, postprocess = self._fn(
+            client_call_details, request_iterator, True, False
+        )
+        response = continuation(new_details, new_request_iterator)
+        return postprocess(response) if postprocess else response
+
+    def intercept_stream_stream(
+        self, continuation, client_call_details, request_iterator
+    ):
+        new_details, new_request_iterator, postprocess = self._fn(
+            client_call_details, request_iterator, True, True
+        )
+        response_it = continuation(new_details, new_request_iterator)
+        return postprocess(response_it) if postprocess else response_it
+
+
+def create(intercept_call):
+    return _GenericClientInterceptor(intercept_call)

--- a/bentoml/yatai/client/interceptor/header_client_interceptor.py
+++ b/bentoml/yatai/client/interceptor/header_client_interceptor.py
@@ -1,0 +1,49 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Interceptor that adds headers to outgoing requests."""
+
+import collections
+
+import grpc
+
+from bentoml.yatai.client.interceptor import generic_client_interceptor
+
+
+class _ClientCallDetails(
+    collections.namedtuple(
+        '_ClientCallDetails', ('method', 'timeout', 'metadata', 'credentials')
+    ),
+    grpc.ClientCallDetails,
+):
+    pass
+
+
+def header_adder_interceptor(header, value):
+    def intercept_call(
+        client_call_details, request_iterator, request_streaming, response_streaming
+    ):
+        # pylint: disable=unused-argument
+        metadata = []
+        if client_call_details.metadata is not None:
+            metadata = list(client_call_details.metadata)
+        metadata.append((header, value,))
+        client_call_details = _ClientCallDetails(
+            client_call_details.method,
+            client_call_details.timeout,
+            metadata,
+            client_call_details.credentials,
+        )
+        return client_call_details, request_iterator, None
+
+    return generic_client_interceptor.create(intercept_call)

--- a/bentoml/yatai/yatai_service.py
+++ b/bentoml/yatai/yatai_service.py
@@ -12,18 +12,21 @@ import grpc
 from bentoml import config
 from bentoml.configuration import get_debug_mode
 from bentoml.exceptions import BentoMLException
+from bentoml.yatai.client.interceptor import header_client_interceptor
 from bentoml.yatai.proto.yatai_service_pb2_grpc import add_YataiServicer_to_server
 from bentoml.yatai.utils import ensure_node_available_or_raise, parse_grpc_url
 
 
 def get_yatai_service(
     channel_address=None,
+    access_token=None,
     db_url=None,
     repo_base_url=None,
     s3_endpoint_url=None,
     default_namespace=None,
 ):
     channel_address = channel_address or config('yatai_service').get('url')
+    access_token = access_token or config('yatai_service').get('access_token')
     channel_address = channel_address.strip()
     if channel_address:
         from bentoml.yatai.proto.yatai_service_pb2_grpc import YataiStub
@@ -38,7 +41,9 @@ def get_yatai_service(
 
         logger.debug("Connecting YataiService gRPC server at: %s", channel_address)
         scheme, addr = parse_grpc_url(channel_address)
-
+        header_adder_interceptor = header_client_interceptor.header_adder_interceptor(
+            'access_token', access_token
+        )
         if scheme in ('grpcs', 'https'):
             client_cacert_path = (
                 config().get('yatai_service', 'client_certificate_file')
@@ -47,9 +52,13 @@ def get_yatai_service(
             with open(client_cacert_path, 'rb') as ca_cert_file:
                 ca_cert = ca_cert_file.read()
             credentials = grpc.ssl_channel_credentials(ca_cert, None, None)
-            channel = grpc.secure_channel(addr, credentials)
+            channel = grpc.intercept_channel(
+                grpc.secure_channel(addr, credentials), header_adder_interceptor
+            )
         else:
-            channel = grpc.insecure_channel(addr)
+            channel = grpc.intercept_channel(
+                grpc.insecure_channel(addr), header_adder_interceptor
+            )
         return YataiStub(channel)
     else:
         from bentoml.yatai.yatai_service_impl import YataiService


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
Added authentication token at all grpc requests, this token can be use with a grpc middleware to authenticate and authorized the requests.

## Motivation and Context
BentoML itself doesn’t provide authentication and authorization, it’s commonly done in a proxy in front of it but it's necessary put token in all bentoml request

## How Has This Been Tested?
To do this change, I have added a client interceptor in order to manipulate header request and add token information get by configuration.
I get the example from [here](https://github.com/grpc/grpc/tree/master/examples/python/interceptors/headers)

Set the token in client with following command
`bentoml config set yatai_service.access_token=valid_token`

I've verified that work sniffing the request in a gRPC Proxy

![image](https://user-images.githubusercontent.com/6740590/100122516-c1aa0e00-2e79-11eb-820a-d1e5cd410384.png)

A new package client.interceptor is now available in code, and in yatai/yatai_service.py the grcp channel (secure and insecure) is now wrapped by interceptor channel

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [x] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and 
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
