### PR TITLE
Lets user set a custom access_token header

### DIFF
--- a/bentoml/configuration/default_bentoml.cfg
+++ b/bentoml/configuration/default_bentoml.cfg
@@ -64,6 +64,7 @@ tls_root_ca_cert =
 tls_client_key =
 tls_client_cert =
 access_token =
+access_token_header =
 
 [apiserver]
 default_port = 5000

--- a/bentoml/configuration/default_bentoml.cfg
+++ b/bentoml/configuration/default_bentoml.cfg
@@ -64,7 +64,7 @@ tls_root_ca_cert =
 tls_client_key =
 tls_client_cert =
 access_token =
-access_token_header =
+access_token_header = access_token
 
 [apiserver]
 default_port = 5000

--- a/bentoml/yatai/yatai_service.py
+++ b/bentoml/yatai/yatai_service.py
@@ -17,6 +17,7 @@ from bentoml.yatai.utils import ensure_node_available_or_raise, parse_grpc_url
 def get_yatai_service(
     channel_address=None,
     access_token=None,
+    access_token_header=None,
     db_url=None,
     repo_base_url=None,
     s3_endpoint_url=None,
@@ -24,6 +25,9 @@ def get_yatai_service(
 ):
     channel_address = channel_address or config('yatai_service').get('url')
     access_token = access_token or config('yatai_service').get('access_token')
+    access_token_header = access_token_header or config('yatai_service').get(
+        'access_token_header'
+    )
     channel_address = channel_address.strip()
     if channel_address:
         # Lazily import grpcio for YataiSerivce gRPC related actions
@@ -42,7 +46,7 @@ def get_yatai_service(
         logger.debug("Connecting YataiService gRPC server at: %s", channel_address)
         scheme, addr = parse_grpc_url(channel_address)
         header_adder_interceptor = header_client_interceptor.header_adder_interceptor(
-            'access_token', access_token
+            access_token_header, access_token
         )
         if scheme in ('grpcs', 'https'):
             tls_root_ca_cert = (


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

Will allow the user to set a custom `access_token_header` within their config which will then ensure the set `access_token` is used under that Header defined when making requests with `BentoML` to `Yatai`

I am happy to contribute some docs around this if this works as expected so others are able to use authentication in-front of yatai in the future 👍 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

relates to: https://github.com/bentoml/BentoML/issues/1415

Essentially want to pass a JWT via a custom header to whatever sits in front of `Yatai`. Currently the hard-coded `access_token` header limits my options on the service that can sit in front of `yatai` to valid these tokens

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Wasn't able to get the pip packages installed on my MacBook, will reattempt then but hoping for tests to run upon this PR being opened

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [x] Internal (BentoML's own configuration, logging, utility, exception handling)
- [x] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
