### PR TITLE
tests: add pyright ci check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '17'
       - name: Install test dependencies
         run: ./ci/install_dependencies.sh.cmd
       - name: Run linting script

--- a/ci/format_and_lint.sh
+++ b/ci/format_and_lint.sh
@@ -7,17 +7,24 @@ cd "$GIT_ROOT" || exit
 has_errors=0
 
 # Code auto formatting check with black & isort
-./dev/format.sh
-GIT_STATUS="$(git status --porcelain)"
-if [ "$GIT_STATUS" ];
-then
-  echo "Source code changes are not formatted (./dev/format.sh script)"
-  echo "Files changed:"
-  echo "--------------------------------------------------------------"
-  echo "$GIT_STATUS"
+echo "Running black on bentoml module..."
+if ! (black --check --config "$GIT_ROOT/pyproject.toml" bentoml); then
   has_errors=1
-else
-  echo "Code auto formatting passed"
+fi
+
+echo "Running black on tests and docker modules..."
+if ! (black --check --config "$GIT_ROOT/pyproject.toml" tests docker); then
+  has_errors=1
+fi
+
+echo "Running isort on bentoml module..."
+if ! (isort --check bentoml); then
+  has_errors=1
+fi
+
+echo "Running isort on tests and docker modules..."
+if ! (isort --check tests docker); then
+  has_errors=1
 fi
 
 # The first line of the tests are always empty if there are no linting errors

--- a/ci/format_and_lint.sh
+++ b/ci/format_and_lint.sh
@@ -70,5 +70,13 @@ fi
 #   # has_errors=1
 # fi
 
+if [[ -n $GITHUB_BASE_REF ]]; then
+  echo "Running pyright on changed files..."
+  git fetch origin "$GITHUB_BASE_REF"
+  if ! (git diff --name-only --diff-filter=d "origin/$GITHUB_BASE_REF" -z -- '*.py' | xargs -0 --no-run-if-empty pyright); then
+    has_errors=1
+  fi
+fi
+
 echo "Done"
 exit $has_errors

--- a/ci/install_dependencies.sh.cmd
+++ b/ci/install_dependencies.sh.cmd
@@ -5,9 +5,11 @@ fi
 set -x
 python -m pip install --upgrade pip
 python -m pip install --upgrade --editable ".[test]"
+npm install -g pyright
 exit
 
 :: cmd script
 :WINDOWS
 python -m pip install --upgrade pip
 python -m pip install --upgrade --editable ".[test]"
+npm install -g pyright


### PR DESCRIPTION
Using pyright because `mypy` is unbearably slow and doesn't seem to limit itself to the files passed on the CLI.