### PR TITLE
fix: dataframe output adapter http header respect

### DIFF
--- a/bentoml/_internal/adapters/dataframe_output.py
+++ b/bentoml/_internal/adapters/dataframe_output.py
@@ -73,7 +73,13 @@ class DataframeOutput(JsonOutput):
                 i += task.batch
             try:
                 result = df_to_json(result, self.output_orient)
-                rv.append(InferenceResult(http_status=200, data=result))
+                rv.append(
+                    InferenceResult(
+                        data=result,
+                        http_status=200,
+                        http_headers={"Content-Type": "application/json"}
+                    )
+                )
             except Exception as e:  # pylint: disable=broad-except
                 rv.append(InferenceError(err_msg=str(e), http_status=500))
         return rv


### PR DESCRIPTION
## Description
#1780 DataframeOutput adapter http header respect
Changed `Content-Types` to `application/json`.

## Motivation and Context

`DataframeOutput` is extending `JsonOutput`, but `Content-Types` of http-header is `text/html`.
It causes confusion for users.


## How Has This Been Tested?

**Test Code**

```python
@bentoml.api(input=DataframeInput(orient="records", columns=[], dtype={}),
             output=DataframeOutput(),
             batch=True)
```
**\<As-is\>**
<img width="467" alt="스크린샷 2021-07-26 오후 8 52 46" src="https://user-images.githubusercontent.com/10463931/127099980-3b23f22f-b685-4137-bf13-d21495514f9d.png">

**\<To-be\>**
<img width="464" alt="스크린샷 2021-07-26 오후 9 51 33" src="https://user-images.githubusercontent.com/10463931/127099988-f1e73a75-5865-46ef-8c14-4394f8079074.png">


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
