### PR TITLE
Refactor Saved Bundle Loader

### DIFF
--- a/bentoml/saved_bundle/loader.py
+++ b/bentoml/saved_bundle/loader.py
@@ -96,6 +96,7 @@ def _resolve_remote_bundle_path(bundle_path):
 
 def resolve_remote_bundle(func):
     """Decorate a function to handle remote bundles."""
+
     @wraps(func)
     def wrapper(bundle_path, *args):
         if _is_remote_path(bundle_path):
@@ -103,6 +104,7 @@ def resolve_remote_bundle(func):
                 return func(local_bundle_path, *args)
 
         return func(bundle_path, *args)
+
     return wrapper
 
 

--- a/bentoml/saved_bundle/loader.py
+++ b/bentoml/saved_bundle/loader.py
@@ -19,6 +19,7 @@ import tarfile
 import logging
 import tempfile
 import shutil
+from functools import wraps
 from contextlib import contextmanager
 from urllib.parse import urlparse
 from pathlib import PureWindowsPath, PurePosixPath
@@ -93,11 +94,20 @@ def _resolve_remote_bundle_path(bundle_path):
             yield os.path.join(tmpdir, filename)
 
 
-def load_saved_bundle_config(bundle_path):
-    if _is_remote_path(bundle_path):
-        with _resolve_remote_bundle_path(bundle_path) as local_bundle_path:
-            return load_saved_bundle_config(local_bundle_path)
+def resolve_remote_bundle(func):
+    """Decorate a function to handle remote bundles."""
+    @wraps(func)
+    def wrapper(bundle_path, *args):
+        if _is_remote_path(bundle_path):
+            with _resolve_remote_bundle_path(bundle_path) as local_bundle_path:
+                return func(local_bundle_path, *args)
 
+        return func(bundle_path, *args)
+    return wrapper
+
+
+@resolve_remote_bundle
+def load_saved_bundle_config(bundle_path):
     try:
         return SavedBundleConfig.load(os.path.join(bundle_path, "bentoml.yml"))
     except FileNotFoundError:
@@ -152,6 +162,7 @@ def _find_module_file(bundle_path, service_name, module_file):
     return module_file_path
 
 
+@resolve_remote_bundle
 def load_bento_service_class(bundle_path):
     """
     Load a BentoService class from saved bundle in given path
@@ -160,10 +171,6 @@ def load_bento_service_class(bundle_path):
         #save_to_dir, or the path to pip installed BentoService directory
     :return: BentoService class
     """
-    if _is_remote_path(bundle_path):
-        with _resolve_remote_bundle_path(bundle_path) as local_bundle_path:
-            return load_bento_service_class(local_bundle_path)
-
     config = load_saved_bundle_config(bundle_path)
     metadata = config["metadata"]
 
@@ -211,6 +218,7 @@ def load_bento_service_class(bundle_path):
     return model_service_class
 
 
+@resolve_remote_bundle
 def safe_retrieve(bundle_path, target_dir):
     """Safely retrieve bento service to local path
 
@@ -222,15 +230,10 @@ def safe_retrieve(bundle_path, target_dir):
     Returns:
         string: location of safe local path
     """
-    if _is_remote_path(bundle_path):
-        with _resolve_remote_bundle_path(bundle_path) as local_bundle_path:
-            shutil.copytree(local_bundle_path, target_dir)
-            return target_dir
-
     shutil.copytree(bundle_path, target_dir)
-    return
 
 
+@resolve_remote_bundle
 def load_from_dir(bundle_path):
     """Load bento service from local file path or s3 path
 
@@ -241,10 +244,6 @@ def load_from_dir(bundle_path):
     Returns:
         bentoml.service.BentoService: a loaded BentoService instance
     """
-
-    if _is_remote_path(bundle_path):
-        with _resolve_remote_bundle_path(bundle_path) as local_bundle_path:
-            return load_from_dir(local_bundle_path)
     track_load_start()
 
     svc_cls = load_bento_service_class(bundle_path)
@@ -254,10 +253,7 @@ def load_from_dir(bundle_path):
     return svc
 
 
+@resolve_remote_bundle
 def load_bento_service_api(bundle_path, api_name=None):
-    if _is_remote_path(bundle_path):
-        with _resolve_remote_bundle_path(bundle_path) as local_bundle_path:
-            return load_bento_service_api(local_bundle_path, api_name)
-
     bento_service = load_from_dir(bundle_path)
     return bento_service.get_inference_api(api_name)


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
This change refactors `bentoml.saved_bundle.loader` module to decorate functions to handle remote bundle path.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
