### PR TITLE
opentracing implementation with jaeger

### DIFF
--- a/bentoml/configuration/default_bentoml.cfg
+++ b/bentoml/configuration/default_bentoml.cfg
@@ -48,6 +48,10 @@ yatai_web_server_log_filename = yatai_web_server.log
 [tracing]
 # example: http://127.0.0.1:9411/api/v1/spans
 zipkin_api_url =
+# example: localhost
+opentracing_server_address = localhost
+# example: 5775
+opentracing_server_port = 5775
 
 [yatai_service]
 # URL of remote YataiService gRPC server endpoint to use

--- a/bentoml/server/__init__.py
+++ b/bentoml/server/__init__.py
@@ -19,36 +19,66 @@ from bentoml import config
 
 logger = logging.getLogger(__name__)
 ZIPKIN_API_URL = config("tracing").get("zipkin_api_url")
+OPENTRACING_SERVER_ADDRESS = config("tracing").get("opentracing_server_address")
+OPENTRACING_SERVER_PORT = config("tracing").get("opentracing_server_port")
 
 
 @contextmanager
 def trace(*args, **kwargs):
+    """
+    synchronous tracing function, will choose relevant tracer
+    """
+
     if ZIPKIN_API_URL:
         from bentoml.server.trace import trace as _trace
+        new_args = [ZIPKIN_API_URL, *args]
 
-        return _trace(ZIPKIN_API_URL, *args, **kwargs)
+    elif OPENTRACING_SERVER_ADDRESS:
+        from bentoml.server.opentrace import trace as _trace
+        new_args = [OPENTRACING_SERVER_ADDRESS, *args]
+        kwargs['port'] = OPENTRACING_SERVER_PORT
+
     else:
-        yield
+        yield None
+        return
+
+    with _trace(*new_args, **kwargs) as scope:
+        yield scope
+    return
 
 
 @contextmanager
 def async_trace(*args, **kwargs):
+    """
+    asynchronous tracing function, will choose relevant tracer
+    """
+
     if ZIPKIN_API_URL:
         from bentoml.server.trace import async_trace as _async_trace
+        new_args = [ZIPKIN_API_URL, *args]
 
-        return _async_trace(ZIPKIN_API_URL, *args, **kwargs)
+    elif OPENTRACING_SERVER_ADDRESS:
+        from bentoml.server.opentrace import async_trace as _async_trace
+        new_args = [OPENTRACING_SERVER_ADDRESS, *args]
+        kwargs['port'] = OPENTRACING_SERVER_PORT
+
     else:
-        yield
+        yield None
+        return
+
+    with _async_trace(*new_args, **kwargs) as scope:
+        yield scope
+    return
 
 
 def start_dev_server(
-    saved_bundle_path: str,
-    port: int,
-    enable_microbatch: bool,
-    mb_max_batch_size: int,
-    mb_max_latency: int,
-    run_with_ngrok: bool,
-    enable_swagger: bool,
+        saved_bundle_path: str,
+        port: int,
+        enable_microbatch: bool,
+        mb_max_batch_size: int,
+        mb_max_latency: int,
+        run_with_ngrok: bool,
+        enable_swagger: bool,
 ):
     logger.info("Starting BentoML API server in development mode..")
 
@@ -99,13 +129,12 @@ def start_dev_server(
 
 
 def start_dev_batching_server(
-    saved_bundle_path: str,
-    port: int,
-    api_server_port: int,
-    mb_max_batch_size: int,
-    mb_max_latency: int,
+        saved_bundle_path: str,
+        port: int,
+        api_server_port: int,
+        mb_max_batch_size: int,
+        mb_max_latency: int,
 ):
-
     from bentoml.marshal.marshal import MarshalService
 
     marshal_server = MarshalService(
@@ -121,15 +150,15 @@ def start_dev_batching_server(
 
 
 def start_prod_server(
-    saved_bundle_path: str,
-    port: int,
-    timeout: int,
-    workers: int,
-    enable_microbatch: bool,
-    mb_max_batch_size: int,
-    mb_max_latency: int,
-    microbatch_workers: int,
-    enable_swagger: bool,
+        saved_bundle_path: str,
+        port: int,
+        timeout: int,
+        workers: int,
+        enable_microbatch: bool,
+        mb_max_batch_size: int,
+        mb_max_latency: int,
+        microbatch_workers: int,
+        enable_swagger: bool,
 ):
     logger.info("Starting BentoML API server in production mode..")
 

--- a/bentoml/server/__init__.py
+++ b/bentoml/server/__init__.py
@@ -31,10 +31,12 @@ def trace(*args, **kwargs):
 
     if ZIPKIN_API_URL:
         from bentoml.server.trace import trace as _trace
+
         new_args = [ZIPKIN_API_URL, *args]
 
     elif OPENTRACING_SERVER_ADDRESS:
         from bentoml.server.opentrace import trace as _trace
+
         new_args = [OPENTRACING_SERVER_ADDRESS, *args]
         kwargs['port'] = OPENTRACING_SERVER_PORT
 
@@ -55,10 +57,12 @@ def async_trace(*args, **kwargs):
 
     if ZIPKIN_API_URL:
         from bentoml.server.trace import async_trace as _async_trace
+
         new_args = [ZIPKIN_API_URL, *args]
 
     elif OPENTRACING_SERVER_ADDRESS:
         from bentoml.server.opentrace import async_trace as _async_trace
+
         new_args = [OPENTRACING_SERVER_ADDRESS, *args]
         kwargs['port'] = OPENTRACING_SERVER_PORT
 
@@ -72,13 +76,13 @@ def async_trace(*args, **kwargs):
 
 
 def start_dev_server(
-        saved_bundle_path: str,
-        port: int,
-        enable_microbatch: bool,
-        mb_max_batch_size: int,
-        mb_max_latency: int,
-        run_with_ngrok: bool,
-        enable_swagger: bool,
+    saved_bundle_path: str,
+    port: int,
+    enable_microbatch: bool,
+    mb_max_batch_size: int,
+    mb_max_latency: int,
+    run_with_ngrok: bool,
+    enable_swagger: bool,
 ):
     logger.info("Starting BentoML API server in development mode..")
 
@@ -129,11 +133,11 @@ def start_dev_server(
 
 
 def start_dev_batching_server(
-        saved_bundle_path: str,
-        port: int,
-        api_server_port: int,
-        mb_max_batch_size: int,
-        mb_max_latency: int,
+    saved_bundle_path: str,
+    port: int,
+    api_server_port: int,
+    mb_max_batch_size: int,
+    mb_max_latency: int,
 ):
     from bentoml.marshal.marshal import MarshalService
 
@@ -150,15 +154,15 @@ def start_dev_batching_server(
 
 
 def start_prod_server(
-        saved_bundle_path: str,
-        port: int,
-        timeout: int,
-        workers: int,
-        enable_microbatch: bool,
-        mb_max_batch_size: int,
-        mb_max_latency: int,
-        microbatch_workers: int,
-        enable_swagger: bool,
+    saved_bundle_path: str,
+    port: int,
+    timeout: int,
+    workers: int,
+    enable_microbatch: bool,
+    mb_max_batch_size: int,
+    mb_max_latency: int,
+    microbatch_workers: int,
+    enable_swagger: bool,
 ):
     logger.info("Starting BentoML API server in production mode..")
 

--- a/bentoml/server/opentrace.py
+++ b/bentoml/server/opentrace.py
@@ -17,13 +17,10 @@ def initialize_tracer(service_name, log_level=logging.DEBUG):
     logging.basicConfig(level=log_level)
 
     config = Config(
-        config={
-            'sampler': {'type': 'const', 'param': 1},
-            'logging': True
-        },
+        config={'sampler': {'type': 'const', 'param': 1}, 'logging': True},
         service_name=service_name,
         validate=True,
-        scope_manager=AsyncioScopeManager()
+        scope_manager=AsyncioScopeManager(),
     )
 
     return config.initialize_tracer()
@@ -31,15 +28,15 @@ def initialize_tracer(service_name, log_level=logging.DEBUG):
 
 @contextmanager
 def trace(
-        server_url=None,
-        request_headers=None,
-        async_transport=False,
-        sample_rate=1.0,
-        standalone=False,
-        is_root=False,
-        service_name="some service",
-        span_name="service procedure",
-        port=0,
+    server_url=None,
+    request_headers=None,
+    async_transport=False,
+    sample_rate=1.0,
+    standalone=False,
+    is_root=False,
+    service_name="some service",
+    span_name="service procedure",
+    port=0,
 ):
     """
     Opentracing tracer function
@@ -59,8 +56,9 @@ def trace(
     if span_context is None:
         span_context = span_context_saved or None
 
-    with tracer.start_active_span(operation_name=span_name,
-                                  child_of=span_context) as scope:
+    with tracer.start_active_span(
+        operation_name=span_name, child_of=span_context
+    ) as scope:
         token = span_context_var.set(scope.span.context)
         yield scope
         span_context_var.reset(token)

--- a/bentoml/server/opentrace.py
+++ b/bentoml/server/opentrace.py
@@ -28,15 +28,15 @@ def initialize_tracer(service_name, log_level=logging.DEBUG):
 
 @contextmanager
 def trace(
-        server_url=None,  # @UnusedVariable
-        request_headers=None,
-        async_transport=False,  # @UnusedVariable
-        sample_rate=1.0,  # @UnusedVariable
-        standalone=False,  # @UnusedVariable
-        is_root=False,  # @UnusedVariable
-        service_name="some service",
-        span_name="service procedure",
-        port=0,  # @UnusedVariable
+    server_url=None,  # @UnusedVariable
+    request_headers=None,
+    async_transport=False,  # @UnusedVariable
+    sample_rate=1.0,  # @UnusedVariable
+    standalone=False,  # @UnusedVariable
+    is_root=False,  # @UnusedVariable
+    service_name="some service",
+    span_name="service procedure",
+    port=0,  # @UnusedVariable
 ):
     """
     Opentracing tracer function
@@ -58,7 +58,7 @@ def trace(
         span_context = span_context_saved or None
 
     with tracer.start_active_span(
-            operation_name=span_name, child_of=span_context
+        operation_name=span_name, child_of=span_context
     ) as scope:
         token = span_context_var.set(scope.span.context)
         yield scope

--- a/bentoml/server/opentrace.py
+++ b/bentoml/server/opentrace.py
@@ -4,7 +4,6 @@
 from contextlib import contextmanager
 from contextvars import ContextVar
 import opentracing
-import logging
 from opentracing import Format
 from functools import partial
 from jaeger_client.config import Config
@@ -13,11 +12,9 @@ from opentracing.scope_managers.asyncio import AsyncioScopeManager
 span_context_var = ContextVar('span context', default=None)
 
 
-def initialize_tracer(service_name, log_level=logging.DEBUG):
-    logging.basicConfig(level=log_level)
-
+def initialize_tracer(service_name):
     config = Config(
-        config={'sampler': {'type': 'const', 'param': 1}, 'logging': True},
+        config={'sampler': {'type': 'const', 'param': 1}},
         service_name=service_name,
         validate=True,
         scope_manager=AsyncioScopeManager(),

--- a/bentoml/server/opentrace.py
+++ b/bentoml/server/opentrace.py
@@ -28,19 +28,20 @@ def initialize_tracer(service_name, log_level=logging.DEBUG):
 
 @contextmanager
 def trace(
-    server_url=None,
-    request_headers=None,
-    async_transport=False,
-    sample_rate=1.0,
-    standalone=False,
-    is_root=False,
-    service_name="some service",
-    span_name="service procedure",
-    port=0,
+        server_url=None,  # @UnusedVariable
+        request_headers=None,
+        async_transport=False,  # @UnusedVariable
+        sample_rate=1.0,  # @UnusedVariable
+        standalone=False,  # @UnusedVariable
+        is_root=False,  # @UnusedVariable
+        service_name="some service",
+        span_name="service procedure",
+        port=0,  # @UnusedVariable
 ):
     """
     Opentracing tracer function
     """
+    del server_url, async_transport, sample_rate, standalone, is_root, port
 
     tracer = initialize_tracer(service_name) or opentracing.global_tracer() or None
     if tracer is None:
@@ -57,7 +58,7 @@ def trace(
         span_context = span_context_saved or None
 
     with tracer.start_active_span(
-        operation_name=span_name, child_of=span_context
+            operation_name=span_name, child_of=span_context
     ) as scope:
         token = span_context_var.set(scope.span.context)
         yield scope

--- a/bentoml/server/opentrace.py
+++ b/bentoml/server/opentrace.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+import opentracing
+import logging
+from opentracing import Format
+from functools import partial
+from jaeger_client.config import Config
+from opentracing.scope_managers.asyncio import AsyncioScopeManager
+
+span_context_var = ContextVar('span context', default=None)
+
+
+def initialize_tracer(service_name, log_level=logging.DEBUG):
+    logging.basicConfig(level=log_level)
+
+    config = Config(
+        config={
+            'sampler': {'type': 'const', 'param': 1},
+            'logging': True
+        },
+        service_name=service_name,
+        validate=True,
+        scope_manager=AsyncioScopeManager()
+    )
+
+    return config.initialize_tracer()
+
+
+@contextmanager
+def trace(
+        server_url=None,
+        request_headers=None,
+        async_transport=False,
+        sample_rate=1.0,
+        standalone=False,
+        is_root=False,
+        service_name="some service",
+        span_name="service procedure",
+        port=0,
+):
+    """
+    Opentracing tracer function
+    """
+
+    tracer = initialize_tracer(service_name) or opentracing.global_tracer() or None
+    if tracer is None:
+        yield None
+        return
+
+    span_context = None
+    span_context_saved = span_context_var.get()
+
+    if request_headers is not None:
+        span_context = tracer.extract(Format.HTTP_HEADERS, request_headers)
+
+    if span_context is None:
+        span_context = span_context_saved or None
+
+    with tracer.start_active_span(operation_name=span_name,
+                                  child_of=span_context) as scope:
+        token = span_context_var.set(scope.span.context)
+        yield scope
+        span_context_var.reset(token)
+
+
+async_trace = partial(trace, async_transport=True)

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ install_requires = [
     "protobuf>=3.8.0",
     "psutil",
     "py_zipkin",
+    "opentracing",
+    "jaeger_client",
     # python-dateutil required by pandas and boto3, this makes sure the version
     # works for both
     "python-dateutil>=2.7.3,<3.0.0",

--- a/tests/server/test_tracing_api.py
+++ b/tests/server/test_tracing_api.py
@@ -1,5 +1,4 @@
 import time
-import logging
 import opentracing
 from bentoml.server.opentrace import initialize_tracer, trace
 
@@ -7,10 +6,8 @@ from bentoml.server.opentrace import initialize_tracer, trace
 def test_initialize_tracer():
     service_name = 'test service name'
 
-    tracer = (
-        initialize_tracer(service_name=service_name, log_level=logging.WARNING)
-        or opentracing.global_tracer()
-    )
+    tracer = initialize_tracer(service_name=service_name) or opentracing.global_tracer()
+
     assert tracer is not None
     assert tracer.service_name == service_name
 
@@ -39,5 +36,5 @@ def test_trace():
     ) as scope:
         assert scope is not None
         assert scope.span.operation_name == span_name
-        assert scope.span.start_time < time.time()
+        assert scope.span.start_time <= time.time()
         assert scope.span.finished is False

--- a/tests/server/test_tracing_api.py
+++ b/tests/server/test_tracing_api.py
@@ -1,0 +1,37 @@
+import time
+from bentoml.server.opentrace import initialize_tracer, trace
+
+
+def test_tracer():
+    service_name = 'test service name'
+
+    tracer = initialize_tracer(service_name=service_name)
+    assert tracer.service_name == service_name
+
+
+def test_trace():
+    server_url = None
+    request_headers = None
+    async_transport = False
+    sample_rate = 1.0
+    standalone = False
+    is_root = False
+    service_name = "test service"
+    span_name = "test service procedure"
+    port = 0
+
+    with trace(
+        server_url=server_url,
+        request_headers=request_headers,
+        async_transport=async_transport,
+        sample_rate=sample_rate,
+        standalone=standalone,
+        is_root=is_root,
+        service_name=service_name,
+        span_name=span_name,
+        port=port,
+    ) as scope:
+        assert scope is not None
+        assert scope.span.operation_name == span_name
+        assert scope.span.start_time < time.time()
+        assert scope.span.finished is False

--- a/tests/server/test_tracing_api.py
+++ b/tests/server/test_tracing_api.py
@@ -1,11 +1,13 @@
 import time
+import opentracing
 from bentoml.server.opentrace import initialize_tracer, trace
 
 
 def test_tracer():
     service_name = 'test service name'
 
-    tracer = initialize_tracer(service_name=service_name)
+    tracer = initialize_tracer(service_name=service_name) or opentracing.global_tracer()
+    assert tracer is not None
     assert tracer.service_name == service_name
 
 

--- a/tests/server/test_tracing_api.py
+++ b/tests/server/test_tracing_api.py
@@ -9,7 +9,6 @@ def test_initialize_tracer():
     tracer = initialize_tracer(service_name=service_name) or opentracing.global_tracer()
 
     assert tracer is not None
-    assert tracer.service_name == service_name
 
 
 def test_trace():

--- a/tests/server/test_tracing_api.py
+++ b/tests/server/test_tracing_api.py
@@ -1,12 +1,16 @@
 import time
+import logging
 import opentracing
 from bentoml.server.opentrace import initialize_tracer, trace
 
 
-def test_tracer():
+def test_initialize_tracer():
     service_name = 'test service name'
 
-    tracer = initialize_tracer(service_name=service_name) or opentracing.global_tracer()
+    tracer = (
+        initialize_tracer(service_name=service_name, log_level=logging.WARNING)
+        or opentracing.global_tracer()
+    )
     assert tracer is not None
     assert tracer.service_name == service_name
 


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
Adds [opentracing](https://opentracing.io/) implementation with [jaeger](https://www.jaegertracing.io/).
opentracing is vendor-neutral APIs and instrumentation for distributed tracing

Output example:
<img width="1440" alt="Screen Shot 2021-01-12 at 20 46 25" src="https://user-images.githubusercontent.com/16071898/104568615-f99f2780-5658-11eb-8a86-2c06e1a46492.png">

By default opentracing is off, like zipkin, 
can be turned on like zipkin by providing server address and port default_bentoml.cfg:
`
[tracing]
# example: http://127.0.0.1:9411/api/v1/spans
zipkin_api_url =
# example: localhost
opentracing_server_address = localhost
# example: 5775
opentracing_server_port = 5775
`

## Motivation and Context
Feature of opentracing provides additional functionality and methods of tracing calls, will ease debugging and performance checks kind of problems, provides more standard way of reporting and using traces and also eliminates vendor dependencies. Supports also zipkin trace format, so can totally replace it.

## How Has This Been Tested?
Unit tests in tests/server - passed on following scenarios:
1. No tracing at all
2. zipkin tracing is on
3. opentracing is on
Tests run locally on macos (m1) python 3.8

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [x] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [x] I have added unit tests covering my code change
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
