### PR TITLE
feat(yatai): Add delete button

### DIFF
--- a/yatai/ui/src/components/BentoBundleDeleteConfirm.tsx
+++ b/yatai/ui/src/components/BentoBundleDeleteConfirm.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import axios from "axios";
+import { Redirect } from "react-router-dom";
+import { Button, Dialog, Classes, Intent } from "@blueprintjs/core";
+import { YataiToaster } from "../utils/Toaster";
+
+export interface IBentoBundleDeleteConfirmationProps {
+  name: string;
+  value: string;
+  isOpen: boolean;
+}
+
+const BentoBundleDeleteConfirmation: React.FC<IBentoBundleDeleteConfirmationProps> =
+  (props) => {
+    const [open, setOpen] = React.useState(false);
+    const [isDelete, setDelete] = React.useState(false);
+    const bundle: string = `${props.name}:${props.value}`;
+
+    const handleDelete = async (name: string, version: string) => {
+      axios
+        .post("/api/DeleteBento", { bento_name: name, bento_version: version })
+        .then(() => {
+          const toastState = {
+            message: `${name}:${version} has been deleted.`,
+            intent: Intent.SUCCESS,
+          };
+          setDelete(true);
+          YataiToaster.show({ ...toastState });
+        })
+        .catch((error) => {
+          const toastState = {
+            message: `${name}:${version} has not been deleted.\nError encountered: ${error}`,
+            intent: Intent.DANGER,
+          };
+          YataiToaster.show({ ...toastState });
+        });
+    };
+
+    return (
+      <div>
+        {isDelete ? <Redirect to="/" /> : ""}
+        <Button
+          outlined={true}
+          large={true}
+          onClick={() => {
+            setOpen(true);
+          }}
+        >
+          Delete
+        </Button>
+
+        <Dialog
+          icon="info-sign"
+          onClose={() => {
+            setOpen(false);
+          }}
+          title="Are you sure?"
+          isOpen={open}
+        >
+          <div className={Classes.DIALOG_BODY}>
+            <p>
+              This action cannot be undone. This will permanently delete this
+              bento bundle and may have unintended consequences.
+            </p>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "center",
+                marginTop: "1.5rem",
+              }}
+            >
+              <Button
+                outlined={true}
+                large={true}
+                text={`Delete ${bundle}`}
+                onClick={() => {
+                  handleDelete(props.name, props.value);
+                }}
+              />
+            </div>
+          </div>
+        </Dialog>
+      </div>
+    );
+  };
+
+export default BentoBundleDeleteConfirmation;

--- a/yatai/ui/src/pages/BentoServiceDetail.tsx
+++ b/yatai/ui/src/pages/BentoServiceDetail.tsx
@@ -1,12 +1,20 @@
 import * as React from "react";
 import * as moment from "moment";
 
+import styled from "@emotion/styled";
 import HttpRequestContainer from "../utils/HttpRequestContainer";
 import EnvTable from "../components/BentoServiceDetail/EnvTable";
 import ApisTable from "../components/BentoServiceDetail/ApisTable";
 import ArtifactsTable from "../components/BentoServiceDetail/ArtifactsTable";
 import { Section } from "../containers/Layout";
 import LabelDetailSection from "../components/LabelDetailSection";
+import BentoBundleDeleteConfirmation from "../components/BentoBundleDeleteConfirm";
+
+const BentoDetailInformationSection = styled.div({
+  display: "flex",
+  alignItems: "flex-start",
+  justifyContent: "space-between",
+});
 
 const BentoServiceDetail = (props) => {
   const params = props.match.params;
@@ -24,19 +32,30 @@ const BentoServiceDetail = (props) => {
 
           displayBentoServiceDetail = (
             <div>
-              <p>
-                <b>Created at: </b>
-                {moment
-                  .unix(Number(bento.bento_service_metadata.created_at.seconds))
-                  .toDate()
-                  .toLocaleString()}
-              </p>
-              <p>
-                <b>Storage: </b> {bento.uri.uri}
-              </p>
-              <LabelDetailSection
-                labels={bento.bento_service_metadata.labels}
-              />
+              <BentoDetailInformationSection>
+                <div>
+                  <p>
+                    <b>Created at: </b>
+                    {moment
+                      .unix(
+                        Number(bento.bento_service_metadata.created_at.seconds)
+                      )
+                      .toDate()
+                      .toLocaleString()}
+                  </p>
+                  <p>
+                    <b>Storage: </b> {bento.uri.uri}
+                  </p>
+                  <LabelDetailSection
+                    labels={bento.bento_service_metadata.labels}
+                  />
+                </div>
+                <BentoBundleDeleteConfirmation
+                  name={params.name}
+                  value={params.version}
+                  isOpen={false}
+                ></BentoBundleDeleteConfirmation>
+              </BentoDetailInformationSection>
               <ApisTable apis={bento.bento_service_metadata.apis} />
               <ArtifactsTable
                 artifacts={bento.bento_service_metadata.artifacts}

--- a/yatai/ui/src/utils/Toaster.ts
+++ b/yatai/ui/src/utils/Toaster.ts
@@ -1,0 +1,6 @@
+import { Position, Toaster } from "@blueprintjs/core";
+
+export const YataiToaster = Toaster.create({
+  position: Position.BOTTOM,
+  maxToasts: 1,
+});

--- a/yatai/web_server/package.json
+++ b/yatai/web_server/package.json
@@ -51,7 +51,7 @@
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-import": "^2.19.1",
     "file-loader": "^6.1.0",
-    "jest": "^24.9.0",
+    "jest": "^25",
     "lint-staged": ">=10",
     "nodemon": "^2.0.2",
     "prettier": "2.0.1",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
This adds a delete button to the web UI. The button triggers a modal dialog that informs the user of their decision, then attempts to delete a Bento bundle. Upon deletion it triggers a global toast informing the user of the deletion or if an error occurred.
Here is a [link to a gif](https://imgur.com/GnDs16C) of it in action.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->
This helps build out functionality for the Yatai web UI and is in response to issue #1445 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
