### PR TITLE
fix: Support disabling gunicorn daemon mode

### DIFF
--- a/bentoml/cli/bento_service.py
+++ b/bentoml/cli/bento_service.py
@@ -86,6 +86,9 @@ def create_bento_service_cli(
         BentoMLContainer.config.bento_server.microbatch.workers
     ],
     default_timeout: int = Provide[BentoMLContainer.config.bento_server.timeout],
+    default_daemon: bool = Provide[
+        BentoMLContainer.config.bento_server.daemon.enabled
+    ]
 ):
     # pylint: disable=unused-variable
 
@@ -308,6 +311,12 @@ def create_bento_service_cli(
         help="Run API server with Swagger UI enabled",
         envvar='BENTOML_ENABLE_SWAGGER',
     )
+    @click.option(
+        "--daemon",
+        type=click.BOOL,
+        default=default_daemon,
+        help="Daemonize the Gunicorn process",
+    )
     def serve_gunicorn(
         port,
         workers,
@@ -319,6 +328,7 @@ def create_bento_service_cli(
         microbatch_workers,
         yatai_url,
         enable_swagger,
+        daemon
     ):
         if not psutil.POSIX:
             _echo(
@@ -349,6 +359,7 @@ def create_bento_service_cli(
             mb_max_batch_size=mb_max_batch_size,
             mb_max_latency=mb_max_latency,
             microbatch_workers=microbatch_workers,
+            daemon=daemon
         )
 
     @bentoml_cli.command(

--- a/bentoml/configuration/containers.py
+++ b/bentoml/configuration/containers.py
@@ -52,6 +52,7 @@ SCHEMA = Schema(
             "port": And(int, lambda port: port > 0),
             "workers": Or(And(int, lambda workers: workers > 0), None),
             "timeout": And(int, lambda timeout: timeout > 0),
+            "daemon": {"enabled": bool},
             "max_request_size": And(int, lambda size: size > 0),
             "microbatch": {
                 Optional("enabled", default=True): bool,

--- a/bentoml/configuration/default_configuration.yml
+++ b/bentoml/configuration/default_configuration.yml
@@ -9,6 +9,8 @@ bento_server:
   workers: 1
   timeout: 60
   max_request_size: 20971520
+  daemon:
+    enabled: True
   microbatch:
     workers: 1
     max_batch_size: Null

--- a/bentoml/server/__init__.py
+++ b/bentoml/server/__init__.py
@@ -31,7 +31,7 @@ def start_dev_server(
     run_with_ngrok: Optional[bool] = None,
     enable_swagger: Optional[bool] = None,
     timeout: Optional[int] = None,
-    daemon: bool = True
+    daemon: Optional[bool] = None
 ):
     BentoMLContainer.bundle_path.set(bundle_path)
 

--- a/bentoml/server/__init__.py
+++ b/bentoml/server/__init__.py
@@ -31,6 +31,7 @@ def start_dev_server(
     run_with_ngrok: Optional[bool] = None,
     enable_swagger: Optional[bool] = None,
     timeout: Optional[int] = None,
+    daemon: bool = True
 ):
     BentoMLContainer.bundle_path.set(bundle_path)
 
@@ -57,7 +58,7 @@ def start_dev_server(
     import multiprocessing
 
     model_server_proc = multiprocessing.Process(
-        target=_start_dev_server, args=(BentoMLContainer,), daemon=True,
+        target=_start_dev_server, args=(BentoMLContainer,), daemon=daemon,
     )
     model_server_proc.start()
 
@@ -76,6 +77,7 @@ def start_prod_server(
     mb_max_batch_size: Optional[int] = None,
     mb_max_latency: Optional[int] = None,
     microbatch_workers: Optional[int] = None,
+    daemon: bool = True
 ):
     import psutil
 
@@ -101,7 +103,7 @@ def start_prod_server(
     import multiprocessing
 
     model_server_job = multiprocessing.Process(
-        target=_start_prod_server, args=(BentoMLContainer,), daemon=True
+        target=_start_prod_server, args=(BentoMLContainer,), daemon=daemon
     )
     model_server_job.start()
 


### PR DESCRIPTION
<!--- Thanks for sending a pull request!

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).

- feat: (new feature for the user, not a new feature for build script)
- fix: (bug fix for the user, not a fix to a build script)
- docs: (changes to the documentation)
- style: (formatting, missing semicolons, etc; no production code change)
- refactor: (refactoring production code, eg. renaming a variable)
- perf: (code changes that improve performance)
- test: (adding missing tests, refactoring tests; no production code change)
- chore: (updating grunt tasks etc; no production code change)
- build: (changes that affect the build system or external dependencies)
- ci: (changes to configuration files and scripts)
- revert: (reverts a previous commit)
-->

## Description
Support disabling gunicorn damon mode.
Support running children processes

## Motivation and Context
Running a children process under gunicorn serve is currently not support:
daemonic processes are not allowed to have children

## How Has This Been Tested?
All Bento tests ran without errors.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [X] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
