### PR TITLE
Allow for empty channel list in default conda yml

### DIFF
--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -107,6 +107,14 @@ class CondaEnv(object):
         )
 
     def add_channels(self, channels: List[str]):
+        # Allow for empty channel list in yml and if conda_channels not specified
+        # then use the default
+        if not self._conda_env["channels"]:
+            if not channels:
+                self._conda_env["channels"] = ["conda-forge, defaults"]
+                logger.debug("No channels in yml or conda_channels. Using defaults")
+            else:
+                self._conda_env["channels"] = []
         for channel_name in channels:
             if channel_name not in self._conda_env["channels"]:
                 self._conda_env["channels"] += channels

--- a/tests/test_service_env.py
+++ b/tests/test_service_env.py
@@ -224,3 +224,37 @@ dependencies:
 
     assert 'test-dep-1' in env_yml['dependencies']
     assert 'bentoml-test-lib' in env_yml['dependencies']
+
+
+def test_conda_empty_channels(tmpdir):
+    conda_env_yml_file = os.path.join(tmpdir, 'environment.yml')
+    with open(conda_env_yml_file, 'wb') as f:
+        f.write(
+            """
+name: bentoml-test-conda-env
+channels:
+dependencies:
+  - test-dep-1
+""".encode()
+        )
+
+    @bentoml.env(
+        conda_env_yml_file=conda_env_yml_file,
+        conda_channels=["bentoml-test-channel"],
+        conda_dependencies=["bentoml-test-lib"],
+    )
+    class ServiceWithCondaDeps(bentoml.BentoService):
+        @bentoml.api(input=DataframeInput(), batch=True)
+        def predict(self, df):
+            return df
+
+    service_with_string = ServiceWithCondaDeps()
+    service_with_string.save_to_dir(str(tmpdir))
+
+    from pathlib import Path
+    from bentoml.utils.ruamel_yaml import YAML
+
+    yaml = YAML()
+    env_yml = yaml.load(Path(os.path.join(tmpdir, 'environment.yml')))
+    assert 'bentoml-test-channel' in env_yml['channels']
+    assert len(env_yml['channels']) == 1


### PR DESCRIPTION
## Description

Handles the case when the default yml's channel list is empty.
**This is an alternate approach to https://github.com/bentoml/BentoML/pull/1353 and only one is needed to solve the problem**

## Motivation and Context

There is no easy way to use _only_ a specified set of conda channels which is problematic in environments where the defaults are unavailable. This fixes that as this can be used along with `conda_channels`.

## How Has This Been Tested?

I have added a test case specifically for this option. 
There should not be any integration issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [x] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [x] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
