### PR TITLE
Fixing the Bug 1486 to point to proper docs.json file in Swagger Page

### DIFF
--- a/bentoml/server/api_server.py
+++ b/bentoml/server/api_server.py
@@ -223,7 +223,7 @@ class BentoAPIServer:
             )
         return Response(
             response=DEFAULT_INDEX_HTML.format(
-                url='docs.json', readme=self.bento_service.__doc__
+                url='/docs.json', readme=self.bento_service.__doc__
             ),
             status=200,
             mimetype="text/html",
@@ -238,7 +238,7 @@ class BentoAPIServer:
                 response="Swagger is disabled", status=404, mimetype="text/html"
             )
         return Response(
-            response=SWAGGER_HTML.format(url='docs.json'),
+            response=SWAGGER_HTML.format(url='/docs.json'),
             status=200,
             mimetype="text/html",
         )


### PR DESCRIPTION
## Description
This PR will solve the issue of docs.json in the Swagger Page

## Motivation and Context
This PR will solve the bug #1486 

## How Has This Been Tested?
This PR has been tested in local by running the Swagger API docs page

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
