### PR TITLE
fix(io): support pandas 1.4.0

### DIFF
--- a/bentoml/_internal/io_descriptors/pandas.py
+++ b/bentoml/_internal/io_descriptors/pandas.py
@@ -1,3 +1,4 @@
+import io
 import typing as t
 import logging
 from typing import TYPE_CHECKING
@@ -211,7 +212,7 @@ class PandasDataFrame(IODescriptor["ext.PdDataFrame"]):
                 )
             # TODO(jiang): check dtype
         res = pd.read_json(  # type: ignore[arg-type]
-            obj,
+            io.BytesIO(obj),
             dtype=self._dtype,  # type: ignore[arg-type]
             orient=self._orient,
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,9 +82,6 @@ tracing =
     opentelemetry-exporter-jaeger
     opentelemetry-exporter-prometheus
     opentelemetry-exporter-zipkin
-pandas =
-    pandas<1.4.0;python_version < "3.8"
-    pandas;python_version >= "3.8"
 
 [options.package_data]
 bentoml = py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,9 @@ tracing =
     opentelemetry-exporter-jaeger
     opentelemetry-exporter-prometheus
     opentelemetry-exporter-zipkin
+pandas =
+    pandas<1.4.0;python_version < "3.8"
+    pandas;python_version >= "3.8"
 
 [options.package_data]
 bentoml = py.typed


### PR DESCRIPTION
https://github.com/pandas-dev/pandas/releases/tag/v1.4.0

> pandas 1.4.0 supports Python 3.8 and higher.

pip will install old versions under lower Python versions. Thus only tests with >py38 failed