### PR TITLE
[Fix] ensure Python version; exclude conda-forge from default conda channels

### DIFF
--- a/bentoml/saved_bundle/bentoml-init.sh
+++ b/bentoml/saved_bundle/bentoml-init.sh
@@ -20,7 +20,7 @@ if [ -f ./python_version ]; then
 
   if command -v conda >/dev/null 2>&1; then
     echo "Installing python=$DESIRED_PY_VERSION with conda:"
-    conda install -y -n base conda-forge::python=$DESIRED_PY_VERSION
+    conda install -y -n base defaults::python=$DESIRED_PY_VERSION
   else
     if [[ "$DESIRED_PY_VERSION" != "$CURRENT_PY_VERSION" ]]; then
       echo "WARNING: Python Version $DESIRED_PY_VERSION is required, but $CURRENT_PY_VERSION was found."

--- a/bentoml/saved_bundle/bentoml-init.sh
+++ b/bentoml/saved_bundle/bentoml-init.sh
@@ -18,13 +18,11 @@ if [ -f ./python_version ]; then
   DESIRED_PY_VERSION=${PY_VERSION_SAVED:0:3} # returns 3.6, 3.7 or 3.8
   CURRENT_PY_VERSION=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 
-  if [[ "$DESIRED_PY_VERSION" == "$CURRENT_PY_VERSION" ]]; then
-    echo "Python Version in docker base image $CURRENT_PY_VERSION matches requirement python=$DESIRED_PY_VERSION. Skipping."
+  if command -v conda >/dev/null 2>&1; then
+    echo "Installing python=$DESIRED_PY_VERSION with conda:"
+    conda install -y -n base python=$DESIRED_PY_VERSION
   else
-    if command -v conda >/dev/null 2>&1; then
-      echo "Installing python=$DESIRED_PY_VERSION with conda:"
-      conda install -y -n base python=$DESIRED_PY_VERSION
-    else
+    if [[ "$DESIRED_PY_VERSION" != "$CURRENT_PY_VERSION" ]]; then
       echo "WARNING: Python Version $DESIRED_PY_VERSION is required, but $CURRENT_PY_VERSION was found."
     fi
   fi
@@ -48,7 +46,6 @@ else
 fi
 
 # Install PyPI packages specified in requirements.txt
-pip install --upgrade pip
 pip install -r ./requirements.txt --no-cache-dir $EXTRA_PIP_INSTALL_ARGS
 
 # Install additional python packages inside bundled pip dependencies directory

--- a/bentoml/saved_bundle/bentoml-init.sh
+++ b/bentoml/saved_bundle/bentoml-init.sh
@@ -20,7 +20,7 @@ if [ -f ./python_version ]; then
 
   if command -v conda >/dev/null 2>&1; then
     echo "Installing python=$DESIRED_PY_VERSION with conda:"
-    conda install -y -n base defaults::python=$DESIRED_PY_VERSION
+    conda install -y -n base pkgs/main::python=$DESIRED_PY_VERSION
   else
     if [[ "$DESIRED_PY_VERSION" != "$CURRENT_PY_VERSION" ]]; then
       echo "WARNING: Python Version $DESIRED_PY_VERSION is required, but $CURRENT_PY_VERSION was found."

--- a/bentoml/saved_bundle/bentoml-init.sh
+++ b/bentoml/saved_bundle/bentoml-init.sh
@@ -20,7 +20,7 @@ if [ -f ./python_version ]; then
 
   if command -v conda >/dev/null 2>&1; then
     echo "Installing python=$DESIRED_PY_VERSION with conda:"
-    conda install -y -n base python=$DESIRED_PY_VERSION
+    conda install -y -n base conda-forge::python=$DESIRED_PY_VERSION
   else
     if [[ "$DESIRED_PY_VERSION" != "$CURRENT_PY_VERSION" ]]; then
       echo "WARNING: Python Version $DESIRED_PY_VERSION is required, but $CURRENT_PY_VERSION was found."

--- a/bentoml/saved_bundle/bentoml-init.sh
+++ b/bentoml/saved_bundle/bentoml-init.sh
@@ -20,7 +20,7 @@ if [ -f ./python_version ]; then
 
   if command -v conda >/dev/null 2>&1; then
     echo "Installing python=$DESIRED_PY_VERSION with conda:"
-    conda install -y -n base pkgs/main::python=$DESIRED_PY_VERSION
+    conda install -y -n base pkgs/main::python=$DESIRED_PY_VERSION pip
   else
     if [[ "$DESIRED_PY_VERSION" != "$CURRENT_PY_VERSION" ]]; then
       echo "WARNING: Python Version $DESIRED_PY_VERSION is required, but $CURRENT_PY_VERSION was found."

--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -12,26 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import logging
+import os
 import stat
-from pkg_resources import Requirement, parse_requirements
-from sys import version_info
 from pathlib import Path
+from sys import version_info
 from typing import List
 
-from bentoml.exceptions import BentoMLException
-from bentoml.utils.ruamel_yaml import YAML
+from pkg_resources import Requirement, parse_requirements
+
 from bentoml import config
 from bentoml.configuration import get_bentoml_deploy_version
+from bentoml.exceptions import BentoMLException
 from bentoml.saved_bundle.pip_pkg import (
+    EPP_NO_ERROR,
     EPP_PKG_NOT_EXIST,
     EPP_PKG_VERSION_MISMATCH,
-    EPP_NO_ERROR,
-    verify_pkg,
     get_pkg_version,
+    verify_pkg,
 )
-
+from bentoml.utils.ruamel_yaml import YAML
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +54,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pip
+  - conda-forge::pip
 """
 
 

--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -54,7 +54,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - defaults::pip
+  - pkgs/main::pip
 """
 
 

--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -51,10 +51,8 @@ PYTHON_VERSION = "{minor_version}.{micro}".format(
 DEFAULT_CONDA_ENV_BASE_YAML = """
 name: bentoml-default-conda-env
 channels:
-  - conda-forge
   - defaults
-dependencies:
-  - pkgs/main::pip
+dependencies: []
 """
 
 

--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -46,8 +46,6 @@ PYTHON_VERSION = "{minor_version}.{micro}".format(
 )
 
 
-# Including 'conda-forge' channel in the default channels to ensure newest Python
-# versions can be installed properly via conda when building API server docker image
 DEFAULT_CONDA_ENV_BASE_YAML = """
 name: bentoml-default-conda-env
 channels:

--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -54,7 +54,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - conda-forge::pip
+  - defaults::pip
 """
 
 

--- a/ci/install_python36_osx.sh
+++ b/ci/install_python36_osx.sh
@@ -16,8 +16,7 @@ export PATH="${HOME}/miniconda/bin:${PATH}"
 hash -r  # https://stackoverflow.com/q/45257534/2064085
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda
-conda config --add channels conda-forge
-conda install -y python=3.6 pip  # change base env Python to conda
+conda install -y pkgs/main::python=3.6 pip  # change base env Python to conda
 # Useful for debugging any issues with conda
 conda info -a
 command -v python

--- a/tests/test_service_env.py
+++ b/tests/test_service_env.py
@@ -174,6 +174,7 @@ def test_conda_channels_n_dependencies(tmpdir):
     service_with_string.save_to_dir(str(tmpdir))
 
     from pathlib import Path
+
     from bentoml.utils.ruamel_yaml import YAML
 
     yaml = YAML()
@@ -182,7 +183,7 @@ def test_conda_channels_n_dependencies(tmpdir):
     assert 'defaults' in env_yml['channels']
     assert 'bentoml-test-channel' in env_yml['channels']
 
-    assert 'pip' in env_yml['dependencies']
+    assert 'defaults::pip' in env_yml['dependencies']
     assert 'bentoml-test-lib' in env_yml['dependencies']
 
 
@@ -201,6 +202,7 @@ def test_conda_overwrite_channels(tmpdir):
     service_with_string.save_to_dir(str(tmpdir))
 
     from pathlib import Path
+
     from bentoml.utils.ruamel_yaml import YAML
 
     yaml = YAML()
@@ -237,6 +239,7 @@ dependencies:
     service_with_string.save_to_dir(str(tmpdir))
 
     from pathlib import Path
+
     from bentoml.utils.ruamel_yaml import YAML
 
     yaml = YAML()

--- a/tests/test_service_env.py
+++ b/tests/test_service_env.py
@@ -183,7 +183,7 @@ def test_conda_channels_n_dependencies(tmpdir):
     assert 'defaults' in env_yml['channels']
     assert 'bentoml-test-channel' in env_yml['channels']
 
-    assert 'defaults::pip' in env_yml['dependencies']
+    assert 'pkgs/main::pip' in env_yml['dependencies']
     assert 'bentoml-test-lib' in env_yml['dependencies']
 
 

--- a/tests/test_service_env.py
+++ b/tests/test_service_env.py
@@ -179,11 +179,9 @@ def test_conda_channels_n_dependencies(tmpdir):
 
     yaml = YAML()
     env_yml = yaml.load(Path(os.path.join(tmpdir, 'environment.yml')))
-    assert 'conda-forge' in env_yml['channels']
     assert 'defaults' in env_yml['channels']
     assert 'bentoml-test-channel' in env_yml['channels']
 
-    assert 'pkgs/main::pip' in env_yml['dependencies']
     assert 'bentoml-test-lib' in env_yml['dependencies']
 
 

--- a/tests/utils/test_usage_stats.py
+++ b/tests/utils/test_usage_stats.py
@@ -4,10 +4,7 @@ from mock import MagicMock, patch
 import bentoml
 from bentoml.cli import create_bentoml_cli
 from bentoml.utils.usage_stats import _get_bento_service_event_properties
-from bentoml.yatai.proto.deployment_pb2 import (
-    DeleteDeploymentResponse,
-    Deployment,
-)
+from bentoml.yatai.proto.deployment_pb2 import DeleteDeploymentResponse, Deployment
 from bentoml.yatai.status import Status
 from bentoml.yatai.yatai_service import get_yatai_service
 
@@ -66,7 +63,7 @@ def test_get_bento_service_event_properties(bento_service):
     assert len(properties["input_types"]) == 4
 
     assert properties["env"] is not None
-    assert properties["env"]["conda_env"]["channels"] == ["conda-forge", "defaults"]
+    assert properties["env"]["conda_env"]["channels"] == ["defaults"]
 
 
 def test_get_bento_service_event_properties_with_no_artifact():


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
- always call `conda install python="{version}"`
- locked the channel of `python` and `pip`
<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In the past two weeks, our integration tests on TensorFlow, Keras with docker failed at some point.
Here is an example: https://github.com/bentoml/BentoML/pull/1375/checks?check_run_id=1644036917

Two issues related to it in the `bento-init.sh`:
- If the Python version in the base image was the same as required, `conda install python={version}` would be skipped. The `python` package wasn't added to the specs of conda. Thus conda will also try to install the newest version of python, 3.9, in the next call.
- The channels of conda are set as ['conda-forge', 'defaults']. Plus we call `conda install python=3.7` to update Python. Sometimes this version code matches "python_pypy=3.7" in the conda-forge channel better. Thus conda will install PyPy instead of CPython.

There is no evidence that this problem will not occur in production.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [x] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
