### PR TITLE
Always start marshal server even if micro-batch is disabled

### DIFF
--- a/bentoml/cli/bento_service.py
+++ b/bentoml/cli/bento_service.py
@@ -15,8 +15,6 @@ from bentoml.cli.click_utils import (
 )
 from bentoml.cli.utils import Spinner
 from bentoml.configuration import BENTOML_CONFIG
-from bentoml.configuration.containers import BentoMLConfiguration, BentoMLContainer
-from bentoml.exceptions import InvalidArgument
 from bentoml.saved_bundle import (
     load_bento_service_api,
     load_bento_service_metadata,
@@ -46,8 +44,7 @@ batch_options = [
     click.option(
         '--enable-microbatch/--disable-microbatch',
         default=None,
-        help="Run API server with micro-batch enabled. This option has been deprecated because "
-        "micro-batch is now the default behavior.",
+        help="Run API server with micro-batch enabled.",
         envvar='BENTOML_ENABLE_MICROBATCH',
     ),
     click.option(
@@ -227,16 +224,6 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         enable_swagger,
         config,
     ):
-        if enable_microbatch is not None:
-            if enable_microbatch:
-                _echo(
-                    "The microbatch option is enabled by default starting release 0.12.0. "
-                    "To learn more about micro-batching, please see "
-                    "https://docs.bentoml.org/en/latest/concepts.html#adaptive-micro-batching"
-                )
-            else:
-                raise InvalidArgument("Disable micro-batching is no longer supported.")
-
         saved_bundle_path = resolve_bundle_path(
             bento, pip_installed_bundle_path, yatai_url
         )
@@ -244,6 +231,7 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
         start_dev_server(
             saved_bundle_path,
             port=port,
+            enable_microbatch=enable_microbatch,
             mb_max_batch_size=mb_max_batch_size,
             mb_max_latency=mb_max_latency,
             run_with_ngrok=run_with_ngrok,
@@ -319,16 +307,6 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
             )
             return
 
-        if enable_microbatch is not None:
-            if enable_microbatch:
-                _echo(
-                    "The microbatch option is enabled by default starting release 0.12.0. "
-                    "To learn more about micro-batching, please see "
-                    "https://docs.bentoml.org/en/latest/concepts.html#adaptive-micro-batching"
-                )
-            else:
-                raise InvalidArgument("Disable micro-batching is no longer supported.")
-
         saved_bundle_path = resolve_bundle_path(
             bento, pip_installed_bundle_path, yatai_url
         )
@@ -338,6 +316,7 @@ def create_bento_service_cli(pip_installed_bundle_path=None):
             port=port,
             workers=workers,
             timeout=timeout,
+            enable_microbatch=enable_microbatch,
             enable_swagger=enable_swagger,
             mb_max_batch_size=mb_max_batch_size,
             mb_max_latency=mb_max_latency,

--- a/bentoml/cli/bento_service.py
+++ b/bentoml/cli/bento_service.py
@@ -15,6 +15,7 @@ from bentoml.cli.click_utils import (
 )
 from bentoml.cli.utils import Spinner
 from bentoml.configuration import BENTOML_CONFIG
+from bentoml.configuration.containers import BentoMLConfiguration, BentoMLContainer
 from bentoml.saved_bundle import (
     load_bento_service_api,
     load_bento_service_metadata,

--- a/bentoml/configuration/default_bentoml.yml
+++ b/bentoml/configuration/default_bentoml.yml
@@ -5,7 +5,7 @@
 
 api_server:
   port: 5000
-  enable_microbatch: False
+  enable_microbatch: True
   run_with_ngrok: False
   enable_swagger: True
   enable_metrics: True

--- a/bentoml/configuration/default_bentoml.yml
+++ b/bentoml/configuration/default_bentoml.yml
@@ -5,7 +5,7 @@
 
 api_server:
   port: 5000
-  enable_microbatch: True
+  enable_microbatch: False
   run_with_ngrok: False
   enable_swagger: True
   enable_metrics: True

--- a/bentoml/marshal/marshal.py
+++ b/bentoml/marshal/marshal.py
@@ -155,6 +155,9 @@ class MarshalService:
             BentoMLContainer.config.api_server.max_request_size
         ],
         outbound_unix_socket: str = None,
+        enable_microbatch: bool = Provide[
+            BentoMLContainer.config.api_server.enable_microbatch
+        ],
     ):
         self._client = None
         self.outbound_unix_socket = outbound_unix_socket
@@ -170,7 +173,9 @@ class MarshalService:
 
         self.bento_service_metadata_pb = load_bento_service_metadata(bento_bundle_path)
 
-        self.setup_routes_from_pb(self.bento_service_metadata_pb)
+        print("### enable_microbatch ###", enable_microbatch)
+        if enable_microbatch:
+            self.setup_routes_from_pb(self.bento_service_metadata_pb)
         if psutil.POSIX:
             import resource
 
@@ -248,6 +253,7 @@ class MarshalService:
                 )
 
     async def request_dispatcher(self, request):
+        print("### Marshal request_dispatcher ###")
         with async_trace(
             service_name=self.__class__.__name__,
             span_name="[1]http request",

--- a/bentoml/marshal/marshal.py
+++ b/bentoml/marshal/marshal.py
@@ -173,7 +173,6 @@ class MarshalService:
 
         self.bento_service_metadata_pb = load_bento_service_metadata(bento_bundle_path)
 
-        print("### enable_microbatch ###", enable_microbatch)
         if enable_microbatch:
             self.setup_routes_from_pb(self.bento_service_metadata_pb)
         if psutil.POSIX:
@@ -253,7 +252,6 @@ class MarshalService:
                 )
 
     async def request_dispatcher(self, request):
-        print("### Marshal request_dispatcher ###")
         with async_trace(
             service_name=self.__class__.__name__,
             span_name="[1]http request",

--- a/bentoml/marshal/marshal.py
+++ b/bentoml/marshal/marshal.py
@@ -372,6 +372,4 @@ class MarshalService:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         app = self.make_app()
-
-        logger.info("Running micro batch service on :%d", port)
         aiohttp.web.run_app(app, port=port)

--- a/bentoml/server/__init__.py
+++ b/bentoml/server/__init__.py
@@ -27,22 +27,19 @@ logger = logging.getLogger(__name__)
 
 @inject
 def start_dev_server(
-    saved_bundle_path: str,
-    port: int = Provide[BentoMLContainer.config.api_server.port],
-    enable_microbatch: bool = Provide[
-        BentoMLContainer.config.api_server.enable_microbatch
-    ],
-    mb_max_batch_size: int = Provide[
-        BentoMLContainer.config.marshal_server.max_batch_size
-    ],
-    mb_max_latency: int = Provide[BentoMLContainer.config.marshal_server.max_latency],
-    run_with_ngrok: bool = Provide[BentoMLContainer.config.api_server.run_with_ngrok],
-    enable_swagger: bool = Provide[BentoMLContainer.config.api_server.enable_swagger],
+    bundle_path: str,
+    port: Optional[int] = None,
+    mb_max_batch_size: Optional[int] = None,
+    mb_max_latency: Optional[int] = None,
+    run_with_ngrok: Optional[bool] = None,
+    enable_swagger: Optional[bool] = None,
+    config_file: Optional[str] = None,
 ):
-    logger.info("Starting BentoML API server in development mode..")
-
-    from bentoml.saved_bundle import load_from_dir
-    from bentoml.server.api_server import BentoAPIServer
+    config = BentoMLConfiguration(override_config_file=config_file)
+    config.override(["api_server", "port"], port)
+    config.override(["api_server", "enable_swagger"], enable_swagger)
+    config.override(["marshal_server", "max_batch_size"], mb_max_batch_size)
+    config.override(["marshal_server", "max_latency"], mb_max_latency)
 
     if run_with_ngrok:
         from threading import Timer
@@ -53,53 +50,67 @@ def start_dev_server(
         thread.setDaemon(True)
         thread.start()
 
-    if enable_microbatch:
-        with reserve_free_port() as api_server_port:
-            # start server right after port released
-            #  to reduce potential race
+    with reserve_free_port() as api_server_port:
+        # start server right after port released
+        #  to reduce potential race
 
-            marshal_proc = multiprocessing.Process(
-                target=start_dev_batching_server,
-                kwargs=dict(
-                    api_server_port=api_server_port,
-                    saved_bundle_path=saved_bundle_path,
-                    port=port,
-                    mb_max_latency=mb_max_latency,
-                    mb_max_batch_size=mb_max_batch_size,
-                ),
-                daemon=True,
-            )
-        marshal_proc.start()
+        model_server_proc = multiprocessing.Process(
+            target=_start_dev_server,
+            kwargs=dict(
+                api_server_port=api_server_port,
+                saved_bundle_path=bundle_path,
+                config=config,
+            ),
+            daemon=True,
+        )
+    model_server_proc.start()
 
-        bento_service = load_from_dir(saved_bundle_path)
-        api_server = BentoAPIServer(bento_service, enable_swagger=enable_swagger)
-        api_server.start(port=api_server_port)
-    else:
-        bento_service = load_from_dir(saved_bundle_path)
-        api_server = BentoAPIServer(bento_service, enable_swagger=enable_swagger)
-        api_server.start(port=port)
+    try:
+        _start_dev_batching_server(
+            api_server_port=api_server_port,
+            saved_bundle_path=bundle_path,
+            config=config,
+        )
+    finally:
+        model_server_proc.terminate()
 
 
-def start_dev_batching_server(
-    saved_bundle_path: str,
-    port: int,
-    api_server_port: int,
-    mb_max_batch_size: int,
-    mb_max_latency: int,
+def _start_dev_server(
+    saved_bundle_path: str, api_server_port: int, config: BentoMLConfiguration,
 ):
+
+    logger.info("Starting BentoML API server in development mode..")
+
+    from bentoml.saved_bundle import load_from_dir
+
+    bento_service = load_from_dir(saved_bundle_path)
+
+    from bentoml.server.api_server import BentoAPIServer
+
+    container = BentoMLContainer()
+    container.config.from_dict(config.as_dict())
+    container.wire(packages=[sys.modules[__name__]])
+
+    api_server = BentoAPIServer(bento_service)
+    api_server.start(port=api_server_port)
+
+
+def _start_dev_batching_server(
+    saved_bundle_path: str, api_server_port: int, config: BentoMLConfiguration,
+):
+    from bentoml import marshal
+
+    container = BentoMLContainer()
+    container.config.from_dict(config.as_dict())
+    container.wire(packages=[marshal])
 
     from bentoml.marshal.marshal import MarshalService
 
     marshal_server = MarshalService(
-        saved_bundle_path,
-        outbound_host="localhost",
-        outbound_port=api_server_port,
-        outbound_workers=1,
-        mb_max_batch_size=mb_max_batch_size,
-        mb_max_latency=mb_max_latency,
+        saved_bundle_path, outbound_host="localhost", outbound_port=api_server_port,
     )
-    logger.info("Running micro batch service on :%d", port)
-    marshal_server.fork_start_app(port=port)
+
+    marshal_server.fork_start_app()
 
 
 def start_prod_server(
@@ -107,7 +118,6 @@ def start_prod_server(
     port: Optional[int] = None,
     workers: Optional[int] = None,
     timeout: Optional[int] = None,
-    enable_microbatch: Optional[bool] = None,
     enable_swagger: Optional[bool] = None,
     mb_max_batch_size: Optional[int] = None,
     mb_max_latency: Optional[int] = None,
@@ -124,46 +134,42 @@ def start_prod_server(
     config.override(["api_server", "port"], port)
     config.override(["api_server", "workers"], workers)
     config.override(["api_server", "timeout"], timeout)
-    config.override(["api_server", "enable_microbatch"], enable_microbatch)
     config.override(["api_server", "enable_swagger"], enable_swagger)
     config.override(["marshal_server", "max_batch_size"], mb_max_batch_size)
     config.override(["marshal_server", "max_latency"], mb_max_latency)
     config.override(["marshal_server", "workers"], microbatch_workers)
 
-    if config.config['api_server'].get('enable_microbatch'):
-        prometheus_lock = multiprocessing.Lock()
-        with reserve_free_port() as api_server_port:
-            pass
+    prometheus_lock = multiprocessing.Lock()
+    with reserve_free_port() as api_server_port:
+        pass
 
-        model_server_job = multiprocessing.Process(
-            target=_start_prod_server,
-            kwargs=dict(
-                saved_bundle_path=saved_bundle_path,
-                port=api_server_port,
-                config=config,
-                prometheus_lock=prometheus_lock,
-            ),
-            daemon=True,
+    model_server_job = multiprocessing.Process(
+        target=_start_prod_server,
+        kwargs=dict(
+            saved_bundle_path=saved_bundle_path,
+            port=api_server_port,
+            config=config,
+            prometheus_lock=prometheus_lock,
+        ),
+        daemon=True,
+    )
+    model_server_job.start()
+
+    try:
+        _start_prod_batching_server(
+            saved_bundle_path=saved_bundle_path,
+            config=config,
+            api_server_port=api_server_port,
+            prometheus_lock=prometheus_lock,
         )
-        model_server_job.start()
-
-        try:
-            _start_prod_batching_server(
-                saved_bundle_path=saved_bundle_path,
-                config=config,
-                api_server_port=api_server_port,
-                prometheus_lock=prometheus_lock,
-            )
-        finally:
-            model_server_job.terminate()
-    else:
-        _start_prod_server(saved_bundle_path=saved_bundle_path, config=config)
+    finally:
+        model_server_job.terminate()
 
 
 def _start_prod_server(
     saved_bundle_path: str,
     config: BentoMLConfiguration,
-    port: Optional[int] = None,
+    port: int,
     prometheus_lock: Optional[multiprocessing.Lock] = None,
 ):
 
@@ -176,14 +182,9 @@ def _start_prod_server(
 
     from bentoml.server.gunicorn_server import GunicornBentoServer
 
-    if port is None:
-        gunicorn_app = GunicornBentoServer(
-            saved_bundle_path, prometheus_lock=prometheus_lock,
-        )
-    else:
-        gunicorn_app = GunicornBentoServer(
-            saved_bundle_path, port=port, prometheus_lock=prometheus_lock,
-        )
+    gunicorn_app = GunicornBentoServer(
+        saved_bundle_path, port=port, prometheus_lock=prometheus_lock,
+    )
     gunicorn_app.run()
 
 

--- a/bentoml/server/api_server.py
+++ b/bentoml/server/api_server.py
@@ -151,7 +151,9 @@ class BentoAPIServer:
         self,
         bento_service: BentoService,
         app_name: str = None,
-        enable_swagger: bool = True,
+        enable_swagger: bool = Provide[
+            BentoMLContainer.config.api_server.enable_swagger
+        ],
         enable_metrics: bool = Provide[
             BentoMLContainer.config.api_server.enable_metrics
         ],

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -857,6 +857,10 @@ image built above:
 Adaptive Micro-Batching
 ^^^^^^^^^^^^^^^^^^^^^^^
 
+.. note::
+  The Adaptive Micro-batching option has become the default behavior starting release 0.12.0.
+  Running with the --disable-microbatch option will fail.
+
 Micro batching is a technique where incoming prediction requests are grouped into small
 batches to achieve the performance advantage of batch processing in model inference
 tasks. BentoML implemented such a micro batching layer that is inspired by the paper
@@ -868,17 +872,6 @@ Given the mass performance improvement a model serving system get from micro-bat
 BentoML APIs were designed to work with micro-batching without any code changes on the 
 user side. It is why all the API InputAdapters are designed to accept a list of input data, 
 as described in the :ref:`concepts-api-func-and-adapters` section.
-
-Currently, micro-batching is still a beta feature, users can enable micro-batching by
-passing a flag when running BentoML API server:
-
-.. code-block:: bash
-
-    # Launch micro batching API server from CLI
-    bentoml serve-gunicorn $saved_path --enable-microbatch
-
-    # Launch model server docker image with micro batching enabled
-    docker run -p 5000:5000 -e BENTOML_ENABLE_MICROBATCH=True {username}/iris-classifier:latest
 
 
 Programmatic Access

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -204,3 +204,34 @@ def test_echo_docker_api_result_push():
 
     res = [line for line in echo_docker_api_result(push_stream)]
     assert_equal_lists(res, expected)
+
+
+@pytest.mark.skipif('not psutil.POSIX')
+def test_gunicorn_serve_command():
+    runner = CliRunner()
+
+    cli = create_bento_service_cli()
+    gunicorn_cmd = cli.commands["serve-gunicorn"]
+
+    with mock.patch(
+        'bentoml.cli.bento_service.start_prod_server',
+    ) as mocked_start_prod_server:
+        runner.invoke(
+            gunicorn_cmd, ["/"],
+        )
+        assert mocked_start_prod_server.called
+
+
+def test_serve_command():
+    runner = CliRunner()
+
+    cli = create_bento_service_cli()
+    gunicorn_cmd = cli.commands["serve"]
+
+    with mock.patch(
+        'bentoml.cli.bento_service.start_dev_server',
+    ) as mocked_start_dev_server:
+        runner.invoke(
+            gunicorn_cmd, ["/"],
+        )
+        assert mocked_start_dev_server.called

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -204,21 +204,3 @@ def test_echo_docker_api_result_push():
 
     res = [line for line in echo_docker_api_result(push_stream)]
     assert_equal_lists(res, expected)
-
-
-@pytest.mark.skipif('not psutil.POSIX')
-@pytest.mark.skip(reason="I'm investigating the right fix for this test.")
-def test_gunicorn_serve_command():
-    runner = CliRunner()
-
-    cli = create_bento_service_cli()
-    gunicorn_cmd = cli.commands["serve-gunicorn"]
-
-    with mock.patch(
-        'bentoml.server.gunicorn_server.GunicornBentoServer',
-    ) as mocked_class:
-        runner.invoke(
-            gunicorn_cmd, ["/"],
-        )
-        instance = mocked_class.return_value
-        assert instance.run.called

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -207,6 +207,7 @@ def test_echo_docker_api_result_push():
 
 
 @pytest.mark.skipif('not psutil.POSIX')
+@pytest.mark.skip(reason="I'm investigating the right fix for this test.")
 def test_gunicorn_serve_command():
     runner = CliRunner()
 

--- a/tests/utils/test_usage_stats.py
+++ b/tests/utils/test_usage_stats.py
@@ -49,6 +49,7 @@ def mock_start_dev_server(
     mb_max_batch_size: int = 0,
     run_with_ngrok: bool = False,
     enable_swagger: bool = False,
+    config_file: str = None,
 ):
     raise KeyboardInterrupt()
 


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
Marshal server is always started at serving time. If micro-batching is enabled, marshal server will perform batching; otherwise, requests to the marshal server are pass through. Refactored `start_dev_server` to follow the same pattern as `start_prod_server`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->
Marshal server will start functioning like a sidecar or reverse proxy. The change enables further functionality to be added to the marshal server.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`./ci/unit_tests.py` but I'm still investigating the right fix to an existing test. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code Refactoring (internal change which is not user facing)
- [x] Documentation
- [x] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [x] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [x] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
