### PR TITLE
Restricted Gunicorn application classes to POSIX environments

### DIFF
--- a/bentoml/__init__.py
+++ b/bentoml/__init__.py
@@ -12,20 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import psutil
-
-if psutil.POSIX:
-    # After Python 3.8, the default start method of multiprocessing for MacOS changed to
-    # spawn, which would cause RecursionError when launching Gunicorn Application.
-    # Ref:
-    # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
-    #
-    # Note: https://bugs.python.org/issue33725 claims that fork method may cause crashes
-    # on MacOS.
-    import multiprocessing
-
-    multiprocessing.set_start_method('fork')
-
 from ._version import get_versions
 
 __version__ = get_versions()['version']

--- a/bentoml/server/gunicorn_server.py
+++ b/bentoml/server/gunicorn_server.py
@@ -16,7 +16,6 @@ import logging
 import psutil
 
 from flask import Response
-from gunicorn.app.base import Application
 
 from bentoml import config
 from bentoml.saved_bundle import load_from_dir
@@ -41,6 +40,7 @@ class GunicornBentoAPIServer(BentoAPIServer):
 
 
 if psutil.POSIX:
+    from gunicorn.app.base import Application
 
     class GunicornBentoServer(Application):  # pylint: disable=abstract-method
         """

--- a/bentoml/server/gunicorn_server.py
+++ b/bentoml/server/gunicorn_server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import psutil
 
 from flask import Response
 from gunicorn.app.base import Application
@@ -39,71 +40,82 @@ class GunicornBentoAPIServer(BentoAPIServer):
         return Response(generate_latest(registry), mimetype=CONTENT_TYPE_LATEST)
 
 
-class GunicornBentoServer(Application):  # pylint: disable=abstract-method
-    """
-    A custom Gunicorn application.
+if psutil.POSIX:
 
-    Usage::
+    class GunicornBentoServer(Application):  # pylint: disable=abstract-method
+        """
+        A custom Gunicorn application.
 
-        >>> from bentoml.server.gunicorn_server import GunicornBentoServer
-        >>>
-        >>> gunicorn_app = GunicornBentoServer(saved_bundle_path, port=5000)
-        >>> gunicorn_app.run()
+        Usage::
 
-    :param bundle_path: path to the saved BentoService bundle
-    :param port: the port you want to run gunicorn server on
-    :param workers: number of worker processes
-    :param timeout: request timeout config
-    """
+            >>> from bentoml.server.gunicorn_server import GunicornBentoServer
+            >>>
+            >>> gunicorn_app = GunicornBentoServer(saved_bundle_path, port=5000)
+            >>> gunicorn_app.run()
 
-    def __init__(
-        self,
-        bundle_path,
-        port=None,
-        workers=None,
-        timeout=None,
-        prometheus_lock=None,
-        enable_swagger=True,
-    ):
-        self.bento_service_bundle_path = bundle_path
+        :param bundle_path: path to the saved BentoService bundle
+        :param port: the port you want to run gunicorn server on
+        :param workers: number of worker processes
+        :param timeout: request timeout config
+        """
 
-        self.port = port or config("apiserver").getint("default_port")
-        timeout = timeout or config("apiserver").getint("default_timeout")
-        max_request_size = config("apiserver").getint("default_max_request_size")
-        self.options = {
-            "bind": "%s:%s" % ("0.0.0.0", self.port),
-            "timeout": timeout,
-            "limit_request_line": max_request_size,
-            "loglevel": config("logging").get("LEVEL").upper(),
-        }
-        if workers:
-            self.options['workers'] = workers
-        self.prometheus_lock = prometheus_lock
-        self.enable_swagger = enable_swagger
+        def __init__(
+            self,
+            bundle_path,
+            port=None,
+            workers=None,
+            timeout=None,
+            prometheus_lock=None,
+            enable_swagger=True,
+        ):
+            self.bento_service_bundle_path = bundle_path
 
-        super(GunicornBentoServer, self).__init__()
+            self.port = port or config("apiserver").getint("default_port")
+            timeout = timeout or config("apiserver").getint("default_timeout")
+            max_request_size = config("apiserver").getint("default_max_request_size")
+            self.options = {
+                "bind": "%s:%s" % ("0.0.0.0", self.port),
+                "timeout": timeout,
+                "limit_request_line": max_request_size,
+                "loglevel": config("logging").get("LEVEL").upper(),
+            }
+            if workers:
+                self.options['workers'] = workers
+            self.prometheus_lock = prometheus_lock
+            self.enable_swagger = enable_swagger
 
-    def load_config(self):
-        self.load_config_from_file("python:bentoml.server.gunicorn_config")
+            super(GunicornBentoServer, self).__init__()
 
-        # override config with self.options
-        gunicorn_config = dict(
-            [
-                (key, value)
-                for key, value in self.options.items()
-                if key in self.cfg.settings and value is not None
-            ]
-        )
-        for key, value in gunicorn_config.items():
-            self.cfg.set(key.lower(), value)
+        def load_config(self):
+            self.load_config_from_file("python:bentoml.server.gunicorn_config")
 
-    def load(self):
-        bento_service = load_from_dir(self.bento_service_bundle_path)
-        api_server = GunicornBentoAPIServer(
-            bento_service, port=self.port, enable_swagger=self.enable_swagger
-        )
-        return api_server.app
+            # override config with self.options
+            gunicorn_config = dict(
+                [
+                    (key, value)
+                    for key, value in self.options.items()
+                    if key in self.cfg.settings and value is not None
+                ]
+            )
+            for key, value in gunicorn_config.items():
+                self.cfg.set(key.lower(), value)
 
-    def run(self):
-        setup_prometheus_multiproc_dir(self.prometheus_lock)
-        super(GunicornBentoServer, self).run()
+        def load(self):
+            bento_service = load_from_dir(self.bento_service_bundle_path)
+            api_server = GunicornBentoAPIServer(
+                bento_service, port=self.port, enable_swagger=self.enable_swagger
+            )
+            return api_server.app
+
+        def run(self):
+            setup_prometheus_multiproc_dir(self.prometheus_lock)
+            super(GunicornBentoServer, self).run()
+
+
+else:
+
+    class GunicornBentoServer:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                "GunicornBentoServer is not supported in non-POSIX environments."
+            )

--- a/bentoml/server/marshal_server.py
+++ b/bentoml/server/marshal_server.py
@@ -16,8 +16,6 @@ import logging
 import multiprocessing
 import psutil
 
-from gunicorn.app.base import Application
-
 from bentoml import config
 from bentoml.marshal.marshal import MarshalService
 from bentoml.server.instruments import setup_prometheus_multiproc_dir
@@ -37,6 +35,7 @@ marshal_logger = logging.getLogger("bentoml.marshal")
 
 
 if psutil.POSIX:
+    from gunicorn.app.base import Application
 
     class GunicornMarshalServer(Application):  # pylint: disable=abstract-method
         def __init__(

--- a/bentoml/server/marshal_server.py
+++ b/bentoml/server/marshal_server.py
@@ -14,6 +14,7 @@
 
 import logging
 import multiprocessing
+import psutil
 
 from gunicorn.app.base import Application
 
@@ -21,81 +22,102 @@ from bentoml import config
 from bentoml.marshal.marshal import MarshalService
 from bentoml.server.instruments import setup_prometheus_multiproc_dir
 
+if psutil.POSIX:
+    # After Python 3.8, the default start method of multiprocessing for MacOS changed to
+    # spawn, which would cause RecursionError when launching Gunicorn Application.
+    # Ref:
+    # https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+    #
+    # Note: https://bugs.python.org/issue33725 claims that fork method may cause crashes
+    # on MacOS.
+    multiprocessing.set_start_method('fork')
+
 
 marshal_logger = logging.getLogger("bentoml.marshal")
 
 
-class GunicornMarshalServer(Application):  # pylint: disable=abstract-method
-    def __init__(
-        self,
-        outbound_host,
-        outbound_port,
-        bundle_path,
-        port=None,
-        workers=1,
-        timeout=None,
-        prometheus_lock=None,
-        outbound_workers=1,
-        mb_max_batch_size: int = None,
-        mb_max_latency: int = None,
-    ):
-        self.bento_service_bundle_path = bundle_path
+if psutil.POSIX:
 
-        self.port = port or config("apiserver").getint("default_port")
-        timeout = timeout or config("apiserver").getint("default_timeout")
-        max_request_size = config("apiserver").getint("default_max_request_size")
-        self.options = {
-            "bind": "%s:%s" % ("0.0.0.0", self.port),
-            "timeout": timeout,
-            "limit_request_line": max_request_size,
-            "loglevel": config("logging").get("LEVEL").upper(),
-            "worker_class": "aiohttp.worker.GunicornWebWorker",
-        }
-        if workers:
-            self.options['workers'] = workers
-        self.prometheus_lock = prometheus_lock
+    class GunicornMarshalServer(Application):  # pylint: disable=abstract-method
+        def __init__(
+            self,
+            outbound_host,
+            outbound_port,
+            bundle_path,
+            port=None,
+            workers=1,
+            timeout=None,
+            prometheus_lock=None,
+            outbound_workers=1,
+            mb_max_batch_size: int = None,
+            mb_max_latency: int = None,
+        ):
+            self.bento_service_bundle_path = bundle_path
 
-        self.outbound_port = outbound_port
-        self.outbound_host = outbound_host
-        self.outbound_workers = outbound_workers
-        self.mb_max_batch_size = mb_max_batch_size
-        self.mb_max_latency = mb_max_latency
+            self.port = port or config("apiserver").getint("default_port")
+            timeout = timeout or config("apiserver").getint("default_timeout")
+            max_request_size = config("apiserver").getint("default_max_request_size")
+            self.options = {
+                "bind": "%s:%s" % ("0.0.0.0", self.port),
+                "timeout": timeout,
+                "limit_request_line": max_request_size,
+                "loglevel": config("logging").get("LEVEL").upper(),
+                "worker_class": "aiohttp.worker.GunicornWebWorker",
+            }
+            if workers:
+                self.options['workers'] = workers
+            self.prometheus_lock = prometheus_lock
 
-        super(GunicornMarshalServer, self).__init__()
+            self.outbound_port = outbound_port
+            self.outbound_host = outbound_host
+            self.outbound_workers = outbound_workers
+            self.mb_max_batch_size = mb_max_batch_size
+            self.mb_max_latency = mb_max_latency
 
-    def load_config(self):
-        self.load_config_from_file("python:bentoml.server.gunicorn_config")
+            super(GunicornMarshalServer, self).__init__()
 
-        # override config with self.options
-        gunicorn_config = dict(
-            [
-                (key, value)
-                for key, value in self.options.items()
-                if key in self.cfg.settings and value is not None
-            ]
-        )
-        for key, value in gunicorn_config.items():
-            self.cfg.set(key.lower(), value)
+        def load_config(self):
+            self.load_config_from_file("python:bentoml.server.gunicorn_config")
 
-    def load(self):
-        server = MarshalService(
-            self.bento_service_bundle_path,
-            self.outbound_host,
-            self.outbound_port,
-            outbound_workers=self.outbound_workers,
-            mb_max_batch_size=self.mb_max_batch_size,
-            mb_max_latency=self.mb_max_latency,
-        )
-        return server.make_app()
+            # override config with self.options
+            gunicorn_config = dict(
+                [
+                    (key, value)
+                    for key, value in self.options.items()
+                    if key in self.cfg.settings and value is not None
+                ]
+            )
+            for key, value in gunicorn_config.items():
+                self.cfg.set(key.lower(), value)
 
-    def run(self):
-        setup_prometheus_multiproc_dir(self.prometheus_lock)
-        super(GunicornMarshalServer, self).run()
+        def load(self):
+            server = MarshalService(
+                self.bento_service_bundle_path,
+                self.outbound_host,
+                self.outbound_port,
+                outbound_workers=self.outbound_workers,
+                mb_max_batch_size=self.mb_max_batch_size,
+                mb_max_latency=self.mb_max_latency,
+            )
+            return server.make_app()
 
-    def async_run(self):
-        """
-        Start an micro batch server.
-        """
-        marshal_proc = multiprocessing.Process(target=self.run, daemon=True)
-        marshal_proc.start()
-        marshal_logger.info("Running micro batch service on :%d", self.port)
+        def run(self):
+            setup_prometheus_multiproc_dir(self.prometheus_lock)
+            super(GunicornMarshalServer, self).run()
+
+        def async_run(self):
+            """
+            Start an micro batch server.
+            """
+            marshal_proc = multiprocessing.Process(target=self.run, daemon=True)
+            marshal_proc.start()
+            marshal_logger.info("Running micro batch service on :%d", self.port)
+
+
+else:
+
+    class GunicornMarshalServer:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                "GunicornMarshalServer is not supported in non-POSIX environments."
+            )

--- a/tests/utils/test_usage_stats.py
+++ b/tests/utils/test_usage_stats.py
@@ -1,5 +1,3 @@
-import pytest
-import psutil  # noqa # pylint: disable=unused-import
 from click.testing import CliRunner
 from mock import MagicMock, patch
 
@@ -110,7 +108,6 @@ def test_track_cli_with_click_exception():
         assert properties['return_code'] == 1
 
 
-@pytest.mark.skipif('not psutil.POSIX')
 def test_track_cli_with_keyboard_interrupt(bento_bundle_path):
     with patch('bentoml.cli.click_utils.track') as track:
         track.side_effect = mock_track_func


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
Restricted Gunicorn application classes to POSIX environments.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->
This change allows dependency injector to wire packages separately for CLI `bentoml serve` and `bentoml serve-unicorn` allowing `bentoml serve` continue to work for non-POSIX operating systems.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
./dev/format.sh
./dev/lint.sh
./ci/unit_test.sh

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [x] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
