### PR TITLE
[Fix] run entry point as a non-root user in docker

### DIFF
--- a/bentoml/saved_bundle/bentoml-init.sh
+++ b/bentoml/saved_bundle/bentoml-init.sh
@@ -4,7 +4,7 @@
 # Usage:
 #   * `bentoml-init.sh` to run the full script
 #   * `bentoml-init.sh <step_name>` to run a specific step 
-#      available steps: [setup.py python_version environment.yml requirement.txt bundled_pip_dependencies]
+#      available steps: [custom_setup ensure_python restore_conda_env install_pip_packages install_bundled_pip_packages
 
 set -ex
 
@@ -13,12 +13,12 @@ SAVED_BUNDLE_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)
 cd $SAVED_BUNDLE_PATH
 
 # Run the user defined setup.sh script if it is presented
-if [ $# -eq 0 ] || [ $1 == "setup.py" ] ; then
+if [ $# -eq 0 ] || [ $1 == "custom_setup" ] ; then
   if [ -f ./setup.sh ]; then chmod +x ./setup.sh && bash -c ./setup.sh; fi
 fi
 
 # Check and install the right python version
-if [ $# -eq 0 ] || [ $1 == "python_version" ] ; then
+if [ $# -eq 0 ] || [ $1 == "ensure_python" ] ; then
   if [ -f ./python_version ]; then
     PY_VERSION_SAVED=$(cat ./python_version)
     # remove PATCH version - since most patch version only contains backwards compatible
@@ -40,7 +40,7 @@ if [ $# -eq 0 ] || [ $1 == "python_version" ] ; then
   fi
 fi
 
-if [ $# -eq 0 ] || [ $1 == "environment.yml" ] ; then
+if [ $# -eq 0 ] || [ $1 == "restore_conda_env" ] ; then
   if command -v conda >/dev/null 2>&1; then
     # set pip_interop_enabled to improve conda-pip interoperability. Conda can use
     # pip-installed packages to satisfy dependencies.
@@ -60,12 +60,12 @@ if [ $# -eq 0 ] || [ $1 == "environment.yml" ] ; then
 fi
 
 # Install PyPI packages specified in requirements.txt
-if [ $# -eq 0 ] || [ $1 == "requirements.txt" ] ; then
+if [ $# -eq 0 ] || [ $1 == "install_pip_packages" ] ; then
   pip install -r ./requirements.txt --no-cache-dir $EXTRA_PIP_INSTALL_ARGS
 fi
 
 # Install additional python packages inside bundled pip dependencies directory
-if [ $# -eq 0 ] || [ $1 == "bundled_pip_dependencies" ] ; then
+if [ $# -eq 0 ] || [ $1 == "install_bundled_pip_packages" ] ; then
   for filename in ./bundled_pip_dependencies/*; do
     [ -e "$filename" ] || continue
     pip install -U "$filename"

--- a/bentoml/saved_bundle/bentoml-init.sh
+++ b/bentoml/saved_bundle/bentoml-init.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # Bash Script that installs the dependencies specified in the BentoService archive
+#
+# Usage:
+#   * `bentoml-init.sh` to run the full script
+#   * `bentoml-init.sh <step_name>` to run a specific step 
+#      available steps: [setup.py python_version environment.yml requirement.txt bundled_pip_dependencies]
+
 set -ex
 
 # cd to the saved bundle directory
@@ -7,51 +13,61 @@ SAVED_BUNDLE_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P)
 cd $SAVED_BUNDLE_PATH
 
 # Run the user defined setup.sh script if it is presented
-if [ -f ./setup.sh ]; then chmod +x ./setup.sh && bash -c ./setup.sh; fi
+if [ $# -eq 0 ] || [ $1 == "setup.py" ] ; then
+  if [ -f ./setup.sh ]; then chmod +x ./setup.sh && bash -c ./setup.sh; fi
+fi
 
 # Check and install the right python version
-if [ -f ./python_version ]; then
-  PY_VERSION_SAVED=$(cat ./python_version)
-  # remove PATCH version - since most patch version only contains backwards compatible
-  # bug fixes and the BentoML defautl docker base image will include the latest
-  # patch version of each Python minor release
-  DESIRED_PY_VERSION=${PY_VERSION_SAVED:0:3} # returns 3.6, 3.7 or 3.8
-  CURRENT_PY_VERSION=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+if [ $# -eq 0 ] || [ $1 == "python_version" ] ; then
+  if [ -f ./python_version ]; then
+    PY_VERSION_SAVED=$(cat ./python_version)
+    # remove PATCH version - since most patch version only contains backwards compatible
+    # bug fixes and the BentoML defautl docker base image will include the latest
+    # patch version of each Python minor release
+    DESIRED_PY_VERSION=${PY_VERSION_SAVED:0:3} # returns 3.6, 3.7 or 3.8
+    CURRENT_PY_VERSION=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 
-  if [[ "$DESIRED_PY_VERSION" == "$CURRENT_PY_VERSION" ]]; then
-    echo "Python Version in docker base image $CURRENT_PY_VERSION matches requirement python=$DESIRED_PY_VERSION. Skipping."
-  else
-    if command -v conda >/dev/null 2>&1; then
-      echo "Installing python=$DESIRED_PY_VERSION with conda:"
-      conda install -y -n base pkgs/main::python=$DESIRED_PY_VERSION pip
+    if [[ "$DESIRED_PY_VERSION" == "$CURRENT_PY_VERSION" ]]; then
+      echo "Python Version in docker base image $CURRENT_PY_VERSION matches requirement python=$DESIRED_PY_VERSION. Skipping."
     else
-      echo "WARNING: Python Version $DESIRED_PY_VERSION is required, but $CURRENT_PY_VERSION was found."
+      if command -v conda >/dev/null 2>&1; then
+        echo "Installing python=$DESIRED_PY_VERSION with conda:"
+        conda install -y -n base pkgs/main::python=$DESIRED_PY_VERSION pip
+      else
+        echo "WARNING: Python Version $DESIRED_PY_VERSION is required, but $CURRENT_PY_VERSION was found."
+      fi
     fi
   fi
 fi
 
-if command -v conda >/dev/null 2>&1; then
-  # set pip_interop_enabled to improve conda-pip interoperability. Conda can use
-  # pip-installed packages to satisfy dependencies.
-  # this option is only available after conda version 4.6.0
-  # "|| true" ignores the error when the option is not found, for older conda version
-  # This is commented out due to a bug with conda's implementation, we should revisit
-  # after conda remove the experimental flag on pip_interop_enabled option
-  # See more details on https://github.com/bentoml/BentoML/pull/1012
-  # conda config --set pip_interop_enabled True || true
-
-  echo "Updating conda base environment with environment.yml"
-  conda env update -n base -f ./environment.yml
-  conda clean --all
-else
-  echo "WARNING: conda command not found, skipping conda dependencies in environment.yml"
+if [ $# -eq 0 ] || [ $1 == "environment.yml" ] ; then
+  if command -v conda >/dev/null 2>&1; then
+    # set pip_interop_enabled to improve conda-pip interoperability. Conda can use
+    # pip-installed packages to satisfy dependencies.
+    # this option is only available after conda version 4.6.0
+    # "|| true" ignores the error when the option is not found, for older conda version
+    # This is commented out due to a bug with conda's implementation, we should revisit
+    # after conda remove the experimental flag on pip_interop_enabled option
+    # See more details on https://github.com/bentoml/BentoML/pull/1012
+    # conda config --set pip_interop_enabled True || true
+  
+    echo "Updating conda base environment with environment.yml"
+    conda env update -n base -f ./environment.yml
+    conda clean --all
+  else
+    echo "WARNING: conda command not found, skipping conda dependencies in environment.yml"
+  fi
 fi
 
 # Install PyPI packages specified in requirements.txt
-pip install -r ./requirements.txt --no-cache-dir $EXTRA_PIP_INSTALL_ARGS
+if [ $# -eq 0 ] || [ $1 == "requirements.txt" ] ; then
+  pip install -r ./requirements.txt --no-cache-dir $EXTRA_PIP_INSTALL_ARGS
+fi
 
 # Install additional python packages inside bundled pip dependencies directory
-for filename in ./bundled_pip_dependencies/*; do
- [ -e "$filename" ] || continue
- pip install -U "$filename"
-done
+if [ $# -eq 0 ] || [ $1 == "bundled_pip_dependencies" ] ; then
+  for filename in ./bundled_pip_dependencies/*; do
+    [ -e "$filename" ] || continue
+    pip install -U "$filename"
+  done
+fi

--- a/bentoml/saved_bundle/docker-entrypoint.sh
+++ b/bentoml/saved_bundle/docker-entrypoint.sh
@@ -12,7 +12,7 @@ _is_sourced() {
 _main() {
   # if first arg looks like a flag, assume we want to start bentoml YataiService
   if [ "${1:0:1}" = '-' ]; then
-    set -- bentoml serve-gunicorn "$@" /home/bentoml
+    set -- bentoml serve-gunicorn "$@" $BUNDLE_PATH
   fi
 
   # Set BentoML API server port via env var

--- a/bentoml/saved_bundle/docker-entrypoint.sh
+++ b/bentoml/saved_bundle/docker-entrypoint.sh
@@ -12,7 +12,7 @@ _is_sourced() {
 _main() {
   # if first arg looks like a flag, assume we want to start bentoml YataiService
   if [ "${1:0:1}" = '-' ]; then
-    set -- bentoml serve-gunicorn "$@" /bento
+    set -- bentoml serve-gunicorn "$@" /home/bentoml
   fi
 
   # Set BentoML API server port via env var

--- a/bentoml/saved_bundle/templates.py
+++ b/bentoml/saved_bundle/templates.py
@@ -74,8 +74,12 @@ FROM {docker_base_image}
 # Configure PIP install arguments, e.g. --index-url, --trusted-url, --extra-index-url
 ARG EXTRA_PIP_INSTALL_ARGS=
 ENV EXTRA_PIP_INSTALL_ARGS $EXTRA_PIP_INSTALL_ARGS
-CMD useradd -m bento
-USER bento
+
+ARG UNAME=bento
+ARG UID=1034
+ARG GID=1034
+CMD groupadd -g $GID -o $UNAME && useradd -m -u $UID -g $GID -o -r $UNAME
+USER $UNAME
 
 # copy over files needed for init script
 COPY environment.yml requirements.txt setup.sh* bentoml-init.sh python_version* /home/bento/

--- a/bentoml/saved_bundle/templates.py
+++ b/bentoml/saved_bundle/templates.py
@@ -74,36 +74,38 @@ FROM {docker_base_image}
 # Configure PIP install arguments, e.g. --index-url, --trusted-url, --extra-index-url
 ARG EXTRA_PIP_INSTALL_ARGS=
 ENV EXTRA_PIP_INSTALL_ARGS $EXTRA_PIP_INSTALL_ARGS
+CMD useradd -m bento
+USER bento
 
 # copy over files needed for init script
-COPY environment.yml requirements.txt setup.sh* bentoml-init.sh python_version* /bento/
-WORKDIR /bento
+COPY environment.yml requirements.txt setup.sh* bentoml-init.sh python_version* /home/bento/
+WORKDIR /home/bento
 
 # copy over entrypoint scripts
 COPY docker-entrypoint.sh /usr/local/bin/
 
 # Copy environment.yml, because bundled_pip_dependencies might not exist. This
 # prevent COPY command from failing.
-COPY environment.yml bundled_pip_dependencies*  /bento/bundled_pip_dependencies/
+COPY environment.yml bundled_pip_dependencies*  /home/bento/bundled_pip_dependencies/
 
 # Remove environment.yml from bundled_pip_dependencies directory
-RUN rm /bento/bundled_pip_dependencies/environment.yml
+RUN rm /home/bento/bundled_pip_dependencies/environment.yml
 
 # Execute permission for scripts
-RUN chmod +x /bento/bentoml-init.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /home/bento/bentoml-init.sh /usr/local/bin/docker-entrypoint.sh
 
 # Install conda, pip dependencies and run user defined setup script
-RUN if [ -f /bento/bentoml-init.sh ]; then bash -c /bento/bentoml-init.sh; fi
+RUN if [ -f /home/bento/bentoml-init.sh ]; then bash -c /home/bento/bentoml-init.sh; fi
 
 # copy over model files
-COPY . /bento
+COPY . /home/bento
 
 # the env var $PORT is required by heroku container runtime
 ENV PORT 5000
 EXPOSE $PORT
 
 ENTRYPOINT [ "docker-entrypoint.sh" ]
-CMD ["bentoml", "serve-gunicorn", "/bento"]
+CMD ["bentoml", "serve-gunicorn", "/home/bento"]
 """  # noqa: E501
 
 INIT_PY_TEMPLATE = """\

--- a/bentoml/saved_bundle/templates.py
+++ b/bentoml/saved_bundle/templates.py
@@ -80,6 +80,7 @@ ARG GID=1034
 RUN groupadd -g $GID -o bentoml && useradd -m -u $UID -g $GID -o -r bentoml
 USER bentoml
 WORKDIR /home/bentoml
+ENV BENTOML_HOME=/home/bentoml/var/
 
 # copy over files needed for init script
 COPY --chown=bentoml:bentoml environment.yml requirements.txt setup.sh* bentoml-init.sh python_version* ./

--- a/bentoml/saved_bundle/templates.py
+++ b/bentoml/saved_bundle/templates.py
@@ -79,8 +79,9 @@ ARG UID=1034
 ARG GID=1034
 RUN groupadd -g $GID -o bentoml && useradd -m -u $UID -g $GID -o -r bentoml
 
-ENV BENTOML_HOME=/home/bentoml/
 ARG BUNDLE_PATH=/home/bentoml/bundle
+ENV BUNDLE_PATH=$BUNDLE_PATH
+ENV BENTOML_HOME=/home/bentoml/
 
 RUN mkdir $BUNDLE_PATH && chown bentoml:bentoml $BUNDLE_PATH -R
 WORKDIR $BUNDLE_PATH

--- a/bentoml/saved_bundle/templates.py
+++ b/bentoml/saved_bundle/templates.py
@@ -83,7 +83,7 @@ ENV BENTOML_HOME=/home/bentoml/
 ARG BUNDLE_PATH=/home/bentoml/bundle
 
 RUN mkdir $BUNDLE_PATH && chown bentoml:bentoml $BUNDLE_PATH -R
-WORKDIR $BUNDLE_PATN
+WORKDIR $BUNDLE_PATH
 
 COPY --chown=bentoml:bentoml bentoml-init.sh docker-entrypoint.sh ./
 RUN chmod +x ./bentoml-init.sh ./docker-entrypoint.sh


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
Run the API server as root has potential security risks.
<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [x] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
