### PR TITLE
fix(internal): set name of SysPath* to *

### DIFF
--- a/bentoml/_internal/bento/bento.py
+++ b/bentoml/_internal/bento/bento.py
@@ -328,6 +328,9 @@ class SysPathBento(Bento):
         return self
 
 
+SysPathBento.__name__ = "Bento"
+
+
 class BentoStore(Store[SysPathBento]):
     def __init__(self, base_path: t.Union[PathType, "FS"]):
         super().__init__(base_path, SysPathBento)

--- a/bentoml/_internal/models/model.py
+++ b/bentoml/_internal/models/model.py
@@ -158,6 +158,9 @@ class SysPathModel(Model):
         return self._fs.getsyspath(item)
 
 
+SysPathModel.__name__ = "Model"
+
+
 class ModelStore(Store[SysPathModel]):
     def __init__(self, base_path: t.Union[PathType, FS]):
         super().__init__(base_path, SysPathModel)


### PR DESCRIPTION
This is a somewhat hacky way to do this, but I think that it's ever-so-slightly nice since these classes are more like versions of `Model` than anything else; ideally `Model` would just have an associated type for its resulting output but that was very hard to handle so this is how it's done now.