### PR TITLE
[bug fix] Update lock table's resource_id column type

### DIFF
--- a/bentoml/yatai/db/stores/lock.py
+++ b/bentoml/yatai/db/stores/lock.py
@@ -1,7 +1,7 @@
 import datetime
 import enum
 
-from sqlalchemy import UniqueConstraint, Column, Integer, Enum, DateTime
+from sqlalchemy import UniqueConstraint, Column, Integer, Enum, DateTime, String
 from bentoml.exceptions import LockUnavailable
 from bentoml.yatai.db import Base
 
@@ -16,7 +16,7 @@ class Lock(Base):
     __tablename__ = 'locks'
     __table_args__ = tuple(UniqueConstraint('resource_id', name='_resource_id_uc',))
     id = Column(Integer, primary_key=True)
-    resource_id = Column(Integer, nullable=False, unique=True)
+    resource_id = Column(String, nullable=False, unique=True)
     lock_status = Column(Enum(LOCK_STATUS))
     locks_held = Column(Integer)
     ttl = Column(DateTime)

--- a/bentoml/yatai/migrations/versions/370a2bf2e594_update_lock_table_column.py
+++ b/bentoml/yatai/migrations/versions/370a2bf2e594_update_lock_table_column.py
@@ -1,0 +1,30 @@
+"""update lock table column
+
+Revision ID: 370a2bf2e594
+Revises: af18f0b83286
+Create Date: 2021-06-15 13:41:18.015802
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '370a2bf2e594'
+down_revision = 'af18f0b83286'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # SQLite does not support making modifications to existing columns.
+    # Alembic "batch mode" is designed to overcome this limitation.
+    # https://alembic.sqlalchemy.org/en/latest/batch.html#batch-mode-with-autogenerate
+    with op.batch_alter_table('locks') as batch_op:
+        batch_op.alter_column(
+            column_name='resource_id', type_=sa.String, existing_type=sa.INTEGER
+        )
+
+
+def downgrade():
+    pass

--- a/bentoml/yatai/migrations/versions/370a2bf2e594_update_lock_table_column.py
+++ b/bentoml/yatai/migrations/versions/370a2bf2e594_update_lock_table_column.py
@@ -27,4 +27,7 @@ def upgrade():
 
 
 def downgrade():
-    pass
+    with op.batch_alter_table('locks') as batch_op:
+        batch_op.alter_column(
+            column_name='resource_id', type_=sa.INTEGER, existing_type=sa.String
+        )


### PR DESCRIPTION
<!--- Thanks for sending a pull request! Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review. -->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
fix #1680 

Lock table's `resource_id` column was Integer type.  SQLite uses what it calls a dynamic typing system, which ultimately means that you can store text in integer fields. It wasn't reporting error. If use Postgres, BentoML will throw error when attempting to acquire lock.

This fix update the column type in the table declaration, also create a migration for existing users.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature and improvements (non-breaking change which adds/improves functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code Refactoring (internal change which is not user facing)
- [ ] Documentation
- [ ] Test, CI, or build
<!--- [ ] Others: describe the type of change if it does not fit to categories listed -->

## Component(s) if applicable
- [ ] BentoService (service definition, dependency management, API input/output adapters)
- [ ] Model Artifact (model serialization, multi-framework support)
- [ ] Model Server (mico-batching, dockerisation, logging, OpenAPI, instruments)
- [ ] YataiService gRPC server (model registry, cloud deployment automation)
- [ ] YataiService web server (nodejs HTTP server and web UI)
- [ ] Internal (BentoML's own configuration, logging, utility, exception handling)
- [ ] BentoML CLI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
