### PR TITLE
chore: revert attrs dependency changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,17 +68,10 @@ sphinxcontrib-fulltoc = {version = "*", optional = true}
 sphinxcontrib-spelling = {version = "*", optional = true}
 sphinx-copybutton = {version = "*", optional = true}
 pyenchant = {version = "*", optional = true}
-types-click = {version = "*", optional = true}
-types-chardet = {version = "*", optional = true}
-types-setuptools = {version = "*", optional = true}
-types-PyYAML = {version = "*", optional = true}
-pyspark-stubs = {version = "*", optional = true}
-types-filelock = {version = "*", optional = true}
 
 [tool.poetry.extras]
 model-server = ["prometheus-client", "jaeger-client", "py-zipkin", "opentracing"]
 docs = ["recommonmark", "sphinx", "sphinx-click", "sphinx_rtd_theme", "sphinxcontrib-fulltoc", "sphinxcontrib-spelling", "sphinx_copybutton", "pyenchant"]
-types = ["types-click", "types-chardet", "types-setuptools", "pyspark-stubs", "types-filelock", "types-PyYAML"]
 
 [tool.poetry.dev-dependencies]
 attrs = ">=21.1"
@@ -102,6 +95,12 @@ autoflake = "*"
 twine = "*"
 wheel = "*"
 pydantic = "*"
+types-click = "*"
+types-chardet = "*"
+types-setuptools = "*"
+types-PyYAML = "*"
+pyspark-stubs = "*"
+types-filelock = "*"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "setuptools", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ python-multipart = "*"
 rich = "*"
 pyyaml = "*"
 cattrs = "*"
-attrs = ">=21"
+attrs = ">=20"
 pathspec = "*"
 typing-extensions = "^3.7.4"
 aiofiles = "*"
@@ -81,6 +81,7 @@ docs = ["recommonmark", "sphinx", "sphinx-click", "sphinx_rtd_theme", "sphinxcon
 types = ["types-click", "types-chardet", "types-setuptools", "pyspark-stubs", "types-filelock", "types-PyYAML"]
 
 [tool.poetry.dev-dependencies]
+attrs = ">=21.1"
 black = "21.4b2"
 codecov = "*"
 coverage = "^4.4"


### PR DESCRIPTION
We only need attrs 21.1 for type checking.