### PR TITLE
Allow option to overwrite list of conda channels

### DIFF
--- a/bentoml/service/__init__.py
+++ b/bentoml/service/__init__.py
@@ -208,6 +208,7 @@ def env_decorator(
     infer_pip_packages: bool = False,
     requirements_txt_file: str = None,
     conda_channels: List[str] = None,
+    conda_overwrite_channels: bool = False,
     conda_dependencies: List[str] = None,
     conda_env_yml_file: str = None,
     setup_sh: str = None,
@@ -229,8 +230,10 @@ def env_decorator(
             this can be a relative path to the requirements.txt file or the content
             of the file
         conda_channels: list of extra conda channels to be used
+        conda_overwrite_channels: Turn on to make conda_channels overwrite the list of
+            channels instead of adding to it
         conda_dependencies: list of conda dependencies required
-        conda_env_yml_file: use a pre-defined conda environment yml filej
+        conda_env_yml_file: use a pre-defined conda environment yml file
         setup_sh: user defined setup bash script, it is executed in docker build time
         docker_base_image: used for customizing the docker container image built with
             BentoML saved bundle. Base image must either have both `bash` and `conda`
@@ -247,6 +250,7 @@ def env_decorator(
             infer_pip_packages=infer_pip_packages or auto_pip_dependencies,
             requirements_txt_file=requirements_txt_file,
             conda_channels=conda_channels,
+            conda_overwrite_channels=conda_overwrite_channels,
             conda_dependencies=conda_dependencies,
             conda_env_yml_file=conda_env_yml_file,
             setup_sh=setup_sh,

--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -71,7 +71,7 @@ class CondaEnv(object):
         channels: List[str] = None,
         dependencies: List[str] = None,
         default_env_yaml_file: str = None,
-        overwrite_channels: bool = False
+        overwrite_channels: bool = False,
     ):
         self._yaml = YAML()
         self._yaml.default_flow_style = False
@@ -110,9 +110,7 @@ class CondaEnv(object):
 
     def add_channels(self, channels: List[str]):
         if channels and self.overwrite_channels:
-            logger.debug(
-                "Removing default conda channels from environment.yml"
-                )
+            logger.debug("Removing default conda channels from environment.yml")
             self._conda_env["channels"] = []
 
         for channel_name in channels:

--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -71,9 +71,11 @@ class CondaEnv(object):
         channels: List[str] = None,
         dependencies: List[str] = None,
         default_env_yaml_file: str = None,
+        overwrite_channels: bool = False
     ):
         self._yaml = YAML()
         self._yaml.default_flow_style = False
+        self.overwrite_channels = overwrite_channels
 
         if default_env_yaml_file:
             env_yml_file = Path(default_env_yaml_file)
@@ -107,6 +109,12 @@ class CondaEnv(object):
         )
 
     def add_channels(self, channels: List[str]):
+        if channels and self.overwrite_channels:
+            logger.debug(
+                "Removing default conda channels from environment.yml"
+                )
+            self._conda_env["channels"] = []
+
         for channel_name in channels:
             if channel_name not in self._conda_env["channels"]:
                 self._conda_env["channels"] += channels
@@ -135,8 +143,10 @@ class BentoServiceEnv(object):
             this can be a relative path to the requirements.txt file or the content
             of the file
         conda_channels: list of extra conda channels to be used
+        conda_overwrite_channels: Turn on to make conda_channels overwrite the list of
+            channels instead of adding to it
         conda_dependencies: list of conda dependencies required
-        conda_env_yml_file: use a pre-defined conda environment yml filej
+        conda_env_yml_file: use a pre-defined conda environment yml file
         setup_sh: user defined setup bash script, it is executed in docker build time
         docker_base_image: used when generating Dockerfile in saved bundle
     """
@@ -150,6 +160,7 @@ class BentoServiceEnv(object):
         infer_pip_packages: bool = False,
         requirements_txt_file: str = None,
         conda_channels: List[str] = None,
+        conda_overwrite_channels: bool = False,
         conda_dependencies: List[str] = None,
         conda_env_yml_file: str = None,
         setup_sh: str = None,
@@ -164,6 +175,7 @@ class BentoServiceEnv(object):
             channels=conda_channels,
             dependencies=conda_dependencies,
             default_env_yaml_file=conda_env_yml_file,
+            overwrite_channels=conda_overwrite_channels,
         )
 
         self._pip_packages = {}

--- a/tests/test_service_env.py
+++ b/tests/test_service_env.py
@@ -186,6 +186,29 @@ def test_conda_channels_n_dependencies(tmpdir):
     assert 'bentoml-test-lib' in env_yml['dependencies']
 
 
+def test_conda_overwrite_channels(tmpdir):
+    @bentoml.env(
+        conda_channels=["bentoml-test-channel"],
+        conda_dependencies=["bentoml-test-lib"],
+        conda_overwrite_channels=True,
+    )
+    class ServiceWithCondaDeps(bentoml.BentoService):
+        @bentoml.api(input=DataframeInput(), batch=True)
+        def predict(self, df):
+            return df
+
+    service_with_string = ServiceWithCondaDeps()
+    service_with_string.save_to_dir(str(tmpdir))
+
+    from pathlib import Path
+    from bentoml.utils.ruamel_yaml import YAML
+
+    yaml = YAML()
+    env_yml = yaml.load(Path(os.path.join(tmpdir, 'environment.yml')))
+    assert 'bentoml-test-channel' in env_yml['channels']
+    assert len(env_yml['channels']) == 1
+
+
 def test_conda_env_yml_file_option(tmpdir):
     conda_env_yml_file = os.path.join(tmpdir, 'environment.yml')
     with open(conda_env_yml_file, 'wb') as f:


### PR DESCRIPTION
## Description

Adds an option to the env decorator so that conda_channels will overwrite the default
**This is an alternate approach to https://github.com/bentoml/BentoML/pull/1354 and only one is needed to solve the problem**

## Motivation and Context

There is no easy way to use _only_ a specified set of conda channels which is problematic in environments where the defaults are unavailable. This fixes that. 

## How Has This Been Tested?

I have added a test case specifically for this option. 
There should not be any integration issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

The default option is False, which is the same behaviour currently so is backwards compatible.

## Component(s) if applicable
- [x] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [x] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
