### PR TITLE
Applying conda's `--override_channels` in bento-init.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ master ]
   schedule:
-    cron: '0 2 * * *'
+    - cron: '0 2 * * *'
 
 jobs:
 

--- a/bentoml/service/__init__.py
+++ b/bentoml/service/__init__.py
@@ -31,9 +31,9 @@ from bentoml.configuration import get_bentoml_deploy_version
 from bentoml.exceptions import BentoMLException, InvalidArgument, NotFound
 from bentoml.saved_bundle import save_to_dir
 from bentoml.saved_bundle.config import (
-    SavedBundleConfig,
-    DEFAULT_MAX_LATENCY,
     DEFAULT_MAX_BATCH_SIZE,
+    DEFAULT_MAX_LATENCY,
+    SavedBundleConfig,
 )
 from bentoml.saved_bundle.pip_pkg import seek_pip_packages
 from bentoml.service.artifacts import ArtifactCollection, BentoServiceArtifact
@@ -237,6 +237,7 @@ def env_decorator(
     requirements_txt_file: str = None,
     conda_channels: List[str] = None,
     conda_overwrite_channels: bool = False,
+    conda_override_channels: bool = False,
     conda_dependencies: List[str] = None,
     conda_env_yml_file: str = None,
     setup_sh: str = None,
@@ -257,9 +258,13 @@ def env_decorator(
         auto_pip_dependencies: same as infer_pip_packages but deprecated
         requirements_txt_file: path to the requirements.txt where pip dependencies
             are explicitly specified, with ideally pinned versions
-        conda_channels: list of extra conda channels to be used
-        conda_overwrite_channels: Turn on to make conda_channels overwrite the list of
-            channels instead of adding to it
+        conda_channels: list of extra conda channels other than dafault channels to be
+            used. This is equivalent to passing the --channels to conda commands
+        conda_override_channels: ensures that conda searches only your specified
+            channel and no other channels, such as default channels.
+            This is equivalent to passing the --override-channels option to conda
+            commands, or adding `nodefaults` to the `channels` in the environment.yml
+        conda_overwrite_channels: aliases to `override_channels`
         conda_dependencies: list of conda dependencies required
         conda_env_yml_file: use a pre-defined conda environment yml file
         setup_sh: user defined setup bash script, it is executed in docker build time
@@ -297,6 +302,7 @@ def env_decorator(
             infer_pip_packages=infer_pip_packages or auto_pip_dependencies,
             requirements_txt_file=requirements_txt_file,
             conda_channels=conda_channels,
+            conda_override_channels=conda_override_channels,
             conda_overwrite_channels=conda_overwrite_channels,
             conda_dependencies=conda_dependencies,
             conda_env_yml_file=conda_env_yml_file,

--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -71,7 +71,6 @@ class CondaEnv(object):
     ):
         self._yaml = YAML()
         self._yaml.default_flow_style = False
-        self.overwrite_channels = overwrite_channels
 
         if default_env_yaml_file:
             env_yml_file = Path(default_env_yaml_file)
@@ -88,7 +87,7 @@ class CondaEnv(object):
             self.set_name(name)
 
         if channels:
-            self.add_channels(channels)
+            self.set_channels(channels, overwrite_channels)
 
         if dependencies:
             self.add_conda_dependencies(dependencies)
@@ -104,16 +103,10 @@ class CondaEnv(object):
             conda_dependencies + self._conda_env["dependencies"]
         )
 
-    def add_channels(self, channels: List[str]):
-        if channels and self.overwrite_channels:
-            logger.debug("Removing default conda channels from environment.yml")
-            self._conda_env["channels"] = []
-
-        for channel_name in channels:
-            if channel_name not in self._conda_env["channels"]:
-                self._conda_env["channels"] += channels
-            else:
-                logger.debug(f"Conda channel {channel_name} already added")
+    def set_channels(self, channels: List[str], overwrite_channels=False):
+        if overwrite_channels and "nodefaults" not in channels:
+            channels.append("nodefaults")
+        self._conda_env["channels"] = channels
 
     def write_to_yaml_file(self, filepath):
         with open(filepath, 'wb') as output_yaml:
@@ -135,9 +128,12 @@ class BentoServiceEnv(object):
             pip dependencies and pin their version
         requirements_txt_file: path to the requirements.txt where pip dependencies
             are explicitly specified, with ideally pinned versions
-        conda_channels: list of extra conda channels to be used
-        conda_overwrite_channels: Turn on to make conda_channels overwrite the list of
-            channels instead of adding to it
+        conda_channels: list of extra conda channels other than dafault channels to be
+            used. This is equivalent to passing the --channels to conda commands
+        conda_overwrite_channels: ensures that conda searches only your specified
+            channel and no other channels, such as default channels.
+            This is equivalent to passing the --override-channels option to conda
+            commands, or adding `nodefaults` to the `channels` in the environment.yml
         conda_dependencies: list of conda dependencies required
         conda_env_yml_file: use a pre-defined conda environment yml file
         setup_sh: user defined setup bash script, it is executed in docker build time
@@ -228,9 +224,6 @@ class BentoServiceEnv(object):
                     f"'{self._docker_base_image}'"
                 )
         self._zipimport_archives = zipimport_archives
-
-    def add_conda_channels(self, channels: List[str]):
-        self._conda_env.add_channels(channels)
 
     def add_conda_dependencies(self, conda_dependencies: List[str]):
         self._conda_env.add_conda_dependencies(conda_dependencies)

--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -84,6 +84,11 @@ class CondaEnv(object):
         if name:
             self.set_name(name)
 
+        if override_channels and channels is None:
+            raise BentoMLException(
+                "No `conda_channels` provided while override_channels=True"
+            )
+
         if channels:
             self.set_channels(channels, override_channels)
 

--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -48,8 +48,6 @@ PYTHON_VERSION = "{minor_version}.{micro}".format(
 
 DEFAULT_CONDA_ENV_BASE_YAML = """
 name: bentoml-default-conda-env
-channels:
-  - defaults
 dependencies: []
 """
 
@@ -129,7 +127,9 @@ class BentoServiceEnv(object):
         requirements_txt_file: path to the requirements.txt where pip dependencies
             are explicitly specified, with ideally pinned versions
         conda_channels: list of extra conda channels other than dafault channels to be
-            used. This is equivalent to passing the --channels to conda commands
+            used. This is equivalent to passing the --channels to conda commands.
+            If the `conda_env_yml_file` is specified, this will override the `channels`
+            section of the env yml file
         conda_override_channels: ensures that conda searches only your specified
             channel and no other channels, such as default channels.
             This is equivalent to passing the --override-channels option to conda

--- a/bentoml/service/env.py
+++ b/bentoml/service/env.py
@@ -67,7 +67,7 @@ class CondaEnv(object):
         channels: List[str] = None,
         dependencies: List[str] = None,
         default_env_yaml_file: str = None,
-        overwrite_channels: bool = False,
+        override_channels: bool = False,
     ):
         self._yaml = YAML()
         self._yaml.default_flow_style = False
@@ -87,7 +87,7 @@ class CondaEnv(object):
             self.set_name(name)
 
         if channels:
-            self.set_channels(channels, overwrite_channels)
+            self.set_channels(channels, override_channels)
 
         if dependencies:
             self.add_conda_dependencies(dependencies)
@@ -103,8 +103,8 @@ class CondaEnv(object):
             conda_dependencies + self._conda_env["dependencies"]
         )
 
-    def set_channels(self, channels: List[str], overwrite_channels=False):
-        if overwrite_channels and "nodefaults" not in channels:
+    def set_channels(self, channels: List[str], override_channels=False):
+        if override_channels and "nodefaults" not in channels:
             channels.append("nodefaults")
         self._conda_env["channels"] = channels
 
@@ -130,10 +130,11 @@ class BentoServiceEnv(object):
             are explicitly specified, with ideally pinned versions
         conda_channels: list of extra conda channels other than dafault channels to be
             used. This is equivalent to passing the --channels to conda commands
-        conda_overwrite_channels: ensures that conda searches only your specified
+        conda_override_channels: ensures that conda searches only your specified
             channel and no other channels, such as default channels.
             This is equivalent to passing the --override-channels option to conda
             commands, or adding `nodefaults` to the `channels` in the environment.yml
+        conda_overwrite_channels: aliases to `override_channels`
         conda_dependencies: list of conda dependencies required
         conda_env_yml_file: use a pre-defined conda environment yml file
         setup_sh: user defined setup bash script, it is executed in docker build time
@@ -151,6 +152,7 @@ class BentoServiceEnv(object):
         requirements_txt_file: str = None,
         conda_channels: List[str] = None,
         conda_overwrite_channels: bool = False,
+        conda_override_channels: bool = False,
         conda_dependencies: List[str] = None,
         conda_env_yml_file: str = None,
         setup_sh: str = None,
@@ -167,7 +169,7 @@ class BentoServiceEnv(object):
             channels=conda_channels,
             dependencies=conda_dependencies,
             default_env_yaml_file=conda_env_yml_file,
-            overwrite_channels=conda_overwrite_channels,
+            override_channels=conda_overwrite_channels or conda_override_channels,
         )
 
         self._pip_packages = {}

--- a/tests/test_service_env.py
+++ b/tests/test_service_env.py
@@ -189,7 +189,7 @@ def test_conda_overwrite_channels(tmpdir):
     @bentoml.env(
         conda_channels=["bentoml-test-channel"],
         conda_dependencies=["bentoml-test-lib"],
-        conda_overwrite_channels=True,
+        conda_override_channels=True,
     )
     class ServiceWithCondaDeps(bentoml.BentoService):
         @bentoml.api(input=DataframeInput(), batch=True)

--- a/tests/utils/test_usage_stats.py
+++ b/tests/utils/test_usage_stats.py
@@ -63,7 +63,6 @@ def test_get_bento_service_event_properties(bento_service):
     assert len(properties["input_types"]) == 4
 
     assert properties["env"] is not None
-    assert properties["env"]["conda_env"]["channels"] == ["defaults"]
 
 
 def test_get_bento_service_event_properties_with_no_artifact():


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
The current option `conda_channels` and `conda_overwrite_channels` imply developers have full control of the conda channels. But a bentoml service with `conda_overwrite_channels=True` will still install packages from channels other than specified in `conda_channels ` (from the official channels #1429). conda itself has a similar option `--override-channels` and already has a different solution for that.

In this PR, the behavior of `conda_overwrite_channels ` is changed following the official pattern: [conda/docs/sharing-an-environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#sharing-an-environment)
An option `conda_override_channels ` was added and act like the `--override-channels` option for conda.
`conda_overwrite_channels` now is a alias of `conda_override_channels`

Note: this PR contains **breaking changes** in two specific cases.

1. `conda_channels` now override the values of `channels` in the `conda_env_yml_file` rather than append it
    If the existent service has both `conda_channels` and `conda_env_yml_file` set, devs may need to merge the channel lists together.
2. If `conda_overwrite_channels=True`, conda will ignore the official default channels(including `pkgs/main`). Which means all packages could only be installed from the specified `conda_channels` above.

<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#1429 
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
