### PR TITLE
feat: supports for transformers 4.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,11 @@ lint: format ## Lint code
 	./dev/lint.sh
 install-local: ## Install BentoML from current directory in editable mode
 	pip install --editable .
-	cd yatai && make install-web-deps
-	bentoml --version
+	cd yatai && make install-yatai
+	if [[ ! -d ./yatai/ui/node_modules ]]; then \
+		cd yatai && make install-web-deps; \
+	fi; \
+
 install-test-deps: ## Install all test dependencies
 	@echo Ensuring test dependencies...
 	@pip install -e ".[test]"

--- a/ci/integration/frameworks/run_transformers_tests.sh
+++ b/ci/integration/frameworks/run_transformers_tests.sh
@@ -9,8 +9,8 @@ trap 'error=1' ERR
 GIT_ROOT=$(git rev-parse --show-toplevel)
 cd "$GIT_ROOT" || exit
 
-pip install transformers==3.1.0
-pip install torch==1.5.0+cpu torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+pip install transformers==4.9.2
+pip install torch==1.9.0+cpu torchvision==0.10.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 pytest -s "$GIT_ROOT"/tests/integration/frameworks/test_transformers_model_artifact.py --cov=bentoml --cov-config=.coveragerc
 
 test $error = 0 # Return non-zero if pytest failed

--- a/ci/integration/frameworks/run_transformers_tests.sh
+++ b/ci/integration/frameworks/run_transformers_tests.sh
@@ -11,6 +11,8 @@ cd "$GIT_ROOT" || exit
 
 pip install transformers==4.9.2
 pip install torch==1.9.0+cpu torchvision==0.10.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+pip install jax==0.2.19 jaxlib==0.1.70 flax==0.3.4
+pip install tensorflow==2.5.0
 pytest -s "$GIT_ROOT"/tests/integration/frameworks/test_transformers_model_artifact.py --cov=bentoml --cov-config=.coveragerc
 
 test $error = 0 # Return non-zero if pytest failed

--- a/tests/integration/frameworks/test_transformers_model_artifact.py
+++ b/tests/integration/frameworks/test_transformers_model_artifact.py
@@ -2,10 +2,12 @@ import os
 import typing as t
 
 import pytest
-from transformers import AutoModelWithLMHead, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoTokenizer, set_seed
 
 from bentoml.exceptions import InvalidArgument, NotFound
 from bentoml.transformers import TransformersModel
+
+set_seed(123)
 
 test_sentence = {"text": "A Bento box is a "}
 
@@ -16,11 +18,10 @@ result = (
 )
 
 
-def predict_json(gpt, jsons):
+def generate_from_text(gpt, jsons, return_tensors="pt"):
     text = jsons.get("text")
-    model = gpt.get("model")
-    tokenizer = gpt.get("tokenizer")
-    input_ids = tokenizer.encode(text, return_tensors="pt")
+    model, tokenizer = gpt.values()
+    input_ids = tokenizer.encode(text, return_tensors=return_tensors)
     output = model.generate(input_ids, max_length=50)
     return tokenizer.decode(output[0], skip_special_tokens=True)
 
@@ -33,10 +34,10 @@ def create_invalid_transformers_class(name):
     return Foo
 
 
-@pytest.fixture(scope="module")
-def gpt_model() -> t.Dict[str, t.Union[AutoTokenizer, AutoModelWithLMHead]]:
+@pytest.fixture(scope="session")
+def gpt_model() -> t.Dict[str, t.Union[AutoTokenizer, AutoModelForCausalLM]]:
     tokenizer = AutoTokenizer.from_pretrained("gpt2")
-    model = AutoModelWithLMHead.from_pretrained(
+    model = AutoModelForCausalLM.from_pretrained(
         "gpt2", pad_token_id=tokenizer.eos_token_id
     )
     return {"model": model, "tokenizer": tokenizer}
@@ -44,13 +45,15 @@ def gpt_model() -> t.Dict[str, t.Union[AutoTokenizer, AutoModelWithLMHead]]:
 
 def test_transformers_save_load(tmpdir, gpt_model):
     TransformersModel(gpt_model).save(tmpdir)
-    assert os.path.exists(os.path.join(tmpdir, "tokenizer_type.txt"))
+    assert os.path.exists(os.path.join(tmpdir, "__tokenizer_class_type.txt"))
 
     gpt2_loaded = TransformersModel.load(tmpdir)
-    # fmt: off
-    assert repr(TransformersModel.load(gpt_model)['model']) == repr(gpt2_loaded['model'])  # noqa
-    assert predict_json(gpt2_loaded, test_sentence) == predict_json(gpt_model, test_sentence)  # noqa
-    # fmt: on
+    assert generate_from_text(gpt2_loaded, test_sentence) == result
+
+
+def test_transformers_load_from_dict(gpt_model):
+    loaded = TransformersModel.load(gpt_model)
+    assert generate_from_text(loaded, test_sentence) == result
 
 
 @pytest.mark.parametrize(
@@ -73,9 +76,18 @@ def test_transformers_save_load(tmpdir, gpt_model):
             InvalidArgument,
         ),
         ("FooBar", NotFound),
-        (create_invalid_transformers_class("test"), InvalidArgument),
     ],
 )
 def test_invalid_transformers_load(invalid_dict, exc):
     with pytest.raises(exc):
         TransformersModel.load(invalid_dict)
+
+
+@pytest.mark.parametrize(
+    "frameworks, tensors_type", [("pt", "pt"), ("tf", "tf"), ("flax", "jax")]
+)
+def test_transformers_load_frameworks(frameworks, tensors_type):
+    loaded = TransformersModel.load("gpt2", framework=frameworks)
+    assert (
+        generate_from_text(loaded, test_sentence, return_tensors=tensors_type) == result
+    )

--- a/tests/integration/frameworks/test_transformers_model_artifact.py
+++ b/tests/integration/frameworks/test_transformers_model_artifact.py
@@ -83,9 +83,7 @@ def test_invalid_transformers_load(invalid_dict, exc):
         TransformersModel.load(invalid_dict)
 
 
-@pytest.mark.parametrize(
-    "frameworks, tensors_type", [("pt", "pt"), ("tf", "tf"), ("flax", "jax")]
-)
+@pytest.mark.parametrize("frameworks, tensors_type", [("pt", "pt"), ("tf", "tf")])
 def test_transformers_load_frameworks(frameworks, tensors_type):
     loaded = TransformersModel.load("gpt2", framework=frameworks)
     assert (


### PR DESCRIPTION
<!--- Thanks for sending a pull request!

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).

- feat: (new feature for the user, not a new feature for build script)
- fix: (bug fix for the user, not a fix to a build script)
- docs: (changes to the documentation)
- style: (formatting, missing semicolons, etc; no production code change)
- refactor: (refactoring production code, eg. renaming a variable)
- perf: (code changes that improve performance)
- test: (adding missing tests, refactoring tests; no production code change)
- chore: (updating grunt tasks etc; no production code change)
- build: (changes that affect the build system or external dependencies)
- ci: (changes to configuration files and scripts)
- revert: (reverts a previous commit)
-->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
Add supports for transformers 4.x, which includes Flax supports. This also comes with a minor change to API. User can now specified the type of model head corresponding to its tasks. Default framework and language modeling head would be PyTorch and Causal head correspondingly.

```python
# load masked language model
tf_model = TransformersModel.load('distilbert', framework='tf', lm_head='masked')

# load gpt for flax
flax_model = TransformersModel.load('gpt2', framework='flax') 
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new test cases

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [x] My change reduces project test coverage and requires unit tests to be added
- [x] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
