### PR TITLE
Refactor multiprocessing set_start_method('fork') to initialization

### DIFF
--- a/bentoml/__init__.py
+++ b/bentoml/__init__.py
@@ -12,6 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import psutil
+
+if psutil.POSIX:
+    # After Python 3.8, the default start method of multiprocessing for MacOS changed to
+    # spawn, which would cause RecursionError when launching Gunicorn Application.
+    # Ref:
+    # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+    #
+    # Note: https://bugs.python.org/issue33725 claims that fork method may cause crashes
+    # on MacOS.
+    import multiprocessing
+
+    multiprocessing.set_start_method('fork')
 
 from ._version import get_versions
 

--- a/bentoml/server/marshal_server.py
+++ b/bentoml/server/marshal_server.py
@@ -15,22 +15,12 @@
 import logging
 import multiprocessing
 
-import psutil
 from gunicorn.app.base import Application
 
 from bentoml import config
 from bentoml.marshal.marshal import MarshalService
 from bentoml.server.instruments import setup_prometheus_multiproc_dir
 
-if psutil.POSIX:
-    # After Python 3.8, the default start method of multiprocessing for MacOS changed to
-    # spawn, which would cause RecursionError when launching Gunicorn Application.
-    # Ref:
-    # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
-    #
-    # Note: https://bugs.python.org/issue33725 claims that fork method may cause crashes
-    # on MacOS.
-    multiprocessing.set_start_method('fork')
 
 marshal_logger = logging.getLogger("bentoml.marshal")
 


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

Refactor multiprocessing set_start_method('fork') to the very beginning, before forking or spawning any process. The logic was added in response to the default start method change in multiprocess for MacOS. Ideally, the start method should be set before forking or spawning any processes. The original location in `bentoml/server/marshal_server.py` was not ideal because we have logic starting a new process before reaching that point in `bentoml/server/__init__.py`.

Thanks for the troubleshooting help from @yubozhao.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

Similar to gunicorn, dependency-injector requires the start method of new processes to be forking, to carry forward the containers and providers. Therefore, we should ensure start method is "fork" before starting any new processes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

./dev/format.sh
./dev/lint.sh
./ci/unit_test.sh

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
