### PR TITLE
fix: add checking if obj has __module__ attribute

### DIFF
--- a/bentoml/utils/cloudpickle.py
+++ b/bentoml/utils/cloudpickle.py
@@ -844,7 +844,7 @@ class CloudPickler(Pickler):
         elif obj is type(NotImplemented):
             return self.save_reduce(type, (NotImplemented,), obj=obj)
 
-        if obj.__module__ == "__main__":
+        if hasattr(obj, "__module__") and obj.__module__ == "__main__":
             return self.save_dynamic_class(obj)
 
         try:


### PR DESCRIPTION
## Description
Add checking if obj has `__module__` attribute in order to avoid getting an exception when saving service with  PyTorch DynamicQuantizedLinear artifact

## Motivation and Context

Fix #2169

## How Has This Been Tested?
Do the same as in #2169


## Checklist:
- [x] My code follows the bentoml code style, both `./dev/format.sh` and
  `./dev/lint.sh` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
