### PR TITLE
Fix Utils Init Imports

### DIFF
--- a/bentoml/_internal/utils/__init__.py
+++ b/bentoml/_internal/utils/__init__.py
@@ -18,9 +18,7 @@ from typing import (
 from urllib.parse import uses_netloc, uses_params, uses_relative
 
 from ..types import PathType
-from .gcs import is_gcs_url
 from .lazy_loader import LazyLoader
-from .s3 import is_s3_url
 
 _T = TypeVar("_T")
 _V = TypeVar("_V")


### PR DESCRIPTION
<!--- Thanks for sending a pull request!

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).

- feat: (new feature for the user, not a new feature for build script)
- fix: (bug fix for the user, not a fix to a build script)
- docs: (changes to the documentation)
- style: (formatting, missing semicolons, etc; no production code change)
- refactor: (refactoring production code, eg. renaming a variable)
- perf: (code changes that improve performance)
- test: (adding missing tests, refactoring tests; no production code change)
- chore: (updating grunt tasks etc; no production code change)
- build: (changes that affect the build system or external dependencies)
- ci: (changes to configuration files and scripts)
- revert: (reverts a previous commit)
-->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

Since the implementations of Google Cloud Storage and AWS S3 Bucket have been moved, the utility functions don't need those imports and can cause `ModuleNotFoundError: No module named 'bentoml._internal.utils.gcs'`.

So I deleted those imports for the XGBoost example to work. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

In my previous request, I forgot to test the solution in my local fork, and therefore it wasn't a part of the PR #1868 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested having run `make install-local` and `pip install xgboost`

I then ran the given example in `xgboost.py`: 
```python
import xgboost as xgb
import bentoml.xgboost

# read in data
dtrain = xgb.DMatrix('agaricus.txt.train')
dtest = xgb.DMatrix('agaricus.txt.test')
# specify parameters via map
param = dict(max_depth=2, eta=1, objective='binary:logistic')
num_round = 2
bst = xgb.train(param, dtrain, num_round)

preds = bst.predict(dtest)
print(preds)

tag = bentoml.xgboost.save("my_xgboost_model", bst, booster_params=param)
# example tag: my_xgboost_model:20210929_153BC4
print("TAG", tag)

# load the booster back:
bst = bentoml.xgboost.load("my_xgboost_model:latest") # or
# bst = bentoml.xgboost.load(tag)
print("BST", bst)
```

and got the result:
```bash
[17:58:10] WARNING: ../src/learner.cc:1095: Starting in XGBoost 1.3.0, the default evaluation metric used with the objective 'binary:logistic' was changed from 'error' to 'logloss'. Explicitly set eval_metric if you'd like to restore the old behavior.
[0.28583017 0.9239239  0.28583017 ... 0.9239239  0.05169873 0.9239239 ]
TAG my_xgboost_model:20211006_83E73D
BST <xgboost.core.Booster object at 0x7ff42bb70d90>
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
