### PR TITLE
[enhancement] default to retain bento service's label when push to remote yatai

### DIFF
--- a/bentoml/cli/bento_management.py
+++ b/bentoml/cli/bento_management.py
@@ -296,12 +296,19 @@ Specify target service bundles to remove:
         required=True,
         help='Remote YataiService URL. Example: "--yatai-url http://localhost:50050"',
     )
-    def push(bento, yatai_url):
+    @click.option(
+        '--without-labels',
+        is_flag=True,
+        help="Do not retain bento service's labels when pushing to "
+        "remote yatai server",
+    )
+    def push(bento, yatai_url, without_labels):
         if ':' not in bento:
             _echo(f'BentoService {bento} invalid - specify name:version')
             return
         yc = get_yatai_client(yatai_url)
-        yc.repository.push(bento=bento)
+        with_labels = not without_labels
+        yc.repository.push(bento, with_labels)
         _echo(f'Pushed {bento} to {yatai_url}')
 
     @cli.command(help='Retrieve')

--- a/bentoml/cli/bento_management.py
+++ b/bentoml/cli/bento_management.py
@@ -297,17 +297,17 @@ Specify target service bundles to remove:
         help='Remote YataiService URL. Example: "--yatai-url http://localhost:50050"',
     )
     @click.option(
-        '--without-labels',
-        is_flag=True,
-        help="Do not retain bento service's labels when pushing to "
-        "remote yatai server",
+        '--with-labels/--without-labels',
+        default=True,
+        help="Retain bento bundle's labels or not for push Bento bundle to remote "
+        "yatai. When running with --without-labels, labels are not retained in the "
+        "remote yatai server"
     )
-    def push(bento, yatai_url, without_labels):
+    def push(bento, yatai_url, with_labels):
         if ':' not in bento:
             _echo(f'BentoService {bento} invalid - specify name:version')
             return
         yc = get_yatai_client(yatai_url)
-        with_labels = not without_labels
         yc.repository.push(bento, with_labels)
         _echo(f'Pushed {bento} to {yatai_url}')
 

--- a/bentoml/cli/bento_management.py
+++ b/bentoml/cli/bento_management.py
@@ -301,7 +301,7 @@ Specify target service bundles to remove:
         default=True,
         help="Retain bento bundle's labels or not for push Bento bundle to remote "
         "yatai. When running with --without-labels, labels are not retained in the "
-        "remote yatai server"
+        "remote yatai server",
     )
     def push(bento, yatai_url, with_labels):
         if ':' not in bento:

--- a/bentoml/yatai/client/bento_repository_api.py
+++ b/bentoml/yatai/client/bento_repository_api.py
@@ -64,13 +64,12 @@ class BentoRepositoryAPIClient:
         # YataiService stub for accessing remote YataiService RPCs
         self.yatai_service = yatai_service
 
-    def push(self, bento, labels=None):
+    def push(self, bento, with_labels=True):
         """
         Push a local BentoService to a remote yatai server.
 
         Args:
             bento: a BentoService identifier in the format of NAME:VERSION
-            labels: optional. List of labels for the BentoService.
 
         Returns:
             BentoService saved path
@@ -97,6 +96,12 @@ class BentoRepositoryAPIClient:
             bento_bundle_path = local_bento_pb.uri.gcs_presigned_url
         else:
             bento_bundle_path = local_bento_pb.uri.uri
+        labels = (
+            dict(local_bento_pb.bento_service_metadata.labels)
+            if with_labels is True and local_bento_pb.bento_service_metadata.labels
+            else None
+        )
+
         return self.upload_from_dir(bento_bundle_path, labels=labels)
 
     def pull(self, bento):
@@ -125,8 +130,16 @@ class BentoRepositoryAPIClient:
 
             from bentoml.yatai.client import get_yatai_client
 
+            labels = (
+                dict(bento_pb.bento_service_metadata.labels)
+                if bento_pb.bento_service_metadata.labels
+                else None
+            )
+
             local_yc = get_yatai_client()
-            return local_yc.repository.upload_from_dir(target_bundle_path)
+            return local_yc.repository.upload_from_dir(
+                target_bundle_path, labels=labels
+            )
 
     def upload(self, bento_service, version=None, labels=None):
         """Save and upload given bento_service to yatai_service, which manages all your

--- a/tests/yatai/client/test_bento_repository_api.py
+++ b/tests/yatai/client/test_bento_repository_api.py
@@ -263,7 +263,7 @@ def test_list(yatai_server_container, example_bento_service_class):
     svc.save(yatai_url=yatai_server_container)
 
     bentos = yc.repository.list(bento_name=svc.name)
-    assert len(bentos) == 5
+    assert len(bentos) == 7
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
fix #1589 

**Breaking Change:**

Python API
```python
yatai_client.repository.push(bento_tag, labels) -> yatai_client.repository.push(bento_tag, with_labels)
```
Remove old parameters `labels`, add new parameter `with_labels`
with labels, Boolean, default `True`:  If `True`, local bento service's labels will be preserved in the remote yatai server.

CLI:
```bash
$ bentoml push bento_bundle_name:version --yatai-url $yatai_service_endpoint  --with-labels/--without-labels
```
`--with-labels/--without-labels`: new CLI option flag. If user does not want to preserve the bento service labels in the remote yatai server use `--without-labels` flag. Default is `--with-labels`

**Follow up Changes**
Introduce new `set labels` function to the Yatai.  

*API and CLI syntax is not finalized.*

```python
yatai_client.repository.set_labels('bento_name:version', labels={'foo':bar'})
# this API will set the new labels to the bento service
```

```bash
$ bentoml labels set bento_name:version foo=bar,abc=123,
```




## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
