### PR TITLE
fix: handle crash when runners return a generator instead of a list

### DIFF
--- a/bentoml/_internal/runner/container.py
+++ b/bentoml/_internal/runner/container.py
@@ -375,7 +375,10 @@ class AutoContainer(DataContainer[t.Any, t.Any]):
     @abc.abstractmethod
     def batch_to_payload(cls, batch: BatchType) -> Payload:  # type: ignore[override]
         container_cls = DataContainerRegistry.find_by_batch_type(type(batch))
-        return container_cls.batch_to_payload(batch)
+        ret = container_cls.batch_to_payload(batch)
+        if isinstance(ret, GeneratorType):
+            ret = list(ret)  # Ensure the result is a list
+        return ret
 
     @classmethod
     def payloads_to_batch(cls, payload_list: t.Sequence[Payload], batch_axis: int = 0):
@@ -391,4 +394,7 @@ class AutoContainer(DataContainer[t.Any, t.Any]):
         batch_axis: int = 0,
     ) -> t.List[Payload]:
         container_cls = DataContainerRegistry.find_by_batch_type(type(batch))
-        return container_cls.batch_to_payloads(batch, batch_axis=batch_axis)
+        ret = container_cls.batch_to_payloads(batch, batch_axis=batch_axis)
+        if isinstance(ret, GeneratorType):
+            ret = list(ret)  # Ensure the result is a list
+        return ret

--- a/bentoml/_internal/runner/container.py
+++ b/bentoml/_internal/runner/container.py
@@ -251,6 +251,9 @@ class DefaultContainer(DataContainer[t.Any, t.List[t.Any]]):
 
     @classmethod
     def single_to_payload(cls, single: t.Any) -> Payload:
+        if isinstance(single, GeneratorType):
+            # Generators can't be pickled.
+            single = list(single)  # type: ignore
         return cls.create_payload(pickle.dumps(single))
 
     @classmethod

--- a/bentoml/_internal/runner/container.py
+++ b/bentoml/_internal/runner/container.py
@@ -1,6 +1,7 @@
 import abc
 import pickle
 import typing as t
+from types import GeneratorType
 from typing import TYPE_CHECKING
 
 from simple_di import inject
@@ -244,6 +245,8 @@ class DefaultContainer(DataContainer[t.Any, t.List[t.Any]]):
         cls, batch: t.List[t.Any], batch_axis: int = 0
     ) -> t.List[t.Any]:
         assert batch_axis == 0
+        if isinstance(batch, GeneratorType):
+            batch = list(batch)
         return batch
 
     @classmethod
@@ -341,7 +344,10 @@ class AutoContainer(DataContainer[t.Any, t.Any]):
     @classmethod
     def batch_to_singles(cls, batch: t.Any, batch_axis: int = 0) -> t.List[t.Any]:
         container_cls = DataContainerRegistry.find_by_batch_type(type(batch))
-        return container_cls.batch_to_singles(batch, batch_axis=batch_axis)
+        ret = container_cls.batch_to_singles(batch, batch_axis=batch_axis)
+        if isinstance(ret, GeneratorType):
+            ret = list(ret)  # Ensure the result is a list
+        return ret
 
     @classmethod
     def single_to_payload(cls, single: SingleType) -> Payload:  # type: ignore[override]

--- a/bentoml/_internal/runner/local.py
+++ b/bentoml/_internal/runner/local.py
@@ -1,3 +1,4 @@
+from types import GeneratorType
 import typing as t
 
 from .runner import Runner
@@ -40,6 +41,11 @@ class LocalRunner(RunnerImpl):
                 batch_result,
                 batch_axis=self._runner.batch_options.output_batch_axis,
             )
+            if isinstance(single_results, GeneratorType):
+                # A runner may mistakenly return a generator, causing 
+                # indexing & pickling errors downstream.
+                single_results = list(single_results)
+
             return single_results[0]
 
         if isinstance(self._runner, SimpleRunner):

--- a/bentoml/_internal/runner/local.py
+++ b/bentoml/_internal/runner/local.py
@@ -1,4 +1,3 @@
-from types import GeneratorType
 import typing as t
 
 from .runner import Runner
@@ -41,11 +40,6 @@ class LocalRunner(RunnerImpl):
                 batch_result,
                 batch_axis=self._runner.batch_options.output_batch_axis,
             )
-            if isinstance(single_results, GeneratorType):
-                # A runner may mistakenly return a generator, causing 
-                # indexing & pickling errors downstream.
-                single_results = list(single_results)
-
             return single_results[0]
 
         if isinstance(self._runner, SimpleRunner):


### PR DESCRIPTION
## Description

Some runners (e.g. SpaCy) return a generator object from their batch run instead of a list (which is expected). This causes an error when the `run` method blindly indexes into the zeroth-element of the object: permitted in a list, but not a generator. In production, it also results in a "can not pickle generator" error.

<!--- Describe your changes in detail -->

Since BentoML has a wide diversity of authors & runner implementations, I think it's best to handle this defensively instead of frame it exclusively as a problem for the runner to fix (e.g. the SpaCy runner).

This PR is based off of the `1.0.0a2` tag and simply checks if the result is a generator before attempting to index into the zeroth element. If it's a generator, it converts it to the intended `list` type.


I think it's safest to handle this defensively: 

## Motivation and Context

This makes BentoML core more robust to anticipated errors in framework-specific runner implementations.

## How Has This Been Tested?

My code no longer crashes as it was before. Not a great test, but it's a relatively simple two-line fix..

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `make format` and
  `make lint` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly