### PR TITLE
[Enhancement]Add remote path support for save_to_dir function

### DIFF
--- a/bentoml/saved_bundle/bundler.py
+++ b/bentoml/saved_bundle/bundler.py
@@ -303,5 +303,6 @@ def _upload_file_to_remote_path(remote_path, file_path, file_name):
         http_response = requests.put(remote_path)
         if http_response.status_code != 200:
             raise BentoMLException(
-                f'Error uploading BentoService bundle to {remote_path}'
+                f'Error uploading BentoService to {remote_path} '
+                f'{http_response.status_code}'
             )

--- a/bentoml/saved_bundle/bundler.py
+++ b/bentoml/saved_bundle/bundler.py
@@ -71,6 +71,10 @@ def save_to_dir(bento_service, path, version=None, silent=False):
     if _is_remote_path(path):
         # If user provided path is an remote location, the bundle will first save to
         # a temporary directory and then upload to the remote location
+        logger.info(
+            'Saving bento to an remote path. BentoML will first save the bento '
+            'to a local temporary directory and then upload to the remote path.'
+        )
         remote_save_path = path
         temp_dir = TempDirectory()
         temp_dir.create()

--- a/bentoml/saved_bundle/bundler.py
+++ b/bentoml/saved_bundle/bundler.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib
-import io
 import os
 import shutil
 import stat
@@ -68,10 +67,11 @@ def save_to_dir(bento_service, path, version=None, silent=False):
         raise BentoMLException(
             "save_to_dir only works with instances of custom BentoService class"
         )
+    remote_save_path = None
     if _is_remote_path(path):
         # If user provided path is an remote location, the bundle will first save to
         # a temporary directory and then upload to the remote location
-        remote_path = path
+        remote_save_path = path
         temp_dir = TempDirectory()
         temp_dir.create()
         path = temp_dir.path
@@ -202,15 +202,15 @@ def save_to_dir(bento_service, path, version=None, silent=False):
     _bundle_local_bentoml_if_installed_from_source(bundled_pip_dependencies_path)
 
     # Upload saved bento bundle from temp directory to the remote location
-    if remote_path is not None:
-        _upload_bento_to_remote_path(remote_path, path, bento_service.name)
+    if remote_save_path is not None:
+        _upload_bento_to_remote_path(remote_save_path, path, bento_service.name)
 
     if not silent:
         logger.info(
             "BentoService bundle '%s:%s' created at: %s",
             bento_service.name,
             bento_service.version,
-            remote_path if remote_path else path,
+            remote_save_path if remote_save_path is not None else path,
         )
 
 

--- a/bentoml/saved_bundle/bundler.py
+++ b/bentoml/saved_bundle/bundler.py
@@ -19,6 +19,8 @@ import logging
 import tarfile
 from urllib.parse import urlparse
 
+import requests
+
 from bentoml.configuration import _is_pip_installed_bentoml
 
 from bentoml.exceptions import BentoMLException
@@ -297,3 +299,9 @@ def _upload_file_to_remote_path(remote_path, file_path, file_name):
         bucket = gcs_client.bucket(bucket_name)
         blob = bucket.blob(object_path)
         blob.upload_from_filename(file_path)
+    else:
+        http_response = requests.put(remote_path)
+        if http_response.status_code != 200:
+            raise BentoMLException(
+                f'Error uploading BentoService bundle to {remote_path}'
+            )

--- a/bentoml/saved_bundle/bundler.py
+++ b/bentoml/saved_bundle/bundler.py
@@ -12,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib
+import io
 import os
 import shutil
 import stat
 import logging
-
+import tarfile
+from urllib.parse import urlparse
 
 from bentoml.configuration import _is_pip_installed_bentoml
 
 from bentoml.exceptions import BentoMLException
+from bentoml.saved_bundle.loader import _is_remote_path
 from bentoml.saved_bundle.local_py_modules import copy_local_py_modules
 from bentoml.saved_bundle.templates import (
     BENTO_SERVICE_BUNDLE_SETUP_PY_TEMPLATE,
@@ -28,6 +31,8 @@ from bentoml.saved_bundle.templates import (
     MODEL_SERVER_DOCKERFILE_CPU,
     INIT_PY_TEMPLATE,
 )
+from bentoml.utils import is_s3_url, is_gcs_url
+from bentoml.utils.tempdir import TempDirectory
 from bentoml.utils.usage_stats import track_save
 from bentoml.saved_bundle.config import SavedBundleConfig
 
@@ -49,7 +54,9 @@ def save_to_dir(bento_service, path, version=None, silent=False):
     is not empty, this call may override existing files in the given path.
 
     :param bento_service (bentoml.service.BentoService): a Bento Service instance
-    :param path (str): Destination of where the bento service will be saved
+    :param path (str): Destination of where the bento service will be saved. The
+        destination can be local path or remote path. The remote path supports both
+        AWS S3('s3://bucket/path') and Google Cloud Storage('gs://bucket/path').
     :param version (str): Override the service version with given version string
     :param silent (boolean): whether to hide the log message showing target save path
     """
@@ -61,6 +68,13 @@ def save_to_dir(bento_service, path, version=None, silent=False):
         raise BentoMLException(
             "save_to_dir only works with instances of custom BentoService class"
         )
+    if _is_remote_path(path):
+        # If user provided path is an remote location, the bundle will first save to
+        # a temporary directory and then upload to the remote location
+        remote_path = path
+        temp_dir = TempDirectory()
+        temp_dir.create()
+        path = temp_dir.path
 
     if version is not None:
         # If parameter version provided, set bento_service version
@@ -187,12 +201,16 @@ def save_to_dir(bento_service, path, version=None, silent=False):
     bundled_pip_dependencies_path = os.path.join(path, 'bundled_pip_dependencies')
     _bundle_local_bentoml_if_installed_from_source(bundled_pip_dependencies_path)
 
+    # Upload saved bento bundle from temp directory to the remote location
+    if remote_path is not None:
+        _upload_bento_to_remote_path(remote_path, path, bento_service.name)
+
     if not silent:
         logger.info(
             "BentoService bundle '%s:%s' created at: %s",
             bento_service.name,
             bento_service.version,
-            path,
+            remote_path if remote_path else path,
         )
 
 
@@ -241,3 +259,38 @@ def _bundle_local_bentoml_if_installed_from_source(target_path):
 
         # clean up sdist build files
         shutil.rmtree(source_dir)
+
+
+def _upload_bento_to_remote_path(remote_path, bento_path, bento_name):
+    with TempDirectory() as temp_dir:
+        file_name = f'{bento_name}.tar'
+        tarfile_path = f'{temp_dir}/{file_name}'
+        with tarfile.open(tarfile_path, mode="w:gz") as tar:
+            tar.add(bento_path, arcname=bento_name)
+
+        parsed_url = urlparse(remote_path)
+        bucket_name = parsed_url.netloc
+        object_prefix_path = parsed_url.path.lstrip('/')
+        object_path = f'{object_prefix_path}/{file_name}'
+        if is_s3_url(remote_path):
+            try:
+                import boto3
+            except ImportError:
+                raise BentoMLException(
+                    '"boto3" package is required for saving bento to AWS S3 bucket'
+                )
+            s3_client = boto3.client('s3')
+            with open(tarfile_path, 'rb') as f:
+                s3_client.upload_fileobj(f, bucket_name, object_path)
+        elif is_gcs_url(remote_path):
+            try:
+                from google.cloud import storage
+            except ImportError:
+                raise BentoMLException(
+                    '"google.cloud" package is required for saving bento to Google '
+                    'Cloud Storage'
+                )
+            gcs_client = storage.Client()
+            bucket = gcs_client.bucket(bucket_name)
+            blob = bucket.blob(object_path)
+            blob.upload_from_filename(tarfile_path)

--- a/bentoml/saved_bundle/loader.py
+++ b/bentoml/saved_bundle/loader.py
@@ -40,7 +40,7 @@ def _is_http_url(bundle_path):
 
 
 def _is_remote_path(bundle_path):
-    return (
+    return isinstance(bundle_path, str) and (
         is_s3_url(bundle_path) or is_gcs_url(bundle_path) or _is_http_url(bundle_path)
     )
 

--- a/bentoml/yatai/client/bento_repository_api.py
+++ b/bentoml/yatai/client/bento_repository_api.py
@@ -191,7 +191,7 @@ class BentoRepositoryAPIClient:
                 http_response = requests.put(
                     response.uri.s3_presigned_url, data=fileobj
                 )
-            else:
+            elif response.uri.uri == BentoUri.GCS:
                 http_response = requests.put(
                     response.uri.gcs_presigned_url, data=fileobj
                 )


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
Add S3 and Google Cloud Storage support for `save_to_dir` function

```python
# Save to S3
save_to_dir(my_bento_service, path='s3://bucket_name/path/to/save')

# Save to GCS
save_to_dir(my_bento_service, path='gs://bucket_name/path/to/save')
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
