### PR TITLE
chore(internal): use license_files instead of license_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ url = https://github.com/bentoml/BentoML
 author = BentoML Team
 author_email = contact@bentoml.ai
 license = Apache-2.0
-license_file = LICENSE
+license_files = LICENSE
 keywords = MLOps, AI, Bento
 classifiers =
     License :: OSI Approved :: Apache Software License


### PR DESCRIPTION
pytest was constantly complaining to me about this