### PR TITLE
refactor: statsmodels framework impl

### DIFF
--- a/bentoml/sklearn.py
+++ b/bentoml/sklearn.py
@@ -1,6 +1,7 @@
 import os
 import typing as t
 
+import sklearn
 import numpy as np
 from simple_di import Provide, WrappedCallable
 from simple_di import inject as _inject

--- a/bentoml/statsmodels.py
+++ b/bentoml/statsmodels.py
@@ -145,7 +145,6 @@ class _StatsModelsRunner(Runner):
 
     # pylint: disable=arguments-differ,attribute-defined-outside-init
     def _setup(self) -> None:
-        gpu_device_id = self.resource_quota.gpus[self.replica_id]
 
         self._model = sm.load(fname=model_file)
 


### PR DESCRIPTION
## Description
Bentoml's statsmodels framework implementation uses `statsmodel`'s methods to save and restore(load) prediction models as a`Pickle` file instance.

Code was refactored to suit the new implementation structure (**check**: Minor updates to `sklearn` framework). The _StatsModelsRunner class inherits from _Runner -> _BaseRunner -> _RunnerImplMixin class. For parallelism support, I have utilized the `parallel_func` method from `statsmodels.tools.parallel`, which is a parallel utility function using `joblib`.

## Motivation and Context
This PR refactors current `statsmodels` for the **BentoML version 1.0** release, and will resemble the implementation of other Machine Learning frameworks that were supported in BentoML version 0.13.1. 

## How Has This Been Tested?
Run tests/integration/frameworks/test_statsmodels_impl.py.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [x] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
