### PR TITLE
feat(codebase): add LazyType.isinstance with TypeGuard(PEP647) support

### DIFF
--- a/bentoml/_internal/frameworks/pytorch.py
+++ b/bentoml/_internal/frameworks/pytorch.py
@@ -12,7 +12,7 @@ from simple_di import Provide
 from bentoml import Tag
 from bentoml import Runner
 
-from ..types import TypeRef
+from ..types import LazyType
 from ..models import Model
 from ..models import PT_EXT
 from ..models import SAVE_NAMESPACE
@@ -374,7 +374,7 @@ class PytorchTensorContainer(DataContainer[torch.Tensor, torch.Tensor]):
 
 
 DataContainerRegistry.register_container(
-    TypeRef("torch", "Tensor"),
-    TypeRef("torch", "Tensor"),
+    LazyType("torch", "Tensor"),
+    LazyType("torch", "Tensor"),
     PytorchTensorContainer,
 )

--- a/bentoml/_internal/frameworks/pytorch.py
+++ b/bentoml/_internal/frameworks/pytorch.py
@@ -12,6 +12,7 @@ from simple_di import Provide
 from bentoml import Tag
 from bentoml import Runner
 
+from ..types import TypeRef
 from ..models import Model
 from ..models import PT_EXT
 from ..models import SAVE_NAMESPACE
@@ -19,7 +20,6 @@ from ..utils.pkg import get_pkg_version
 from ...exceptions import BentoMLException
 from ...exceptions import MissingDependencyException
 from ..runner.utils import Params
-from ..runner.utils import TypeRef
 from ..runner.container import Payload
 from ..runner.container import DataContainer
 from ..runner.container import DataContainerRegistry

--- a/bentoml/_internal/io_descriptors/image.py
+++ b/bentoml/_internal/io_descriptors/image.py
@@ -7,7 +7,7 @@ from starlette.requests import Request
 from multipart.multipart import parse_options_header
 from starlette.responses import Response
 
-from bentoml._internal.types import TypeRef
+from bentoml._internal.types import LazyType
 
 from .base import ImageType
 from .base import IODescriptor
@@ -146,9 +146,9 @@ class Image(IODescriptor[ImageType]):
         return PIL.Image.open(io.BytesIO(bytes_))
 
     async def to_http_response(self, obj: ImageType) -> Response:
-        if TypeRef["NDArray"]("numpy.ndarray").isinstance(obj):
+        if LazyType["NDArray"]("numpy.ndarray").isinstance(obj):
             image = PIL.Image.fromarray(obj, mode=self._pilmode)
-        elif TypeRef["PIL.Image.Image"]("PIL.Image.Image").isinstance(obj):
+        elif LazyType["PIL.Image.Image"]("PIL.Image.Image").isinstance(obj):
             image = obj
         else:
             raise InternalServerError(

--- a/bentoml/_internal/io_descriptors/image.py
+++ b/bentoml/_internal/io_descriptors/image.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     import PIL.Image
     import numpy.typing
 
+    NDArray = numpy.typing.NDArray[t.Any]
+
     _Mode = t.Literal[
         "1", "CMYK", "F", "HSV", "I", "L", "LAB", "P", "RGB", "RGBA", "RGBX", "YCbCr"
     ]
@@ -144,7 +146,7 @@ class Image(IODescriptor[ImageType]):
         return PIL.Image.open(io.BytesIO(bytes_))
 
     async def to_http_response(self, obj: ImageType) -> Response:
-        if TypeRef["numpy.typing.NDArray[t.Any]"]("numpy.ndarray").isinstance(obj):
+        if TypeRef["NDArray"]("numpy.ndarray").isinstance(obj):
             image = PIL.Image.fromarray(obj, mode=self._pilmode)
         elif TypeRef["PIL.Image.Image"]("PIL.Image.Image").isinstance(obj):
             image = obj

--- a/bentoml/_internal/runner/container.py
+++ b/bentoml/_internal/runner/container.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from simple_di import inject
 from simple_di import Provide
 
-from .utils import TypeRef
+from ..types import TypeRef
 from ..configuration.containers import BentoServerContainer
 
 SingleType = t.TypeVar("SingleType")
@@ -250,8 +250,8 @@ class DataContainerRegistry:
         batch_type: t.Union[TypeRef, type],
         container_cls: t.Type[DataContainer],
     ):
-        single_type = TypeRef.from_type(single_type)
-        batch_type = TypeRef.from_type(batch_type)
+        single_type = TypeRef(single_type)
+        batch_type = TypeRef(batch_type)
 
         cls.CONTAINER_BATCH_TYPE_MAP[batch_type] = container_cls
         cls.CONTAINER_SINGLE_TYPE_MAP[single_type] = container_cls
@@ -260,14 +260,14 @@ class DataContainerRegistry:
     def find_by_single_type(
         cls, type_: t.Union[t.Type[SingleType], TypeRef]
     ) -> t.Type[DataContainer[SingleType, BatchType]]:
-        typeref = TypeRef.from_type(type_)
+        typeref = TypeRef(type_)
         return cls.CONTAINER_SINGLE_TYPE_MAP.get(typeref, DefaultContainer)
 
     @classmethod
     def find_by_batch_type(
         cls, type_: t.Union[t.Type[BatchType], TypeRef]
     ) -> t.Type[DataContainer[SingleType, BatchType]]:
-        typeref = TypeRef.from_type(type_)
+        typeref = TypeRef(type_)
         return cls.CONTAINER_BATCH_TYPE_MAP.get(typeref, DefaultContainer)
 
     @classmethod

--- a/bentoml/_internal/runner/container.py
+++ b/bentoml/_internal/runner/container.py
@@ -240,34 +240,34 @@ class DefaultContainer(DataContainer[t.Any, t.List[t.Any]]):
 
 
 class DataContainerRegistry:
-    CONTAINER_SINGLE_TYPE_MAP: t.Dict[TypeRef, t.Type[DataContainer]] = dict()
-    CONTAINER_BATCH_TYPE_MAP: t.Dict[TypeRef, t.Type[DataContainer]] = dict()
+    CONTAINER_SINGLE_TYPE_MAP: t.Dict[TypeRef[t.Any], t.Type[DataContainer]] = dict()
+    CONTAINER_BATCH_TYPE_MAP: t.Dict[TypeRef[t.Any], t.Type[DataContainer]] = dict()
 
     @classmethod
     def register_container(
         cls,
-        single_type: t.Union[TypeRef, type],
-        batch_type: t.Union[TypeRef, type],
+        single_type: t.Union[TypeRef[t.Any], type],
+        batch_type: t.Union[TypeRef[t.Any], type],
         container_cls: t.Type[DataContainer],
     ):
-        single_type = TypeRef(single_type)
-        batch_type = TypeRef(batch_type)
+        single_type = TypeRef.from_type(single_type)
+        batch_type = TypeRef.from_type(batch_type)
 
         cls.CONTAINER_BATCH_TYPE_MAP[batch_type] = container_cls
         cls.CONTAINER_SINGLE_TYPE_MAP[single_type] = container_cls
 
     @classmethod
     def find_by_single_type(
-        cls, type_: t.Union[t.Type[SingleType], TypeRef]
+        cls, type_: t.Union[t.Type[SingleType], TypeRef[t.Any]]
     ) -> t.Type[DataContainer[SingleType, BatchType]]:
-        typeref = TypeRef(type_)
+        typeref = TypeRef.from_type(type_)
         return cls.CONTAINER_SINGLE_TYPE_MAP.get(typeref, DefaultContainer)
 
     @classmethod
     def find_by_batch_type(
-        cls, type_: t.Union[t.Type[BatchType], TypeRef]
+        cls, type_: t.Union[t.Type[BatchType], TypeRef[t.Any]]
     ) -> t.Type[DataContainer[SingleType, BatchType]]:
-        typeref = TypeRef(type_)
+        typeref = TypeRef.from_type(type_)
         return cls.CONTAINER_BATCH_TYPE_MAP.get(typeref, DefaultContainer)
 
     @classmethod

--- a/bentoml/_internal/runner/container.py
+++ b/bentoml/_internal/runner/container.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from simple_di import inject
 from simple_di import Provide
 
-from ..types import TypeRef
+from ..types import LazyType
 from ..configuration.containers import BentoServerContainer
 
 SingleType = t.TypeVar("SingleType")
@@ -240,34 +240,34 @@ class DefaultContainer(DataContainer[t.Any, t.List[t.Any]]):
 
 
 class DataContainerRegistry:
-    CONTAINER_SINGLE_TYPE_MAP: t.Dict[TypeRef[t.Any], t.Type[DataContainer]] = dict()
-    CONTAINER_BATCH_TYPE_MAP: t.Dict[TypeRef[t.Any], t.Type[DataContainer]] = dict()
+    CONTAINER_SINGLE_TYPE_MAP: t.Dict[LazyType[t.Any], t.Type[DataContainer]] = dict()
+    CONTAINER_BATCH_TYPE_MAP: t.Dict[LazyType[t.Any], t.Type[DataContainer]] = dict()
 
     @classmethod
     def register_container(
         cls,
-        single_type: t.Union[TypeRef[t.Any], type],
-        batch_type: t.Union[TypeRef[t.Any], type],
+        single_type: t.Union[LazyType[t.Any], type],
+        batch_type: t.Union[LazyType[t.Any], type],
         container_cls: t.Type[DataContainer],
     ):
-        single_type = TypeRef.from_type(single_type)
-        batch_type = TypeRef.from_type(batch_type)
+        single_type = LazyType.from_type(single_type)
+        batch_type = LazyType.from_type(batch_type)
 
         cls.CONTAINER_BATCH_TYPE_MAP[batch_type] = container_cls
         cls.CONTAINER_SINGLE_TYPE_MAP[single_type] = container_cls
 
     @classmethod
     def find_by_single_type(
-        cls, type_: t.Union[t.Type[SingleType], TypeRef[t.Any]]
+        cls, type_: t.Union[t.Type[SingleType], LazyType[t.Any]]
     ) -> t.Type[DataContainer[SingleType, BatchType]]:
-        typeref = TypeRef.from_type(type_)
+        typeref = LazyType.from_type(type_)
         return cls.CONTAINER_SINGLE_TYPE_MAP.get(typeref, DefaultContainer)
 
     @classmethod
     def find_by_batch_type(
-        cls, type_: t.Union[t.Type[BatchType], TypeRef[t.Any]]
+        cls, type_: t.Union[t.Type[BatchType], LazyType[t.Any]]
     ) -> t.Type[DataContainer[SingleType, BatchType]]:
-        typeref = TypeRef.from_type(type_)
+        typeref = LazyType.from_type(type_)
         return cls.CONTAINER_BATCH_TYPE_MAP.get(typeref, DefaultContainer)
 
     @classmethod
@@ -282,19 +282,19 @@ class DataContainerRegistry:
 
 def register_builtin_containers():
     DataContainerRegistry.register_container(
-        TypeRef("numpy", "ndarray"), TypeRef("numpy", "ndarray"), NdarrayContainer
+        LazyType("numpy", "ndarray"), LazyType("numpy", "ndarray"), NdarrayContainer
     )
     # DataContainerRegistry.register_container(np.ndarray, np.ndarray, NdarrayContainer)
 
     DataContainerRegistry.register_container(
-        TypeRef("pandas.core.series", "Series"),
-        TypeRef("pandas.core.frame", "DataFrame"),
+        LazyType("pandas.core.series", "Series"),
+        LazyType("pandas.core.frame", "DataFrame"),
         PandasDataFrameContainer,
     )
 
     DataContainerRegistry.register_container(
-        TypeRef("pandas.core.frame", "DataFrame"),
-        TypeRef("pandas.core.frame", "DataFrame"),
+        LazyType("pandas.core.frame", "DataFrame"),
+        LazyType("pandas.core.frame", "DataFrame"),
         PandasDataFrameContainer,
     )
 

--- a/bentoml/_internal/types.py
+++ b/bentoml/_internal/types.py
@@ -89,7 +89,7 @@ class TypeRef(t.Generic[T]):
     def __init__(self, module_or_cls: str, qualname: str) -> None:
         """TypeRef("numpy", "ndarray")"""
 
-    @t.overload
+    @overload
     def __init__(self, module_or_cls: type) -> None:
         """TypeRef(numpy.ndarray)"""
 

--- a/bentoml/_internal/types.py
+++ b/bentoml/_internal/types.py
@@ -118,7 +118,13 @@ class TypeRef(t.Generic[T]):
             if hasattr(module_or_cls, "__qualname__"):
                 self.qualname: str = getattr(module_or_cls, "__qualname__")
             else:
-                self.qualname: str = getattr(module_or_cls, __name__)
+                self.qualname: str = getattr(module_or_cls, "__name__")
+
+    @classmethod
+    def from_type(cls, typ_: t.Union["TypeRef[T]", "t.Type[T]"]) -> "TypeRef[T]":
+        if isinstance(typ_, TypeRef):
+            return typ_
+        return cls(typ_)
 
     def __eq__(self, o: object) -> bool:
         """

--- a/bentoml/_internal/types.py
+++ b/bentoml/_internal/types.py
@@ -89,7 +89,7 @@ class TypeRef(t.Generic[T]):
     def __init__(self, module_or_cls: str, qualname: str) -> None:
         """TypeRef("numpy", "ndarray")"""
 
-    @overload
+    @t.overload
     def __init__(self, module_or_cls: type) -> None:
         """TypeRef(numpy.ndarray)"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ force_alphabetical_sort_within_sections = true
 skip_glob = ["typings/*", "docs/*"]
 
 [tool.pyright]
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 include = ["bentoml", "typings"]
 exclude = ['bentoml/_version.py','bentoml/__main__.py']
 strictListInference = true

--- a/tests/unit/_internal/runner/utils.py
+++ b/tests/unit/_internal/runner/utils.py
@@ -1,15 +1,13 @@
 import numpy as np
 
-from bentoml._internal.runner.utils import TypeRef
+from bentoml._internal.types import TypeRef
 
 
 def test_typeref():
 
     # assert __eq__
     assert TypeRef("numpy", "ndarray") == np.ndarray
-    assert TypeRef("numpy", "ndarray") == TypeRef.from_instance(
-        np.random.randint([2, 3])
-    )
+    assert TypeRef("numpy", "ndarray") == TypeRef(type(np.array([2, 3])))
 
     # evaluate
-    assert TypeRef("numpy", "ndarray").evaluate() == np.ndarray
+    assert TypeRef("numpy", "ndarray").get_class() == np.ndarray

--- a/tests/unit/_internal/runner/utils.py
+++ b/tests/unit/_internal/runner/utils.py
@@ -1,13 +1,13 @@
 import numpy as np
 
-from bentoml._internal.types import TypeRef
+from bentoml._internal.types import LazyType
 
 
 def test_typeref():
 
     # assert __eq__
-    assert TypeRef("numpy", "ndarray") == np.ndarray
-    assert TypeRef("numpy", "ndarray") == TypeRef(type(np.array([2, 3])))
+    assert LazyType("numpy", "ndarray") == np.ndarray
+    assert LazyType("numpy", "ndarray") == LazyType(type(np.array([2, 3])))
 
     # evaluate
-    assert TypeRef("numpy", "ndarray").get_class() == np.ndarray
+    assert LazyType("numpy", "ndarray").get_class() == np.ndarray


### PR DESCRIPTION
<!--- Thanks for sending a pull request!

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).

- feat: (new feature for the user, not a new feature for build script)
- fix: (bug fix for the user, not a fix to a build script)
- docs: (changes to the documentation)
- style: (formatting, missing semicolons, etc; no production code change)
- refactor: (refactoring production code, eg. renaming a variable)
- perf: (code changes that improve performance)
- test: (adding missing tests, refactoring tests; no production code change)
- chore: (updating grunt tasks etc; no production code change)
- build: (changes that affect the build system or external dependencies)
- ci: (changes to configuration files and scripts)
- revert: (reverts a previous commit)
-->

## Description
<!--- Describe your changes in detail -->
    TypeRef provides solutions for several conflicts when applying lazy dependencies,
         type annotations and runtime class checking.
     It works both for runtime and type checking phases.
     * conflicts 1
     isinstance(obj, class) requires importing the class first, which breaks
     lazy dependencies
     solution:
     >>> TypeRef("numpy.ndarray").isinstance(obj)
     * conflicts 2
     `isinstance(obj, str)` will narrow obj types down to str. But it only works for the
     case that the class is the type at the same time. For numpy.ndarray which the type
     is actually numpy.typing.NDArray, we had to hack the type checking.
     solution:
     >>> if TYPE_CHECKING:
     >>>     from numpy.typing import NDArray
     >>> TypeRef["NDArray"]("numpy.ndarray").isinstance(obj)`
     >>> #  this will narrow the obj to NDArray with PEP-647
     * conflicts 3
     compare/refer/map classes before importing them.
     >>> HANDLER_MAP = {
     >>>     TypeRef("numpy.ndarray"): ndarray_handler,
     >>>     TypeRef("pandas.DataFrame"): pdframe_handler,
     >>> }
     >>>
     >>> HANDLER_MAP[TypeRef(numpy.ndarray)]](array)
     >>> TypeRef("numpy.ndarray") == numpy.ndarray
<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
