### PR TITLE
fix docs and readme for onnx-mlir

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Standarlize model serving and deployment workflow for teams:
 * Paddle - [Docs](https://docs.bentoml.org/en/latest/frameworks.html#paddle)
 * EvalML - [Docs](https://docs.bentoml.org/en/latest/frameworks.html#evalml)
 * EasyOCR -[Docs](https://docs.bentoml.org/en/latest/frameworks.html#easyocr)
+* ONNX-MLIR - [Docs](https://docs.bentoml.org/en/latest/frameworks.html#onnx-mlir)
 
 
 ### Deployment Options

--- a/bentoml/frameworks/onnxmlir.py
+++ b/bentoml/frameworks/onnxmlir.py
@@ -43,19 +43,20 @@ class OnnxMlirModelArtifact(BentoServiceArtifact):
     >>>     # convert the input data into the float32 input
     >>>     # convert the input data into the float32 input
     >>>     img_data = np.stack(input_data).transpose(0, 3, 1, 2)
-    >>> 
+    >>>
     >>>     #normalize
     >>>     mean_vec = np.array([0.485, 0.456, 0.406])
     >>>     stddev_vec = np.array([0.229, 0.224, 0.225])
-    >>> 
-    >>> 
+    >>>
+    >>>
     >>>     norm_img_data = np.zeros(img_data.shape).astype('float32')
-    >>> 
-    >>> 
+    >>>
+    >>>
     >>>     for i in range(img_data.shape[0]):
     >>>         for j in range(img_data.shape[1]):
-    >>>             norm_img_data[i,j,:,:] = (img_data[i,j,:,:]/255 - mean_vec[j]) / stddev_vec[j]
-    >>> 
+    >>>             norm_img_data[i,j,:,:] =
+    >>>             (img_data[i,j,:,:]/255 - mean_vec[j]) / stddev_vec[j]
+    >>>
     >>>     #add batch channel
     >>>     norm_img_data = norm_img_data.reshape(-1, 3, 224, 224).astype('float32')
     >>>     return norm_img_data

--- a/bentoml/frameworks/onnxmlir.py
+++ b/bentoml/frameworks/onnxmlir.py
@@ -23,48 +23,67 @@ class OnnxMlirModelArtifact(BentoServiceArtifact):
         MissingDependencyException: PyRuntime must be accessible in path.
 
     Example usage:
-        import bentoml
-        from bentoml import env, artifacts, api, BentoService
-        from bentoml.adapters import ImageInput
-        from bentoml.frameworks.onnxmlir import OnnxMlirModelArtifact
-        from bentoml.types import JsonSerializable, InferenceTask, InferenceError
-        from bentoml.service.artifacts.common import PickleArtifact
-        from typing import List
-        import numpy as np
-        import pandas as pd
-        import sys
 
-        @bentoml.env(infer_pip_packages=True)
-        @bentoml.artifacts([OnnxMlirModelArtifact('model'), PickleArtifact('labels')])
-        class ResNetPredict(BentoService):
-
-            def preprocess(self, input_data):
-                # convert the input data into the float32 input
-                ...
-
-            def softmax(self, x):
-                x = x.reshape(-1)
-                e_x = np.exp(x - np.max(x))
-                return e_x / e_x.sum(axis=0)
-
-            def post_process(self, raw_result):
-                return self.softmax(np.array(raw_result)).tolist()
-
-            @bentoml.api(input=ImageInput(), batch=True)
-            def predict(self, image_ndarrays: List[np.ndarray]) -> List[str]:
-                input_datas = self.preprocess(image_ndarrays)
-
-                outputs = []
-                for i in range(input_datas.shape[0]):
-                    raw_result = self.artifacts.model.run(input_datas[i:i+1])
-                    result = self.post_process(raw_result)
-                    idx = np.argmax(result)
-                    sort_idx = np.flip(np.squeeze(np.argsort(result)))
-
-                    # return top 5 labels
-                    outputs.append(self.artifacts.labels[sort_idx[:5]])
-                return outputs
-
+    >>> import bentoml
+    >>> from bentoml import env, artifacts, api, BentoService
+    >>> from bentoml.adapters import ImageInput
+    >>> from bentoml.frameworks.onnxmlir import OnnxMlirModelArtifact
+    >>> from bentoml.types import JsonSerializable, InferenceTask, InferenceError
+    >>> from bentoml.service.artifacts.common import PickleArtifact
+    >>> from typing import List
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> import sys
+    >>>
+    >>> @bentoml.env(infer_pip_packages=True)
+    >>> @bentoml.artifacts([OnnxMlirModelArtifact('model'), PickleArtifact('labels')])
+    >>> class ResNetPredict(BentoService):
+    >>>
+    >>> def preprocess(self, input_data):
+    >>>     # convert the input data into the float32 input
+    >>>     # convert the input data into the float32 input
+    >>>     img_data = np.stack(input_data).transpose(0, 3, 1, 2)
+    >>> 
+    >>>     #normalize
+    >>>     mean_vec = np.array([0.485, 0.456, 0.406])
+    >>>     stddev_vec = np.array([0.229, 0.224, 0.225])
+    >>> 
+    >>> 
+    >>>     norm_img_data = np.zeros(img_data.shape).astype('float32')
+    >>> 
+    >>> 
+    >>>     for i in range(img_data.shape[0]):
+    >>>         for j in range(img_data.shape[1]):
+    >>>             norm_img_data[i,j,:,:] = (img_data[i,j,:,:]/255 - mean_vec[j]) / stddev_vec[j]
+    >>> 
+    >>>     #add batch channel
+    >>>     norm_img_data = norm_img_data.reshape(-1, 3, 224, 224).astype('float32')
+    >>>     return norm_img_data
+    >>>
+    >>>
+    >>> def softmax(self, x):
+    >>>     x = x.reshape(-1)
+    >>>     e_x = np.exp(x - np.max(x))
+    >>>     return e_x / e_x.sum(axis=0)
+    >>>
+    >>> def post_process(self, raw_result):
+    >>>     return self.softmax(np.array(raw_result)).tolist()
+    >>>
+    >>> @bentoml.api(input=ImageInput(), batch=True)
+    >>> def predict(self, image_ndarrays: List[np.ndarray]) -> List[str]:
+    >>>     input_datas = self.preprocess(image_ndarrays)
+    >>>
+    >>>     outputs = []
+    >>>     for i in range(input_datas.shape[0]):
+    >>>         raw_result = self.artifacts.model.run(input_datas[i:i+1])
+    >>>         result = self.post_process(raw_result)
+    >>>         idx = np.argmax(result)
+    >>>         sort_idx = np.flip(np.squeeze(np.argsort(result)))
+    >>>
+    >>>         # return top 5 labels
+    >>>         outputs.append(self.artifacts.labels[sort_idx[:5]])
+    >>>         return outputs
+    >>>
     """
 
     def __init__(self, name):


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
This is a follow-up to https://github.com/bentoml/BentoML/issues/1565 
The readme and doc needs to be fixed to reflect the ONNX-MLIR support and to better format the doc example.

## Motivation and Context
Motivation is to have the doc more in-line with other frameworks supported. 

## How Has This Been Tested?
Regenerated the doc as shown in the developer markdown file. Displayed to ensure formatting looks as desired.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [x] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
