### PR TITLE
[IN PROGRESS] Custom swagger endpoint path

### DIFF
--- a/bentoml/cli/bento_service.py
+++ b/bentoml/cli/bento_service.py
@@ -198,8 +198,9 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         '--swagger-url-prefix',
         type=click.STRING,
         default="",
-        help='Prefix. '
-        'Example: "xxx"',
+        help='Prefix for the swagger endpoints'
+        'Example: "/my_service" which will put the \
+            endpoint as /my_service/predict',
     )
     def serve(
         port,
@@ -223,7 +224,7 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
             mb_max_latency,
             run_with_ngrok,
             enable_swagger,
-            swagger_url_prefix
+            swagger_url_prefix,
         )
 
     # Example Usage:
@@ -276,8 +277,9 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         '--swagger-url-prefix',
         type=click.STRING,
         default="",
-        help='Prefix. '
-        'Example: "xxx"',
+        help='Prefix for the swagger endpoints'
+        'Example: "/my_service" which will put the \
+            endpoint as /my_service/predict',
     )
     def serve_gunicorn(
         port,

--- a/bentoml/cli/bento_service.py
+++ b/bentoml/cli/bento_service.py
@@ -194,6 +194,13 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         help="Run API server with Swagger UI enabled",
         envvar='BENTOML_ENABLE_SWAGGER',
     )
+    @click.option(
+        '--swagger-url-prefix',
+        type=click.STRING,
+        default="",
+        help='Prefix. '
+        'Example: "xxx"',
+    )
     def serve(
         port,
         bento=None,
@@ -203,6 +210,7 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         run_with_ngrok=False,
         yatai_url=None,
         enable_swagger=True,
+        swagger_url_prefix="",
     ):
         saved_bundle_path = resolve_bundle_path(
             bento, pip_installed_bundle_path, yatai_url
@@ -215,6 +223,7 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
             mb_max_latency,
             run_with_ngrok,
             enable_swagger,
+            swagger_url_prefix
         )
 
     # Example Usage:
@@ -263,6 +272,13 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         help="Run API server with Swagger UI enabled",
         envvar='BENTOML_ENABLE_SWAGGER',
     )
+    @click.option(
+        '--swagger-url-prefix',
+        type=click.STRING,
+        default="",
+        help='Prefix. '
+        'Example: "xxx"',
+    )
     def serve_gunicorn(
         port,
         workers,
@@ -274,6 +290,7 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         microbatch_workers=1,
         yatai_url=None,
         enable_swagger=True,
+        swagger_url_prefix="",
     ):
         if not psutil.POSIX:
             _echo(
@@ -296,6 +313,7 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
             mb_max_latency,
             microbatch_workers,
             enable_swagger,
+            swagger_url_prefix,
         )
 
     @bentoml_cli.command(

--- a/bentoml/cli/bento_service.py
+++ b/bentoml/cli/bento_service.py
@@ -198,9 +198,9 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         '--swagger-url-prefix',
         type=click.STRING,
         default="",
-        help='Prefix for the swagger endpoints'
-        'Example: "/my_service" which will put the \
-            endpoint as /my_service/predict',
+        help='Prefix for the swagger endpoints. '
+        'Example: "/my_service" which will make the '
+        'endpoint /my_service/predict',
     )
     def serve(
         port,
@@ -277,9 +277,9 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         '--swagger-url-prefix',
         type=click.STRING,
         default="",
-        help='Prefix for the swagger endpoints'
-        'Example: "/my_service" which will put the \
-            endpoint as /my_service/predict',
+        help='Prefix for the swagger endpoints. '
+        'Example: "/my_service" which will make the '
+        'endpoint /my_service/predict',
     )
     def serve_gunicorn(
         port,

--- a/bentoml/server/__init__.py
+++ b/bentoml/server/__init__.py
@@ -49,6 +49,7 @@ def start_dev_server(
     mb_max_latency: int,
     run_with_ngrok: bool,
     enable_swagger: bool,
+    swagger_url_prefix: str
 ):
     logger.info("Starting BentoML API server in development mode..")
 
@@ -87,13 +88,15 @@ def start_dev_server(
 
         bento_service = load(saved_bundle_path)
         api_server = BentoAPIServer(
-            bento_service, port=api_server_port, enable_swagger=enable_swagger
+            bento_service, port=api_server_port, enable_swagger=enable_swagger,
+            swagger_url_prefix=swagger_url_prefix
         )
         api_server.start()
     else:
         bento_service = load(saved_bundle_path)
         api_server = BentoAPIServer(
-            bento_service, port=port, enable_swagger=enable_swagger
+            bento_service, port=port, enable_swagger=enable_swagger,
+            swagger_url_prefix=swagger_url_prefix
         )
         api_server.start()
 
@@ -130,6 +133,7 @@ def start_prod_server(
     mb_max_latency: int,
     microbatch_workers: int,
     enable_swagger: bool,
+    swagger_url_prefix: str,
 ):
     logger.info("Starting BentoML API server in production mode..")
 
@@ -172,11 +176,13 @@ def start_prod_server(
                 timeout,
                 prometheus_lock,
                 enable_swagger,
+                swagger_url_prefix
             )
         marshal_server.async_run()
         gunicorn_app.run()
     else:
         gunicorn_app = GunicornBentoServer(
-            saved_bundle_path, port, workers, timeout, enable_swagger=enable_swagger
+            saved_bundle_path, port, workers, timeout, enable_swagger=enable_swagger,
+            swagger_url_prefix=swagger_url_prefix
         )
         gunicorn_app.run()

--- a/bentoml/server/__init__.py
+++ b/bentoml/server/__init__.py
@@ -49,7 +49,7 @@ def start_dev_server(
     mb_max_latency: int,
     run_with_ngrok: bool,
     enable_swagger: bool,
-    swagger_url_prefix: str
+    swagger_url_prefix: str,
 ):
     logger.info("Starting BentoML API server in development mode..")
 
@@ -88,15 +88,19 @@ def start_dev_server(
 
         bento_service = load(saved_bundle_path)
         api_server = BentoAPIServer(
-            bento_service, port=api_server_port, enable_swagger=enable_swagger,
-            swagger_url_prefix=swagger_url_prefix
+            bento_service,
+            port=api_server_port,
+            enable_swagger=enable_swagger,
+            swagger_url_prefix=swagger_url_prefix,
         )
         api_server.start()
     else:
         bento_service = load(saved_bundle_path)
         api_server = BentoAPIServer(
-            bento_service, port=port, enable_swagger=enable_swagger,
-            swagger_url_prefix=swagger_url_prefix
+            bento_service,
+            port=port,
+            enable_swagger=enable_swagger,
+            swagger_url_prefix=swagger_url_prefix,
         )
         api_server.start()
 
@@ -176,13 +180,17 @@ def start_prod_server(
                 timeout,
                 prometheus_lock,
                 enable_swagger,
-                swagger_url_prefix
+                swagger_url_prefix,
             )
         marshal_server.async_run()
         gunicorn_app.run()
     else:
         gunicorn_app = GunicornBentoServer(
-            saved_bundle_path, port, workers, timeout, enable_swagger=enable_swagger,
-            swagger_url_prefix=swagger_url_prefix
+            saved_bundle_path,
+            port,
+            workers,
+            timeout,
+            enable_swagger=enable_swagger,
+            swagger_url_prefix=swagger_url_prefix,
         )
         gunicorn_app.run()

--- a/bentoml/server/api_server.py
+++ b/bentoml/server/api_server.py
@@ -160,7 +160,7 @@ class BentoAPIServer:
         port=DEFAULT_PORT,
         app_name=None,
         enable_swagger=True,
-        swagger_url_prefix=""
+        swagger_url_prefix="",
     ):
         app_name = bento_service.name if app_name is None else app_name
 
@@ -335,7 +335,9 @@ class BentoAPIServer:
             partial(self.swagger_static, self.swagger_path),
         )
         self.app.add_url_rule(
-            "/docs.json", "docs", partial(self.docs_view_func, self.bento_service, self.swagger_url_prefix)
+            "/docs.json",
+            "docs",
+            partial(self.docs_view_func, self.bento_service, self.swagger_url_prefix),
         )
         self.app.add_url_rule("/healthz", "healthz", self.healthz_view_func)
         self.app.add_url_rule(

--- a/bentoml/server/api_server.py
+++ b/bentoml/server/api_server.py
@@ -160,6 +160,7 @@ class BentoAPIServer:
         port=DEFAULT_PORT,
         app_name=None,
         enable_swagger=True,
+        swagger_url_prefix=""
     ):
         app_name = bento_service.name if app_name is None else app_name
 
@@ -168,6 +169,7 @@ class BentoAPIServer:
         self.app = Flask(app_name, static_folder=None)
         self.static_path = self.bento_service.get_web_static_content_path()
         self.enable_swagger = enable_swagger
+        self.swagger_url_prefix = swagger_url_prefix
 
         self.swagger_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), 'static_content'
@@ -335,19 +337,19 @@ class BentoAPIServer:
         self.app.add_url_rule(
             "/docs.json", "docs", partial(self.docs_view_func, self.bento_service)
         )
-        self.app.add_url_rule("/healthz", "healthz", self.healthz_view_func)
+        self.app.add_url_rule(self.swagger_url_prefix+"/healthz", "healthz", self.healthz_view_func)
         self.app.add_url_rule(
-            "/metadata",
+            self.swagger_url_prefix+"/metadata",
             "metadata",
             partial(self.metadata_json_func, self.bento_service),
         )
 
         if config("apiserver").getboolean("enable_metrics"):
-            self.app.add_url_rule("/metrics", "metrics", self.metrics_view_func)
+            self.app.add_url_rule(self.swagger_url_prefix+"/metrics", "metrics", self.metrics_view_func)
 
         if config("apiserver").getboolean("enable_feedback"):
             self.app.add_url_rule(
-                "/feedback",
+                self.swagger_url_prefix+"/feedback",
                 "feedback",
                 partial(self.feedback_view_func, self.bento_service),
                 methods=["POST"],
@@ -362,7 +364,7 @@ class BentoAPIServer:
         for api in self.bento_service.inference_apis:
             route_function = self.bento_service_api_func_wrapper(api)
             self.app.add_url_rule(
-                rule="/{}".format(api.name),
+                rule="{}/{}".format(self.swagger_url_prefix, api.name),
                 endpoint=api.name,
                 view_func=route_function,
                 methods=api.input_adapter.HTTP_METHODS,

--- a/bentoml/server/gunicorn_server.py
+++ b/bentoml/server/gunicorn_server.py
@@ -64,6 +64,7 @@ class GunicornBentoServer(Application):  # pylint: disable=abstract-method
         timeout=None,
         prometheus_lock=None,
         enable_swagger=True,
+        swagger_url_prefix=""
     ):
         self.bento_service_bundle_path = bundle_path
 
@@ -80,6 +81,7 @@ class GunicornBentoServer(Application):  # pylint: disable=abstract-method
             self.options['workers'] = workers
         self.prometheus_lock = prometheus_lock
         self.enable_swagger = enable_swagger
+        self.swagger_url_prefix = swagger_url_prefix
 
         super(GunicornBentoServer, self).__init__()
 
@@ -100,7 +102,8 @@ class GunicornBentoServer(Application):  # pylint: disable=abstract-method
     def load(self):
         bento_service = load_from_dir(self.bento_service_bundle_path)
         api_server = GunicornBentoAPIServer(
-            bento_service, port=self.port, enable_swagger=self.enable_swagger
+            bento_service, port=self.port, enable_swagger=self.enable_swagger, 
+            swagger_url_prefix=self.swagger_url_prefix
         )
         return api_server.app
 

--- a/bentoml/server/gunicorn_server.py
+++ b/bentoml/server/gunicorn_server.py
@@ -64,7 +64,7 @@ class GunicornBentoServer(Application):  # pylint: disable=abstract-method
         timeout=None,
         prometheus_lock=None,
         enable_swagger=True,
-        swagger_url_prefix=""
+        swagger_url_prefix="",
     ):
         self.bento_service_bundle_path = bundle_path
 
@@ -102,8 +102,10 @@ class GunicornBentoServer(Application):  # pylint: disable=abstract-method
     def load(self):
         bento_service = load_from_dir(self.bento_service_bundle_path)
         api_server = GunicornBentoAPIServer(
-            bento_service, port=self.port, enable_swagger=self.enable_swagger, 
-            swagger_url_prefix=self.swagger_url_prefix
+            bento_service,
+            port=self.port,
+            enable_swagger=self.enable_swagger,
+            swagger_url_prefix=self.swagger_url_prefix,
         )
         return api_server.app
 

--- a/bentoml/server/open_api.py
+++ b/bentoml/server/open_api.py
@@ -17,7 +17,7 @@ from collections import OrderedDict
 from bentoml import config
 
 
-def get_open_api_spec_json(bento_service):
+def get_open_api_spec_json(bento_service, swagger_url_prefix=""):
     """
     The docs for all endpoints in Open API format.
     """
@@ -37,7 +37,7 @@ def get_open_api_spec_json(bento_service):
     paths = OrderedDict()
     default_response = {"200": {"description": "success"}}
 
-    paths["/healthz"] = OrderedDict(
+    paths[swagger_url_prefix+"/healthz"] = OrderedDict(
         get=OrderedDict(
             tags=["infra"],
             description="Health check endpoint. Expecting an empty response with status"
@@ -46,7 +46,7 @@ def get_open_api_spec_json(bento_service):
         )
     )
 
-    paths["/metadata"] = OrderedDict(
+    paths[swagger_url_prefix+"/metadata"] = OrderedDict(
         get=OrderedDict(
             tags=["infra"],
             description="BentoService metadata endpoint. Returns the service's"
@@ -56,7 +56,7 @@ def get_open_api_spec_json(bento_service):
     )
 
     if config("apiserver").getboolean("enable_metrics"):
-        paths["/metrics"] = OrderedDict(
+        paths[swagger_url_prefix+"/metrics"] = OrderedDict(
             get=OrderedDict(
                 tags=["infra"],
                 description="Prometheus metrics endpoint",
@@ -64,7 +64,7 @@ def get_open_api_spec_json(bento_service):
             )
         )
     if config("apiserver").getboolean("enable_feedback"):
-        paths["/feedback"] = OrderedDict(
+        paths[swagger_url_prefix+"/feedback"] = OrderedDict(
             post=OrderedDict(
                 tags=["infra"],
                 description="Provide feedback to prediction results from BentoService. "
@@ -93,7 +93,7 @@ def get_open_api_spec_json(bento_service):
         )
 
     for api in bento_service.inference_apis:
-        path = "/{}".format(api.name)
+        path = "{}/{}".format(swagger_url_prefix, api.name)
         paths[path] = OrderedDict(
             post=OrderedDict(
                 tags=["app"],

--- a/bentoml/server/open_api.py
+++ b/bentoml/server/open_api.py
@@ -38,10 +38,7 @@ def get_open_api_spec_json(bento_service, swagger_url_prefix=""):
     default_response = {"200": {"description": "success"}}
 
     if swagger_url_prefix:
-        if not swagger_url_prefix.startswith("/"):
-            swagger_url_prefix = "/" + swagger_url_prefix
-        if swagger_url_prefix.endswith("/"):
-            swagger_url_prefix = swagger_url_prefix[:-1]
+        swagger_url_prefix = "/" + swagger_url_prefix.strip("/")
 
     paths[swagger_url_prefix + "/healthz"] = OrderedDict(
         get=OrderedDict(

--- a/bentoml/server/open_api.py
+++ b/bentoml/server/open_api.py
@@ -37,7 +37,13 @@ def get_open_api_spec_json(bento_service, swagger_url_prefix=""):
     paths = OrderedDict()
     default_response = {"200": {"description": "success"}}
 
-    paths[swagger_url_prefix+"/healthz"] = OrderedDict(
+    if swagger_url_prefix:
+        if not swagger_url_prefix.startswith("/"):
+            swagger_url_prefix = "/" + swagger_url_prefix
+        if swagger_url_prefix.endswith("/"):
+            swagger_url_prefix = swagger_url_prefix[:-1]
+
+    paths[swagger_url_prefix + "/healthz"] = OrderedDict(
         get=OrderedDict(
             tags=["infra"],
             description="Health check endpoint. Expecting an empty response with status"
@@ -46,7 +52,7 @@ def get_open_api_spec_json(bento_service, swagger_url_prefix=""):
         )
     )
 
-    paths[swagger_url_prefix+"/metadata"] = OrderedDict(
+    paths[swagger_url_prefix + "/metadata"] = OrderedDict(
         get=OrderedDict(
             tags=["infra"],
             description="BentoService metadata endpoint. Returns the service's"
@@ -56,7 +62,7 @@ def get_open_api_spec_json(bento_service, swagger_url_prefix=""):
     )
 
     if config("apiserver").getboolean("enable_metrics"):
-        paths[swagger_url_prefix+"/metrics"] = OrderedDict(
+        paths[swagger_url_prefix + "/metrics"] = OrderedDict(
             get=OrderedDict(
                 tags=["infra"],
                 description="Prometheus metrics endpoint",
@@ -64,7 +70,7 @@ def get_open_api_spec_json(bento_service, swagger_url_prefix=""):
             )
         )
     if config("apiserver").getboolean("enable_feedback"):
-        paths[swagger_url_prefix+"/feedback"] = OrderedDict(
+        paths[swagger_url_prefix + "/feedback"] = OrderedDict(
             post=OrderedDict(
                 tags=["infra"],
                 description="Provide feedback to prediction results from BentoService. "

--- a/tests/server/test_open_api.py
+++ b/tests/server/test_open_api.py
@@ -1,0 +1,34 @@
+import json
+
+from bentoml.server.api_server import BentoAPIServer
+
+def test_open_api_spec_json_swagger_path(bento_service):
+    
+    endpoints = ['/feedback', '/healthz', '/metadata', 
+        '/metrics', '/predict', '/predict_dataframe', 
+        '/predict_dataframe_v1', '/predict_image', '/predict_json', 
+        '/predict_multi_images']
+
+    rest_server = BentoAPIServer(bento_service, enable_swagger=False,swagger_url_prefix="")
+    test_client = rest_server.app.test_client()
+    response = test_client.get("/docs.json")
+    path_list = list(response.json['paths'].keys())
+    assert all([x in path_list for x in endpoints])
+
+    rest_server = BentoAPIServer(bento_service, enable_swagger=False,swagger_url_prefix="/my_test")
+    test_client = rest_server.app.test_client()
+    response = test_client.get("/docs.json")
+    path_list = list(response.json['paths'].keys())
+    assert all(["/my_test" + x in path_list for x in endpoints])
+
+    rest_server = BentoAPIServer(bento_service, enable_swagger=False,swagger_url_prefix="my_test")
+    test_client = rest_server.app.test_client()
+    response = test_client.get("/docs.json")
+    path_list = list(response.json['paths'].keys())
+    assert all(["/my_test" + x in path_list for x in endpoints])
+
+    rest_server = BentoAPIServer(bento_service, enable_swagger=False,swagger_url_prefix="////my_test//")
+    test_client = rest_server.app.test_client()
+    response = test_client.get("/docs.json")
+    path_list = list(response.json['paths'].keys())
+    assert all(["/my_test" + x in path_list for x in endpoints])


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
Allows users to customize the prefix of the endpoint that Swagger is going to call.

Running `bentoml serve MyService:latest --swagger-url-prefix "/xxxx"` will give the Swagger page below

![image](https://user-images.githubusercontent.com/62316076/104740129-8f988800-5715-11eb-808f-eaf15b5ded14.png)

## Motivation and Context
See #1376 
 
Basically if a service is hosted somewhere such as `http://bentoml.com/myservices/Service1` then the Swagger being generated will point to `http://bentoml.com/Service1/predict` which will obviously break.

## How Has This Been Tested?
 _in progress_

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [x] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [x] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

_in progress_

- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
