### PR TITLE
chore(internal): minor bento store fixes

### DIFF
--- a/bentoml/_internal/bento/bento.py
+++ b/bentoml/_internal/bento/bento.py
@@ -155,6 +155,9 @@ class Bento(StoreItem):
             self.fs, fs.open_fs(path, create=True, writeable=True), copy_if_newer=False
         )
 
+    def push(self):
+        pass
+
     def validate(self):
         return self.fs.isfile("bento.yaml")
 

--- a/bentoml/_internal/bento/bento.py
+++ b/bentoml/_internal/bento/bento.py
@@ -9,6 +9,7 @@ import pathspec
 import yaml
 from fs.base import FS
 from fs.copy import copy_dir, copy_file
+from fs.mirror import mirror
 from simple_di import Provide, inject
 
 from ...exceptions import BentoMLException, InvalidArgument
@@ -148,6 +149,11 @@ class Bento(StoreItem):
             os.rmdir(bento_path)
             os.rename(self.fs.getsyspath("/"), bento_path)
             self.fs.close()
+
+    def export(self, path: str):
+        mirror(
+            self.fs, fs.open_fs(path, create=True, writeable=True), copy_if_newer=False
+        )
 
     def validate(self):
         return self.fs.isfile("bento.yaml")

--- a/bentoml/bentos.py
+++ b/bentoml/bentos.py
@@ -82,7 +82,6 @@ import os
 import typing as t
 
 import fs
-from fs.mirror import mirror
 from simple_di import Provide, inject
 
 from ._internal.bento import Bento, BentoStore
@@ -124,9 +123,9 @@ def import_bento(path: str) -> Bento:
     return Bento.from_fs(fs.open_fs(path))
 
 
-def export_bento(bento: Bento, path: str):
-    mirror(bento.fs, fs.open_fs(path), copy_if_newer=False)
-    pass
+def export_bento(tag: t.Union[Tag, str], path: str):
+    bento = get(tag)
+    bento.export(path)
 
 
 @inject

--- a/bentoml/bentos.py
+++ b/bentoml/bentos.py
@@ -128,6 +128,15 @@ def export_bento(tag: t.Union[Tag, str], path: str):
     bento.export(path)
 
 
+def push(tag: t.Union[Tag, str]):
+    bento = get(tag)
+    bento.push()
+
+
+def pull(tag: t.Union[Tag, str]):
+    pass
+
+
 @inject
 def build(
     svc: t.Union["Service", str],
@@ -305,6 +314,8 @@ __all__ = [
     "delete",
     "import_bento",
     "export_bento",
+    "push",
+    "pull",
     "build",
     "load",
 ]


### PR DESCRIPTION
I added `export` and `push` as methods of the `Bento` class, and added `push` and `pull` placeholders so @yetone can start work on that if necessary.