### PR TITLE
fix: bento metadata

### DIFF
--- a/bentoml/_internal/bento/bento.py
+++ b/bentoml/_internal/bento/bento.py
@@ -245,7 +245,7 @@ class BentoStore(Store[SysPathBento]):
 @attr.define(repr=False, frozen=True)
 class BentoInfo:
     tag: Tag
-    service: str = attr.field(converter=lambda svc: svc._import_str)  # type: ignore[reportPrivateUsage]
+    service: str  # type: ignore[reportPrivateUsage]
     labels: t.Dict[str, t.Any]  # TODO: validate user-provide labels
     models: t.List[str]  # TODO: populate with model & framework info
     bentoml_version: str = BENTOML_VERSION
@@ -270,7 +270,7 @@ class BentoInfo:
         del yaml_content["version"]
         try:
             yaml_content["creation_time"] = datetime.fromisoformat(
-                yaml_content["creation_time"]
+                str(yaml_content["creation_time"])
             )
         except ValueError:
             raise BentoMLException(


### PR DESCRIPTION
<!--- Thanks for sending a pull request!

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).

- feat: (new feature for the user, not a new feature for build script)
- fix: (bug fix for the user, not a fix to a build script)
- docs: (changes to the documentation)
- style: (formatting, missing semicolons, etc; no production code change)
- refactor: (refactoring production code, eg. renaming a variable)
- perf: (code changes that improve performance)
- test: (adding missing tests, refactoring tests; no production code change)
- chore: (updating grunt tasks etc; no production code change)
- build: (changes that affect the build system or external dependencies)
- ci: (changes to configuration files and scripts)
- revert: (reverts a previous commit)
-->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

When running
```python
>>> import bentoml
>>> bentoml.get("iris_classifier:latest")
```
I would get two errors: 
```bash
Traceback (most recent call last):
....
  File "/home/damir/Git/BentoML/bentoml/_internal/bento/bento.py", line 170, in info
    return BentoInfo.from_yaml_file(bento_yaml)
  File "/home/damir/Git/BentoML/bentoml/_internal/bento/bento.py", line 273, in from_yaml_file
    yaml_content["creation_time"]
TypeError: fromisoformat: argument must be str
```
and then having fixed that, it would throw
```bash
Traceback (most recent call last):
...
  File "/home/damir/Git/BentoML/bentoml/_internal/bento/bento.py", line 281, in from_yaml_file
    bento_info = cls(**yaml_content)
  File "<attrs generated init bentoml._internal.bento.bento.BentoInfo>", line 4, in __init__
  File "/home/damir/Git/BentoML/bentoml/_internal/bento/bento.py", line 248, in <lambda>
    service: str = attr.field(converter=lambda svc: svc._import_str)  # type: ignore[reportPrivateUsage]
AttributeError: 'str' object has no attribute '_import_str'
```
So I made some small changes to make it work, but let me know if you think it should be dealt with differently.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
