### PR TITLE
improv(xgboost): `save_config` to modelstore

### DIFF
--- a/bentoml/xgboost.py
+++ b/bentoml/xgboost.py
@@ -1,5 +1,6 @@
 import os
 import typing as t
+import json
 
 import numpy as np
 from simple_di import Provide, inject
@@ -60,7 +61,11 @@ def _get_model_info(
             f" failed loading with {__name__}."
         )
     model_file = os.path.join(model_info.path, f"{SAVE_NAMESPACE}{JSON_EXT}")
-    _booster_params = dict() if not booster_params else booster_params
+    if not booster_params:
+        with open(os.path.join(model_info.path, f"config{JSON_EXT}"), 'r') as f:
+            _booster_params = json.load(f)
+    else:
+        _booster_params = booster_params
     for key, value in model_info.options.items():
         if key not in _booster_params:
             _booster_params[key] = value  # pragma: no cover
@@ -159,6 +164,8 @@ def save(
         framework_context=context,
         metadata=metadata,
     ) as ctx:  # type: StoreCtx
+        with open(os.path.join(ctx.path, f"config{JSON_EXT}"), 'w') as f:
+            json.dump(json.loads(model.save_config()), f, indent=4)
         model.save_model(os.path.join(ctx.path, f"{SAVE_NAMESPACE}{JSON_EXT}"))
         return ctx.tag
 

--- a/bentoml/xgboost.py
+++ b/bentoml/xgboost.py
@@ -62,7 +62,7 @@ def _get_model_info(
         )
     model_file = os.path.join(model_info.path, f"{SAVE_NAMESPACE}{JSON_EXT}")
     if not booster_params:
-        with open(os.path.join(model_info.path, f"config{JSON_EXT}"), 'r') as f:
+        with open(os.path.join(model_info.path, f"booster_params{JSON_EXT}"), 'r') as f:
             _booster_params = json.load(f)
     else:
         _booster_params = booster_params
@@ -164,8 +164,8 @@ def save(
         framework_context=context,
         metadata=metadata,
     ) as ctx:  # type: StoreCtx
-        with open(os.path.join(ctx.path, f"config{JSON_EXT}"), 'w') as f:
-            json.dump(json.loads(model.save_config()), f, indent=4)
+        config_file_name = os.path.join(ctx.path, f"booster_params{JSON_EXT}")
+        open(config_file_name, 'a').write(model.save_config())
         model.save_model(os.path.join(ctx.path, f"{SAVE_NAMESPACE}{JSON_EXT}"))
         return ctx.tag
 


### PR DESCRIPTION
<!--- Thanks for sending a pull request!

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).

- feat: (new feature for the user, not a new feature for build script)
- fix: (bug fix for the user, not a fix to a build script)
- docs: (changes to the documentation)
- style: (formatting, missing semicolons, etc; no production code change)
- refactor: (refactoring production code, eg. renaming a variable)
- perf: (code changes that improve performance)
- test: (adding missing tests, refactoring tests; no production code change)
- chore: (updating grunt tasks etc; no production code change)
- build: (changes that affect the build system or external dependencies)
- ci: (changes to configuration files and scripts)
- revert: (reverts a previous commit)
-->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

Saving and loading back config to initialize the XGBoost model. We use the `save_config()` function to save booster parameters in a neat way.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
