### PR TITLE
fix: incorrect PandasDataFrame.to_http_response exception (Issue #2219)

### DIFF
--- a/bentoml/_internal/io_descriptors/pandas.py
+++ b/bentoml/_internal/io_descriptors/pandas.py
@@ -253,7 +253,7 @@ class PandasDataFrame(IODescriptor["ext.PdDataFrame"]):
             HTTP Response of type `starlette.responses.Response`. This can
              be accessed via cURL or any external web traffic.
         """
-        if LazyType["ext.PdDataFrame"](pd.DataFrame).isinstance(obj):
+        if not LazyType["ext.PdDataFrame"](pd.DataFrame).isinstance(obj):
             raise InvalidArgument(
                 f"return object is not of type `pd.DataFrame`, got type {type(obj)} instead"
             )


### PR DESCRIPTION
## Description
This PR fixes https://github.com/bentoml/BentoML/issues/2219 by adding a missing "not" to the type check in pandas.PandasDataFrame.to_http_response.

## Motivation and Context
fixes https://github.com/bentoml/BentoML/issues/2219
