### PR TITLE
[Fix]Failure to containerize model with build-arg value contains multiple `=` characters

### DIFF
--- a/bentoml/cli/bento_service.py
+++ b/bentoml/cli/bento_service.py
@@ -381,7 +381,7 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         docker_build_args = {}
         if build_arg:
             for arg in build_arg:
-                key, value = arg.split("=")
+                key, value = arg.split("=", 1)
                 docker_build_args[key] = value
         if yatai_url is not None:
             spinner_message = f'Sending containerize RPC to YataiService at {yatai_url}'

--- a/bentoml/yatai/yatai_service_impl.py
+++ b/bentoml/yatai/yatai_service_impl.py
@@ -500,7 +500,9 @@ def get_yatai_service_impl(base=object):
                     safe_retrieve(bento_service_bundle_path, temp_bundle_path)
                     try:
                         docker_client.images.build(
-                            path=temp_bundle_path, tag=tag, buildargs=request.build_args
+                            path=temp_bundle_path,
+                            tag=tag,
+                            buildargs=dict(request.build_args),
                         )
                     except (docker.errors.APIError, docker.errors.BuildError) as error:
                         logger.error(f'Encounter container building issue: {error}')

--- a/tests/integration/yatai_server/test_containerize.py
+++ b/tests/integration/yatai_server/test_containerize.py
@@ -1,4 +1,5 @@
 import logging
+import subprocess
 
 from bentoml.yatai.client import get_yatai_client
 from tests.bento_service_examples.example_bento_service import ExampleBentoService
@@ -16,3 +17,27 @@ def test_yatai_server_containerize_without_push():
     tag = 'mytag'
     built_tag = yc.repository.containerize(bento=f'{svc.name}:{svc.version}', tag=tag)
     assert built_tag == f'{tag}:{svc.version}'
+
+
+def test_yatai_server_containerize_from_cli():
+    svc = ExampleBentoService()
+    svc.pack('model', [1, 2, 3])
+    logger.info('Saving bento service to local yatai server')
+    svc.save()
+    bento_tag = f'{svc.name}:{svc.version}'
+    tag = 'mytagfoo'
+
+    command = [
+        'bentoml',
+        'containerize',
+        bento_tag,
+        '--build-arg',
+        'EXTRA_PIP_INSTALL_ARGS=--extra-index-url=https://pypi.org',
+        '-t',
+        tag,
+    ]
+    docker_proc = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    stdout = docker_proc.stdout.read().decode('utf-8')
+    assert f'{tag}:{svc.version}' in stdout, 'Failed to build container'


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
* fix #1403
* Add additional test for using CLI command

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
