### PR TITLE
fix(internal): use importlib for version

### DIFF
--- a/bentoml/__init__.py
+++ b/bentoml/__init__.py
@@ -1,7 +1,9 @@
-from ._version import get_versions
-
-__version__ = get_versions()["version"]
-del get_versions
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:
+    import importlib_metadata
+__version__: str = importlib_metadata.version(__name__)
+del importlib_metadata
 
 from ._internal.configuration import load_global_config  # noqa: E402
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ fs = "*"
 circus = "*"
 uvicorn = "*"
 python-json-logger = "*"
+importlib-metadata = {version = "*", python = "<3.8"}
 opentracing = {version = "*", optional = true}
 py-zipkin = {version = "*", optional = true}
 jaeger-client = {version = "*", optional = true}


### PR DESCRIPTION
I think this is somewhat nicer.

At the moment this will still give the versioneer version inherited from the `setup.py`. If we move away from versioneer / `setup.py` it will give whatever we specify in the `pyproject.toml`, but we can use a poetry plugin to give us VCS versions if we want that.