### PR TITLE
[Fix] StringInput doesn't work with batch=True

### DIFF
--- a/bentoml/adapters/string_input.py
+++ b/bentoml/adapters/string_input.py
@@ -140,4 +140,4 @@ class StringInput(BaseInputAdapter):
     def extract_user_func_args(
         self, tasks: Iterable[InferenceTask[str]]
     ) -> ApiFuncArgs:
-        return (tuple(task.data for task in tasks),)
+        return ([task.data for task in tasks],)

--- a/bentoml/adapters/string_input.py
+++ b/bentoml/adapters/string_input.py
@@ -140,4 +140,4 @@ class StringInput(BaseInputAdapter):
     def extract_user_func_args(
         self, tasks: Iterable[InferenceTask[str]]
     ) -> ApiFuncArgs:
-        return [task.data for task in tasks]
+        return (tuple(task.data for task in tasks),)

--- a/bentoml/types.py
+++ b/bentoml/types.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass, field
 import io
 import os
 from typing import (
@@ -32,7 +33,6 @@ from typing import (
 import urllib
 import uuid
 
-from dataclasses import dataclass, field
 from multidict import CIMultiDict
 from werkzeug.formparser import parse_form_data
 from werkzeug.http import parse_options_header
@@ -257,7 +257,7 @@ class HTTPRequest:
 class HTTPResponse:
     status: int = 200
     headers: HTTPHeaders = HTTPHeaders()
-    body: bytes = b""
+    body: Optional[bytes] = b""
 
     @classmethod
     def new(

--- a/tests/adapters/test_string_input.py
+++ b/tests/adapters/test_string_input.py
@@ -1,0 +1,22 @@
+# pylint: disable=redefined-outer-name
+
+from bentoml.types import HTTPRequest
+
+
+def test_string_input(make_api):
+    from bentoml.adapters import StringInput, JsonOutput
+
+    api = make_api(
+        input_adapter=StringInput(), output_adapter=JsonOutput(), user_func=lambda i: i,
+    )
+
+    body = b'{"a": 1}'
+
+    request = HTTPRequest(body=body)
+    response = api.handle_request(request)
+
+    assert response.body == body.decode()
+
+    responses = api.handle_batch_request([request] * 3)
+    for response in responses:
+        assert response.body == body.decode()

--- a/tests/adapters/test_string_input.py
+++ b/tests/adapters/test_string_input.py
@@ -1,5 +1,7 @@
 # pylint: disable=redefined-outer-name
 
+import json
+
 from bentoml.types import HTTPRequest
 
 
@@ -15,8 +17,8 @@ def test_string_input(make_api):
     request = HTTPRequest(body=body)
     response = api.handle_request(request)
 
-    assert response.body == body.decode()
+    assert json.loads(response.body) == body.decode()
 
     responses = api.handle_batch_request([request] * 3)
     for response in responses:
-        assert response.body == body.decode()
+        assert json.loads(response.body) == body.decode()


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
The StringInput is added as the parent of other practical InputAdapters. Its behavior was not fully covered by tests.

requires: #1576 
<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [x] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
