### PR TITLE
upgrade: urllib3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     "aiohttp",
     "aiohttp_cors==0.7.0",
     "alembic",
-    "urllib3<=1.25.11",
+    "urllib3<=1.26.6",
     "boto3",
     "cerberus",
     "certifi",


### PR DESCRIPTION
## Description
With urllib3's version < 1.26.5, the impact could be:

When provided with a URL containing many @ characters in the authority component the authority regular expression exhibits catastrophic backtracking causing a denial of service if a URL were passed as a parameter or redirected to via an HTTP redirect.

Reference: 
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33503
https://jvn.jp/en/vu/JVNVU92413403/

The patched version of this issue is 1.26.5.

## How Has This Been Tested?
Passed `./ci/unit_tests.sh `

## Checklist:
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed