### PR TITLE
feat(internal): change the format of generated versions

### DIFF
--- a/bentoml/_internal/bento/bento.py
+++ b/bentoml/_internal/bento/bento.py
@@ -53,14 +53,16 @@ class Bento(StoreItem):
         build_ctx: PathType,
         models: t.List[str],
         version: t.Optional[str],
-        description: t.Optional[str],
+        description: str,
         include: t.List[str],
         exclude: t.List[str],
-        env: t.Optional[t.Dict[str, t.Any]],
-        labels: t.Optional[t.Dict[str, str]],
+        env: t.Dict[str, t.Any],
+        labels: t.Dict[str, str],
         model_store: "ModelStore" = Provide[BentoMLContainer.model_store],
     ) -> "Bento":
         tag = Tag(svc.name, version)
+        if version is None:
+            tag = tag.make_new_version()
 
         logger.debug(f"Building BentoML service {tag} from build context {build_ctx}")
 

--- a/bentoml/_internal/models/store.py
+++ b/bentoml/_internal/models/store.py
@@ -18,8 +18,8 @@ from bentoml import __version__ as BENTOML_VERSION
 
 from ...exceptions import BentoMLException, InvalidArgument
 from ..configuration.containers import BentoMLContainer
-from ..types import PathType
-from ..utils import generate_new_version_id, validate_or_create_dir
+from ..types import PathType, Tag
+from ..utils import validate_or_create_dir
 from . import MODEL_YAML_NAMESPACE, YAML_EXT
 
 logger = logging.getLogger(__name__)
@@ -44,12 +44,6 @@ def validate_name(name: str) -> None:
             "may only contain letters, numbers, underscores "
             "and not starting with a number."
         )
-
-
-def _generate_model_tag(name: str) -> str:
-    validate_name(name)
-    version = generate_new_version_id()
-    return f"{name}:{version}"
 
 
 def _process_model_tag(tag: str) -> t.Tuple[str, str]:
@@ -200,7 +194,7 @@ class ModelStore:
         """
         _exc = None
 
-        tag = _generate_model_tag(name)
+        tag = str(Tag(name).make_new_version())
         _, version = tag.split(":")
         model_path = self._create_path(tag)
         model_yaml = Path(model_path, f"{MODEL_YAML_NAMESPACE}{YAML_EXT}")

--- a/bentoml/_internal/utils/__init__.py
+++ b/bentoml/_internal/utils/__init__.py
@@ -3,7 +3,6 @@ import functools
 import socket
 import typing as t
 import uuid
-from datetime import datetime
 from pathlib import Path
 
 from ..types import PathType
@@ -18,7 +17,6 @@ __all__ = [
     "cached_contextmanager",
     "reserve_free_port",
     "get_free_port",
-    "generate_new_version_id",
     "catch_exceptions",
     "LazyLoader",
     "validate_or_create_dir",
@@ -27,18 +25,6 @@ __all__ = [
 
 def randomize_runner_name(module_name: str):
     return f"{module_name.split('.')[-1]}_{uuid.uuid4().hex[:6].lower()}"
-
-
-def generate_new_version_id():
-    """
-    The default function for generating a new unique version string when saving a new
-    bento or a new model
-    """
-    date_string = datetime.now().strftime("%Y%m%d")
-    random_hash = uuid.uuid4().hex[:6].upper()
-
-    # Example output: '20210910_D246ED'
-    return f"{date_string}_{random_hash}"
 
 
 def validate_or_create_dir(*path: PathType) -> None:

--- a/bentoml/_internal/utils/validation.py
+++ b/bentoml/_internal/utils/validation.py
@@ -26,4 +26,4 @@ def validate_tag_str(value: str):
         errors.append(tag_invalid_error_msg)
 
     if errors:
-        raise InvalidArgument(", and ".join(errors))
+        raise InvalidArgument(f"{value} is not a valid tag: " + ", and ".join(errors))

--- a/bentoml/bentos.py
+++ b/bentoml/bentos.py
@@ -11,7 +11,6 @@ from ._internal.bento import Bento, BentoStore
 from ._internal.configuration.containers import BentoMLContainer
 from ._internal.service import load
 from ._internal.types import Tag
-from ._internal.utils import generate_new_version_id
 
 if t.TYPE_CHECKING:
     from ._internal.models.store import ModelStore
@@ -188,7 +187,6 @@ def build(
     build_ctx = os.getcwd() if build_ctx is None else os.path.realpath(build_ctx)
     svc = load(svc_import_str, working_dir=build_ctx)
 
-    version = generate_new_version_id() if version is None else version
     description = svc.__doc__ if description is None else description
     models = [] if models is None else models
     include = ["*"] if include is None else include


### PR DESCRIPTION
This is somewhat a proposal, but I've changed the version format to `YYYYMMDD.<stamp>`, where `<stamp>` is a custom base64 encode of the unix timestamp in seconds.

This way, versions are lexically sortable if we ever decide that they should be. This is currently only important because the store implementations are sorting by tag when listing, which may not be the "correct" order for the user.

There's definitely an argument to be made that the store implementation should also sort by item timestamp too.