### PR TITLE
Implement more sophisticated import / export APIs

### DIFF
--- a/bentoml/_internal/bento/bento.py
+++ b/bentoml/_internal/bento/bento.py
@@ -82,21 +82,30 @@ python:
 @attr.define(repr=False, auto_attribs=False)
 class Bento(StoreItem):
     _tag: Tag = attr.field()
-    _fs: "FS" = attr.field()
+    __fs: "FS" = attr.field()
 
     info: "BentoInfo"
 
     _model_store: ModelStore
     _doc: t.Optional[str] = None
 
-    @_fs.validator
+    @staticmethod
+    def _export_ext() -> str:
+        return "bento"
+
+    @__fs.validator
     def check_fs(self, _attr: t.Any, new_fs: "FS"):
-        new_fs.makedir("models", recreate=True)
+        try:
+            new_fs.makedir("models", recreate=True)
+        except fs.errors.ResourceReadOnly:
+            # when we import a tarfile, it will be read-only, so just skip the step where we create
+            # the models folder.
+            pass
         self._model_store = ModelStore(new_fs.opendir("models"))
 
     def __init__(self, tag: Tag, bento_fs: "FS", info: "BentoInfo"):
         self._tag = tag
-        self._fs = bento_fs
+        self.__fs = bento_fs
         self.check_fs(None, bento_fs)
         self.info = info
         self.validate()
@@ -104,6 +113,10 @@ class Bento(StoreItem):
     @property
     def tag(self) -> Tag:
         return self._tag
+
+    @property
+    def _fs(self) -> "FS":
+        return self.__fs
 
     @classmethod
     @inject
@@ -298,13 +311,9 @@ class Bento(StoreItem):
             out_fs = fs.open_fs(bento_path, create=True, writeable=True)
             fs.mirror.mirror(self._fs, out_fs, copy_if_newer=False)
             self._fs.close()
-            self._fs = out_fs
+            self.__fs = out_fs
 
         return self
-
-    def export(self, path: str):
-        out_fs = fs.open_fs(path, create=True, writeable=True)
-        fs.mirror.mirror(self._fs, out_fs, copy_if_newer=False)
 
     def validate(self):
         return self._fs.isfile(BENTO_YAML_FILENAME)

--- a/bentoml/_internal/bento/bento.py
+++ b/bentoml/_internal/bento/bento.py
@@ -277,13 +277,15 @@ class Bento(StoreItem):
             with item_fs.open(BENTO_YAML_FILENAME, "r", encoding="utf-8") as bento_yaml:
                 info = BentoInfo.from_yaml_file(bento_yaml)
         except fs.errors.ResourceNotFound:
-            logger.warning(f"Failed to import Bento from {item_fs}.")
-            raise BentoMLException("Failed to create Bento because it was invalid")
+            raise BentoMLException(
+                f"Failed to load bento because it does not contain a '{BENTO_YAML_FILENAME}'"
+            )
 
         res = cls(info.tag, item_fs, info)
         if not res.validate():
-            logger.warning(f"Failed to import Bento from {item_fs}.")
-            raise BentoMLException("Failed to create Bento because it was invalid")
+            raise BentoMLException(
+                f"Failed to create bento because it contains an invalid '{BENTO_YAML_FILENAME}'"
+            )
 
         res._flushed = True
         return res

--- a/bentoml/_internal/exportable.py
+++ b/bentoml/_internal/exportable.py
@@ -1,0 +1,364 @@
+import os
+import re
+import typing as t
+import logging
+import urllib.parse
+from abc import ABC
+from abc import abstractmethod
+
+import fs
+import fs.copy
+import fs.mirror
+import fs.opener
+import fs.tempfs
+from fs.base import FS
+
+T = t.TypeVar("T")
+
+
+uriSchemeRe = re.compile(r".*[^\\](?=://)")
+
+
+class Exportable(ABC):
+    @staticmethod
+    @abstractmethod
+    def _export_ext() -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def _export_name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def _fs(self) -> FS:
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def from_fs(cls: t.Type[T], item_fs: FS) -> T:
+        raise NotImplementedError
+
+    @classmethod
+    def guess_format(cls, path: str) -> str:
+        _, ext = fs.path.splitext(path)
+
+        ext = ext if ext == "" else ext[1:]
+        if ext in [cls._export_ext(), "gz", "xz", "bz2", "tar", "zip"]:
+            return ext
+        else:
+            return cls._export_ext()
+
+    @classmethod
+    def import_from(
+        cls: t.Type[T],
+        path: str,
+        input_format: t.Optional[str] = None,
+        *,
+        protocol: t.Optional[str] = None,
+        user: t.Optional[str] = None,
+        passwd: t.Optional[str] = None,
+        params: t.Optional[t.Dict[str, str]] = None,
+        subpath: t.Optional[str] = None,
+    ) -> T:
+        try:
+            parsedurl = fs.opener.parse(path)
+        except fs.opener.errors.ParseError:
+            if protocol is None:
+                protocol = "osfs"
+                resource = path if os.sep == "/" else path.replace(os.sep, "/")
+        else:
+            if any(v is not None for v in [protocol, user, passwd, params, subpath]):
+                raise ValueError(
+                    "An FS URL was passed as the output path; all additional information should be passed as part of the URL."
+                )
+
+            protocol = parsedurl.protocol
+            user = parsedurl.username
+            passwd = parsedurl.password
+            resource = parsedurl.resource
+            params = parsedurl.params
+            subpath = parsedurl.path
+
+        if protocol not in fs.opener.registry.protocols:
+            if protocol == "s3":
+                raise ValueError(
+                    "Tried to open an S3 url but the protocol is not registered; did you 'pip install fs-s3fs'?"
+                )
+            else:
+                raise ValueError(
+                    f"Unknown or unsupported protocol {protocol}. Some supported protocols are 'ftp', 's3', and 'osfs'."
+                )
+
+        isOSPath = protocol in [
+            "temp",
+            "osfs",
+            "userdata",
+            "userconf",
+            "sitedata",
+            "siteconf",
+            "usercache",
+            "userlog",
+        ]
+
+        isCompressedPath = protocol in ["tar", "zip"]
+
+        if input_format is not None:
+            if isCompressedPath:
+                raise ValueError(
+                    f"A {protocol} path was passed along with an input format ({input_format}); only pass one or the other."
+                )
+        else:
+            # try to guess output format if it hasn't been passed
+            input_format = cls.guess_format(resource if subpath is None else subpath)
+
+        if subpath is None:
+            if isCompressedPath:
+                subpath = ""
+            else:
+                resource, subpath = fs.path.split(resource)
+
+        if isOSPath:
+            # we can safely ignore user / passwd / params
+            # get the path on the system so we can skip the copy step
+            try:
+                rsc_dir = fs.open_fs(f"{protocol}://{resource}")
+                # if subpath is root, we can just open directly
+                if (subpath == "" or subpath == "/") and input_format == "folder":
+                    return cls.from_fs(rsc_dir)
+
+                # if subpath is specified, we need to create our own temp fs and mirror that subpath
+                path = rsc_dir.getsyspath(subpath)
+                res = cls._from_compressed(path, input_format)
+            except fs.errors.CreateFailed:
+                raise ValueError("Directory does not exist")
+        else:
+            userblock = ""
+            if user is not None or passwd is not None:
+                if user is not None:
+                    userblock += urllib.parse.quote(user)
+                if passwd is not None:
+                    userblock += ":" + urllib.parse.quote(passwd)
+                userblock += "@"
+
+            resource = urllib.parse.quote(resource)
+
+            query = ""
+            if params is not None:
+                query = "?" + urllib.parse.urlencode(params)
+
+            input_uri = f"{protocol}://{userblock}{resource}{query}"
+
+            if isCompressedPath:
+                input_fs = fs.open_fs(input_uri)
+                res = cls.from_fs(input_fs)
+            else:
+                filename = fs.path.basename(subpath)
+                tempfs = fs.tempfs.TempFS(identifier=f"bentoml-{filename}-import")
+                if input_format == "folder":
+                    input_fs = fs.open_fs(input_uri)
+                    fs.copy.copy_dir(input_fs, subpath, tempfs, filename)
+                else:
+                    input_fs = fs.open_fs(input_uri)
+                    fs.copy.copy_file(input_fs, subpath, input_fs, filename)
+
+                res = cls._from_compressed(tempfs.getsyspath(filename), input_format)
+
+            input_fs.close()
+
+        return res
+
+    def export(
+        self,
+        path: str,
+        output_format: t.Optional[str] = None,
+        *,
+        protocol: t.Optional[str] = None,
+        user: t.Optional[str] = None,
+        passwd: t.Optional[str] = None,
+        params: t.Optional[t.Dict[str, str]] = None,
+        subpath: t.Optional[str] = None,
+    ) -> str:
+        try:
+            parsedurl = fs.opener.parse(path)
+        except fs.opener.errors.ParseError:
+            if protocol is None:
+                protocol = "osfs"
+                resource = path if os.sep == "/" else path.replace(os.sep, "/")
+        else:
+            if any(v is not None for v in [protocol, user, passwd, params, subpath]):
+                raise ValueError(
+                    "An FS URL was passed as the output path; all additional information should be passed as part of the URL."
+                )
+
+            protocol = parsedurl.protocol
+            user = parsedurl.username
+            passwd = parsedurl.password
+            resource = parsedurl.resource
+            params = parsedurl.params
+            subpath = parsedurl.path
+
+        if protocol not in fs.opener.registry.protocols:
+            if protocol == "s3":
+                raise ValueError(
+                    "Tried to open an S3 url but the protocol is not registered; did you install fs-s3fs?"
+                )
+            else:
+                raise ValueError(
+                    f"Unknown or unsupported protocol {protocol}. Some supported protocols are 'ftp', 's3', and 'osfs'."
+                )
+
+        isOSPath = protocol in [
+            "temp",
+            "osfs",
+            "userdata",
+            "userconf",
+            "sitedata",
+            "siteconf",
+            "usercache",
+            "userlog",
+        ]
+
+        isCompressedPath = protocol in ["tar", "zip"]
+
+        if output_format is not None:
+            if isCompressedPath:
+                raise ValueError(
+                    f"A {protocol} path was passed along with an output format ({output_format}); only pass one or the other."
+                )
+        else:
+            # try to guess output format if it hasn't been passed
+            output_format = self.guess_format(resource if subpath is None else subpath)
+
+        # use combine here instead of join because we don't want to fold subpath into path.
+        fullpath = resource if subpath is None else fs.path.combine(resource, subpath)
+
+        if fullpath == "" or (not output_format == "folder" and fullpath[-1] == "/"):
+            subpath = "" if subpath is None else subpath
+            # if the path has no filename or is empty, we generate a filename from the bento tag
+            subpath = fs.path.join(subpath, self._export_name)
+            if output_format in ["gz", "xz", "bz2", "tar", "zip"]:
+                subpath += "." + output_format
+        elif isOSPath:
+            try:
+                dirfs = fs.open_fs(path)
+            except fs.errors.CreateFailed:
+                pass
+            else:
+                if subpath is None or dirfs.isdir(subpath):
+                    subpath = "" if subpath is None else subpath
+                    # path exists and is a directory, we will create a file inside that directory
+                    subpath = fs.path.join(subpath, self._export_name)
+                    if output_format in ["gz", "xz", "bz2", "tar", "zip"]:
+                        subpath += "." + output_format
+
+        if subpath is None:
+            if isCompressedPath:
+                subpath = ""
+            else:
+                resource, subpath = fs.path.split(resource)
+
+        # as a special case, if the output format is the default we will always append the relevant
+        # extension if the output filename does not have it
+        if (
+            output_format == self._export_ext()
+            and fs.path.splitext(subpath)[1] != "." + self._export_ext()
+        ):
+            logging.info(
+                f"adding {self._export_ext} because ext is {fs.path.splitext(subpath)[1]}"
+            )
+            subpath += "." + self._export_ext()
+
+        if isOSPath:
+            # we can safely ignore user / passwd / params
+            # get the path on the system so we can skip the copy step
+            try:
+                rsc_dir = fs.open_fs(f"{protocol}://{resource}")
+                path = rsc_dir.getsyspath(subpath)
+                self._compress(path, output_format)
+            except fs.errors.CreateFailed:
+                raise ValueError(
+                    f"Output directory '{protocol}://{resource}' does not exist."
+                )
+        else:
+            userblock = ""
+            if user is not None or passwd is not None:
+                if user is not None:
+                    userblock += urllib.parse.quote(user)
+                if passwd is not None:
+                    userblock += ":" + urllib.parse.quote(passwd)
+                userblock += "@"
+
+            resource = urllib.parse.quote(resource)
+
+            query = ""
+            if params is not None:
+                query = "?" + urllib.parse.urlencode(params)
+
+            dest_uri = f"{protocol}://{userblock}{resource}{query}"
+
+            if isCompressedPath:
+                destfs = fs.open_fs(dest_uri, writeable=True, create=True)
+                fs.mirror.mirror(self._fs, destfs, copy_if_newer=False)
+            else:
+                tempfs = fs.tempfs.TempFS(identifier=f"bentoml-{self._tag}-export")
+                filename = fs.path.basename(subpath)
+                self._compress(tempfs.getsyspath(filename), output_format)
+
+                if output_format == "folder":
+                    destfs = fs.open_fs(dest_uri)
+                    fs.copy.copy_dir(tempfs, filename, destfs, subpath)
+                else:
+                    destfs = fs.open_fs(dest_uri)
+                    fs.copy.copy_file(tempfs, filename, destfs, subpath)
+
+                tempfs.close()
+
+            destfs.close()
+
+        return path
+
+    def _compress(self, path: str, output_format: str):
+        if output_format in ["gz", "xz", "bz2", "tar", self._export_ext()]:
+            import fs.tarfs
+
+            compression = output_format
+            if compression == "tar":
+                compression = None
+            if compression == self._export_ext():
+                compression = "xz"
+            out_fs = fs.tarfs.WriteTarFS(path, compression)
+        elif output_format == "zip":
+            import fs.zipfs
+
+            out_fs = fs.zipfs.WriteZipFS(path)
+        elif output_format == "folder":
+            out_fs = fs.open_fs(path, writeable=True, create=True)
+        else:
+            raise ValueError(f"Unsupported format {output_format}")
+
+        fs.mirror.mirror(self._fs, out_fs, copy_if_newer=False)
+        out_fs.close()
+
+    @classmethod
+    def _from_compressed(cls: t.Type[T], path: str, input_format: str) -> T:
+        if input_format in ["gz", "xz", "bz2", "tar", cls._export_ext()]:
+            import fs.tarfs
+
+            compression = input_format
+            if compression == "tar":
+                compression = None
+            if compression == cls._export_ext():
+                compression = "xz"
+            ret_fs = fs.tarfs.ReadTarFS(path, compression)
+        elif input_format == "zip":
+            import fs.zipfs
+
+            ret_fs = fs.zipfs.ReadZipFS(path)
+        elif input_format == "folder":
+            ret_fs = fs.open_fs(path)
+        else:
+            raise ValueError(f"Unsupported format {input_format}")
+
+        return cls.from_fs(ret_fs)

--- a/bentoml/_internal/models/model.py
+++ b/bentoml/_internal/models/model.py
@@ -177,13 +177,15 @@ class Model(StoreItem):
             with item_fs.open(MODEL_YAML_FILENAME, "r") as model_yaml:
                 info = ModelInfo.from_yaml_file(model_yaml)
         except fs.errors.ResourceNotFound:
-            logger.warning(f"Failed to import Model from {item_fs}.")
-            raise BentoMLException("Failed to create Model because it was invalid")
+            raise BentoMLException(
+                f"Failed to load bento model because it does not contain a '{MODEL_YAML_FILENAME}'"
+            )
 
         res = cls(info.tag, item_fs, info)
         if not res.validate():
-            logger.warning(f"Failed to import Model from {item_fs}.")
-            raise BentoMLException("Failed to create Model because it was invalid")
+            raise BentoMLException(
+                f"Failed to load bento model because it contains an invalid '{MODEL_YAML_FILENAME}'"
+            )
 
         res._info_flushed = True
         res._custom_objects_flushed = True

--- a/bentoml/_internal/store.py
+++ b/bentoml/_internal/store.py
@@ -11,17 +11,26 @@ from fs.base import FS
 
 from .types import Tag
 from .types import PathType
+from .exportable import Exportable
 from ..exceptions import NotFound
 from ..exceptions import BentoMLException
 
 T = t.TypeVar("T")
 
 
-class StoreItem(ABC):
+class StoreItem(Exportable):
     @property
     @abstractmethod
     def tag(self) -> Tag:
         raise NotImplementedError
+
+    @property
+    def _fs(self) -> FS:
+        raise NotImplementedError
+
+    @property
+    def _export_name(self) -> str:
+        return f"{self.tag.name}-{self.tag.version}"
 
     @classmethod
     @abstractmethod

--- a/bentoml/_internal/store.py
+++ b/bentoml/_internal/store.py
@@ -28,6 +28,11 @@ class StoreItem(Exportable):
     def _fs(self) -> FS:
         raise NotImplementedError
 
+    @classmethod
+    @property
+    def typename(cls) -> str:
+        return cls.__name__
+
     @property
     def _export_name(self) -> str:
         return f"{self.tag.name}-{self.tag.version}"
@@ -43,7 +48,7 @@ class StoreItem(Exportable):
         raise NotImplementedError
 
     def __repr__(self):
-        return f'{self.__class__.__name__}(tag="{self.tag}")'
+        return f'{self.typename}(tag="{self.tag}")'
 
 
 Item = t.TypeVar("Item", bound=StoreItem)
@@ -80,7 +85,7 @@ class Store(ABC, t.Generic[Item]):
         if _tag.version is None:
             if not self._fs.isdir(_tag.name):
                 raise NotFound(
-                    f"no {self._item_type.__name__}s with name '{_tag.name}' found"
+                    f"no {self._item_type.typename}s with name '{_tag.name}' found"
                 )
 
             tags = sorted(
@@ -112,7 +117,7 @@ class Store(ABC, t.Generic[Item]):
                 _tag.version = self._fs.readtext(_tag.latest_path())
             except fs.errors.ResourceNotFound:
                 raise NotFound(
-                    f"no {self._item_type.__name__}s with name '{_tag.name}' exist in BentoML store {self._fs}"
+                    f"no {self._item_type.typename}s with name '{_tag.name}' exist in BentoML store {self._fs}"
                 )
 
         path = _tag.path()
@@ -123,7 +128,7 @@ class Store(ABC, t.Generic[Item]):
         counts = matches.count().directories
         if counts == 0:
             raise NotFound(
-                f"{self._item_type.__name__} '{tag}' is not found in BentoML store {self._fs}"
+                f"{self._item_type.typename} '{tag}' is not found in BentoML store {self._fs}"
             )
         elif counts == 1:
             match = next(iter(matches))
@@ -161,7 +166,7 @@ class Store(ABC, t.Generic[Item]):
         _tag = Tag.from_taglike(tag)
 
         if not self._fs.exists(_tag.path()):
-            raise NotFound(f"{self._item_type.__name__} '{tag}' not found")
+            raise NotFound(f"{self._item_type.typename} '{tag}' not found")
 
         self._fs.removetree(_tag.path())
         if self._fs.isdir(_tag.name):

--- a/bentoml/bentos.py
+++ b/bentoml/bentos.py
@@ -7,7 +7,6 @@ import logging
 import subprocess
 from typing import TYPE_CHECKING
 
-import fs
 from simple_di import inject
 from simple_di import Provide
 
@@ -55,21 +54,153 @@ def delete(
 @inject
 def import_bento(
     path: str,
+    input_format: t.Optional[str] = None,
     *,
+    protocol: t.Optional[str] = None,
+    user: t.Optional[str] = None,
+    passwd: t.Optional[str] = None,
+    params: t.Optional[t.Dict[str, str]] = None,
+    subpath: t.Optional[str] = None,
     _bento_store: "BentoStore" = Provide[BentoMLContainer.bento_store],
 ) -> Bento:
-    return Bento.from_fs(fs.open_fs(path))
+    """
+    Import a bento.
+
+    Examples:
+
+    .. code-block:: python
+        # imports 'my_bento' from '/path/to/folder/my_bento.bento'
+        bentoml.import_bento('/path/to/folder/my_bento.bento')
+
+        # imports 'my_bento' from '/path/to/folder/my_bento.tar.gz'
+        # currently supported formats are tar.gz ('gz'), tar.xz ('xz'), tar.bz2 ('bz2'), and zip
+        bentoml.import_bento('/path/to/folder/my_bento.tar.gz')
+        # treats 'my_bento.ext' as a gzipped tarfile
+        bentoml.import_bento('/path/to/folder/my_bento.ext', 'gz')
+
+        # imports 'my_bento', which is stored as an uncompressed folder, from '/path/to/folder/my_bento/'
+        bentoml.import_bento('/path/to/folder/my_bento', 'folder')
+
+        # imports 'my_bento' from the S3 bucket 'my_bucket', path 'folder/my_bento.bento'
+        # requires `fs-s3fs <https://pypi.org/project/fs-s3fs/>`_ ('pip install fs-s3fs')
+        bentoml.import_bento('s3://my_bucket/folder/my_bento.bento')
+        bentoml.import_bento('my_bucket/folder/my_bento.bento', protocol='s3')
+        bentoml.import_bento('my_bucket', protocol='s3', subpath='folder/my_bento.bento')
+        bentoml.import_bento('my_bucket', protocol='s3', subpath='folder/my_bento.bento',
+                             user='<AWS access key>', passwd='<AWS secret key>',
+                             params={'acl': 'public-read', 'cache-control': 'max-age=2592000,public'})
+
+    For a more comprehensive description of what each of the keyword arguments (:code:`protocol`,
+    :code:`user`, :code:`passwd`, :code:`params`, and :code:`subpath`) mean, see the
+    `FS URL documentation <https://docs.pyfilesystem.org/en/latest/openers.html>`_.
+
+    Args:
+        tag: the tag of the bento to export
+        path: can be one of two things:
+            * a folder on the local filesystem
+            * an `FS URL <https://docs.pyfilesystem.org/en/latest/openers.html>`_, for example
+                :code:`'s3://my_bucket/folder/my_bento.bento'`
+        protocol: (expert) The FS protocol to use when exporting. Some example protocols are :code:`'ftp'`,
+            :code:`'s3'`, and :code:`'userdata'`
+        user: (expert) the username used for authentication if required, e.g. for FTP
+        passwd: (expert) the username used for authentication if required, e.g. for FTP
+        params: (expert) a map of parameters to be passed to the FS used for export, e.g. :code:`{'proxy': 'myproxy.net'}`
+            for setting a proxy for FTP
+        subpath: (expert) the path inside the FS that the bento should be exported to
+        _bento_store: the bento store to save the bento to
+
+    Returns:
+        Bento: the imported bento
+    """
+    return Bento.import_from(
+        path,
+        input_format,
+        protocol=protocol,
+        user=user,
+        passwd=passwd,
+        params=params,
+        subpath=subpath,
+    ).save(_bento_store)
 
 
 @inject
 def export_bento(
     tag: t.Union[Tag, str],
     path: str,
+    output_format: t.Optional[str] = None,
     *,
+    protocol: t.Optional[str] = None,
+    user: t.Optional[str] = None,
+    passwd: t.Optional[str] = None,
+    params: t.Optional[t.Dict[str, str]] = None,
+    subpath: t.Optional[str] = None,
     _bento_store: "BentoStore" = Provide[BentoMLContainer.bento_store],
-):
+) -> str:
+    """
+    Export a bento.
+
+    Examples:
+
+    .. code-block:: python
+        # exports 'my_bento' to '/path/to/folder/my_bento-version.bento' in BentoML's default format
+        bentoml.export_bento('my_bento:latest', '/path/to/folder')
+        # note that folders can only be passed if exporting to the local filesystem; otherwise the
+        # full path, including the desired filename, must be passed
+
+        # exports 'my_bento' to '/path/to/folder/my_bento.bento' in BentoML's default format
+        bentoml.export_bento('my_bento:latest', '/path/to/folder/my_bento')
+        bentoml.export_bento('my_bento:latest', '/path/to/folder/my_bento.bento')
+
+        # exports 'my_bento' to '/path/to/folder/my_bento.tar.gz' in gzip format
+        # currently supported formats are tar.gz ('gz'), tar.xz ('xz'), tar.bz2 ('bz2'), and zip
+        bentoml.export_bento('my_bento:latest', '/path/to/folder/my_bento.tar.gz')
+        # outputs a gzipped tarfile as 'my_bento.ext'
+        bentoml.export_bento('my_bento:latest', '/path/to/folder/my_bento.ext', 'gz')
+
+        # exports 'my_bento' to '/path/to/folder/my_bento/' as a folder
+        bentoml.export_bento('my_bento:latest', '/path/to/folder/my_bento', 'folder')
+
+        # exports 'my_bento' to the S3 bucket 'my_bucket' as 'folder/my_bento-version.bento'
+        bentoml.export_bento('my_bento:latest', 's3://my_bucket/folder')
+        bentoml.export_bento('my_bento:latest', 'my_bucket/folder', protocol='s3')
+        bentoml.export_bento('my_bento:latest', 'my_bucket', protocol='s3', subpath='folder')
+        bentoml.export_bento('my_bento:latest', 'my_bucket', protocol='s3', subpath='folder',
+                             user='<AWS access key>', passwd='<AWS secret key>',
+                             params={'acl': 'public-read', 'cache-control': 'max-age=2592000,public'})
+
+    For a more comprehensive description of what each of the keyword arguments (:code:`protocol`,
+    :code:`user`, :code:`passwd`, :code:`params`, and :code:`subpath`) mean, see the
+    `FS URL documentation <https://docs.pyfilesystem.org/en/latest/openers.html>`_.
+
+    Args:
+        tag: the tag of the Bento to export
+        path: can be one of two things:
+            * a folder on the local filesystem
+            * an `FS URL <https://docs.pyfilesystem.org/en/latest/openers.html>`_
+                * for example, :code:`'s3://my_bucket/folder/my_bento.bento'`
+        protocol: (expert) The FS protocol to use when exporting. Some example protocols are :code:`'ftp'`,
+            :code:`'s3'`, and :code:`'userdata'`
+        user: (expert) the username used for authentication if required, e.g. for FTP
+        passwd: (expert) the username used for authentication if required, e.g. for FTP
+        params: (expert) a map of parameters to be passed to the FS used for export, e.g. :code:`{'proxy': 'myproxy.net'}`
+            for setting a proxy for FTP
+        subpath: (expert) the path inside the FS that the bento should be exported to
+        _bento_store: save Bento created to this BentoStore
+
+    Returns:
+        str: A representation of the path that the Bento was exported to. If it was exported to the local filesystem,
+            this will be the OS path to the exported Bento. Otherwise, it will be an FS URL.
+    """
     bento = get(tag, _bento_store=_bento_store)
-    bento.export(path)
+    return bento.export(
+        path,
+        output_format,
+        protocol=protocol,
+        user=user,
+        passwd=passwd,
+        params=params,
+        subpath=subpath,
+    )
 
 
 @inject
@@ -108,11 +239,11 @@ def build(
     _model_store: "ModelStore" = Provide[BentoMLContainer.model_store],
 ) -> "Bento":
     """
-    User-facing API for building a Bento, the available build options are symmetrical to
-    the content of a valid bentofile.yaml file, for building Bento from CLI.
+    User-facing API for building a Bento. The available build options are identical to the keys of a
+    valid 'bentofile.yaml' file.
 
-    This API will not respect bentofile.yaml file in current environment, build options
-    can only be provided via function call parameters.
+    This API will not respect any 'bentofile.yaml' files. Build options should instead be provided
+    via function call parameters.
 
     Args:
         service: import str for finding the bentoml.Service instance build target

--- a/bentoml/bentos.py
+++ b/bentoml/bentos.py
@@ -69,6 +69,7 @@ def import_bento(
     Examples:
 
     .. code-block:: python
+
         # imports 'my_bento' from '/path/to/folder/my_bento.bento'
         bentoml.import_bento('/path/to/folder/my_bento.bento')
 
@@ -142,6 +143,7 @@ def export_bento(
     Examples:
 
     .. code-block:: python
+
         # exports 'my_bento' to '/path/to/folder/my_bento-version.bento' in BentoML's default format
         bentoml.export_bento('my_bento:latest', '/path/to/folder')
         # note that folders can only be passed if exporting to the local filesystem; otherwise the

--- a/bentoml/models.py
+++ b/bentoml/models.py
@@ -61,6 +61,7 @@ def import_model(
     Examples:
 
     .. code-block:: python
+
         # imports 'my_model' from '/path/to/folder/my_model.bentomodel'
         bentoml.models.import_model('/path/to/folder/my_model.bentomodel')
 
@@ -134,6 +135,7 @@ def export_model(
     Examples:
 
     .. code-block:: python
+
         # exports 'my_model' to '/path/to/folder/my_model-version.bentomodel' in BentoML's default format
         bentoml.models.export_model('my_model:latest', '/path/to/folder')
         # note that folders can only be passed if exporting to the local filesystem; otherwise the

--- a/bentoml/models.py
+++ b/bentoml/models.py
@@ -2,7 +2,6 @@ import typing as t
 from typing import TYPE_CHECKING
 from contextlib import contextmanager
 
-import fs
 from simple_di import inject
 from simple_di import Provide
 
@@ -44,19 +43,155 @@ def delete(
 
 @inject
 def import_model(
-    path: str, *, _model_store: "ModelStore" = Provide[BentoMLContainer.model_store]
+    path: str,
+    input_format: t.Optional[str] = None,
+    *,
+    protocol: t.Optional[str] = None,
+    user: t.Optional[str] = None,
+    passwd: t.Optional[str] = None,
+    params: t.Optional[t.Dict[str, str]] = None,
+    subpath: t.Optional[str] = None,
+    _model_store: "ModelStore" = Provide[BentoMLContainer.model_store],
 ) -> Model:
-    return Model.from_fs(fs.open_fs(path)).save(_model_store)
+    """
+    Import a bento model exported with :code:`bentoml.models.export_model`. To import a model saved
+    with a framework, see the :code:`save` function under the relevant framework, e.g.
+    :code:`bentoml.sklearn.save`.
+
+    Examples:
+
+    .. code-block:: python
+        # imports 'my_model' from '/path/to/folder/my_model.bentomodel'
+        bentoml.models.import_model('/path/to/folder/my_model.bentomodel')
+
+        # imports 'my_model' from '/path/to/folder/my_model.tar.gz'
+        # currently supported formats are tar.gz ('gz'), tar.xz ('xz'), tar.bz2 ('bz2'), and zip
+        bentoml.models.import_model('/path/to/folder/my_model.tar.gz')
+        # treats 'my_model.ext' as a gzipped tarfile
+        bentoml.models.import_model('/path/to/folder/my_model.ext', 'gz')
+
+        # imports 'my_model', which is stored as an uncompressed folder, from '/path/to/folder/my_model/'
+        bentoml.models.import_model('/path/to/folder/my_model', 'folder')
+
+        # imports 'my_model' from the S3 bucket 'my_bucket', path 'folder/my_model.bentomodel'
+        # requires `fs-s3fs <https://pypi.org/project/fs-s3fs/>`_ ('pip install fs-s3fs')
+        bentoml.models.import_model('s3://my_bucket/folder/my_model.bentomodel')
+        bentoml.models.import_model('my_bucket/folder/my_model.bentomodel', protocol='s3')
+        bentoml.models.import_model('my_bucket', protocol='s3', subpath='folder/my_model.bentomodel')
+        bentoml.models.import_model('my_bucket', protocol='s3', subpath='folder/my_model.bentomodel',
+                                    user='<AWS access key>', passwd='<AWS secret key>',
+                                    params={'acl': 'public-read', 'cache-control': 'max-age=2592000,public'})
+
+    For a more comprehensive description of what each of the keyword arguments (:code:`protocol`,
+    :code:`user`, :code:`passwd`, :code:`params`, and :code:`subpath`) mean, see the
+    `FS URL documentation <https://docs.pyfilesystem.org/en/latest/openers.html>`_.
+
+    Args:
+        tag: the tag of the model to export
+        path: can be one of two things:
+            * a folder on the local filesystem
+            * an `FS URL <https://docs.pyfilesystem.org/en/latest/openers.html>`_, for example
+                :code:`'s3://my_bucket/folder/my_model.bentomodel'`
+        protocol: (expert) The FS protocol to use when exporting. Some example protocols are :code:`'ftp'`,
+            :code:`'s3'`, and :code:`'userdata'`
+        user: (expert) the username used for authentication if required, e.g. for FTP
+        passwd: (expert) the username used for authentication if required, e.g. for FTP
+        params: (expert) a map of parameters to be passed to the FS used for export, e.g. :code:`{'proxy': 'myproxy.net'}`
+            for setting a proxy for FTP
+        subpath: (expert) the path inside the FS that the model should be exported to
+        _model_store: the model store to save the model to
+
+    Returns:
+        Model: the imported model
+    """
+    return Model.import_from(
+        path,
+        input_format,
+        protocol=protocol,
+        user=user,
+        passwd=passwd,
+        params=params,
+        subpath=subpath,
+    ).save(_model_store)
 
 
+@inject
 def export_model(
     tag: t.Union[Tag, str],
     path: str,
+    output_format: t.Optional[str] = None,
     *,
+    protocol: t.Optional[str] = None,
+    user: t.Optional[str] = None,
+    passwd: t.Optional[str] = None,
+    params: t.Optional[t.Dict[str, str]] = None,
+    subpath: t.Optional[str] = None,
     _model_store: "ModelStore" = Provide[BentoMLContainer.model_store],
-):
+) -> str:
+    """
+    Export a BentoML model.
+
+    Examples:
+
+    .. code-block:: python
+        # exports 'my_model' to '/path/to/folder/my_model-version.bentomodel' in BentoML's default format
+        bentoml.models.export_model('my_model:latest', '/path/to/folder')
+        # note that folders can only be passed if exporting to the local filesystem; otherwise the
+        # full path, including the desired filename, must be passed
+
+        # exports 'my_model' to '/path/to/folder/my_model.bentomodel' in BentoML's default format
+        bentoml.models.export_model('my_model:latest', '/path/to/folder/my_model')
+        bentoml.models.export_model('my_model:latest', '/path/to/folder/my_model.bentomodel')
+
+        # exports 'my_model' to '/path/to/folder/my_model.tar.gz in gzip format
+        # currently supported formats are tar.gz ('gz'), tar.xz ('xz'), tar.bz2 ('bz2'), and zip
+        bentoml.models.export_model('my_model:latest', '/path/to/folder/my_model.tar.gz')
+        bentoml.models.export_model('my_model:latest', '/path/to/folder/my_model.tar.gz', 'gz')
+
+        # exports 'my_model' to '/path/to/folder/my_model/ as a folder
+        bentoml.models.export_model('my_model:latest', '/path/to/folder/my_model', 'folder')
+
+        # exports 'my_model' to the S3 bucket 'my_bucket' as 'folder/my_model-version.bentomodel'
+        bentoml.models.export_model('my_model:latest', 's3://my_bucket/folder')
+        bentoml.models.export_model('my_model:latest', 'my_bucket/folder', protocol='s3')
+        bentoml.models.export_model('my_model:latest', 'my_bucket', protocol='s3', subpath='folder')
+        bentoml.models.export_model('my_model:latest', 'my_bucket', protocol='s3', subpath='folder',
+                                    user='<AWS access key>', passwd='<AWS secret key>',
+                                    params={'acl': 'public-read', 'cache-control': 'max-age=2592000,public'})
+
+    For a more comprehensive description of what each of the keyword arguments (:code:`protocol`,
+    :code:`user`, :code:`passwd`, :code:`params`, and :code:`subpath`) mean, see the
+    `FS URL documentation <https://docs.pyfilesystem.org/en/latest/openers.html>`_.
+
+    Args:
+        tag: the tag of the model to export
+        path: can be one of two things:
+            * a folder on the local filesystem
+            * an `FS URL <https://docs.pyfilesystem.org/en/latest/openers.html>`_, for example,
+                :code:`'s3://my_bucket/folder/my_model.bentomodel'`
+        protocol: (expert) The FS protocol to use when exporting. Some example protocols are :code:`'ftp'`,
+            :code:`'s3'`, and :code:`'userdata'`.
+        user: (expert) the username used for authentication if required, e.g. for FTP
+        passwd: (expert) the username used for authentication if required, e.g. for FTP
+        params: (expert) a map of parameters to be passed to the FS used for export, e.g. :code:`{'proxy': 'myproxy.net'}`
+            for setting a proxy for FTP
+        subpath: (expert) the path inside the FS that the model should be exported to
+        _model_store: the model store to get the model to save from
+
+    Returns:
+        str: A representation of the path that the model was exported to. If it was exported to the local filesystem,
+            this will be the OS path to the exported model. Otherwise, it will be an FS URL.
+    """
     model = get(tag, _model_store=_model_store)
-    model.export(path)
+    return model.export(
+        path,
+        output_format,
+        protocol=protocol,
+        user=user,
+        passwd=passwd,
+        params=params,
+        subpath=subpath,
+    )
 
 
 def push(

--- a/tests/unit/_internal/bento/bentoa/bentoa.py
+++ b/tests/unit/_internal/bento/bentoa/bentoa.py
@@ -1,0 +1,3 @@
+import bentoml
+
+svc = bentoml.Service("test.bentoa")

--- a/tests/unit/_internal/bento/bentoa/testfile
+++ b/tests/unit/_internal/bento/bentoa/testfile
@@ -1,0 +1,1 @@
+lorem ipsum

--- a/tests/unit/_internal/bento/bentoa1/bentoa.py
+++ b/tests/unit/_internal/bento/bentoa1/bentoa.py
@@ -1,0 +1,3 @@
+import bentoml
+
+svc = bentoml.Service("test.bentoa")

--- a/tests/unit/_internal/bento/bentob/bentob.py
+++ b/tests/unit/_internal/bento/bentob/bentob.py
@@ -1,0 +1,3 @@
+import bentoml
+
+svc = bentoml.Service("test.bentob")

--- a/tests/unit/_internal/bento/test_bento.py
+++ b/tests/unit/_internal/bento/test_bento.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from datetime import datetime
 from datetime import timezone
 
+import fs
 import pytest
 
 from bentoml._internal.bento import Bento
@@ -15,20 +16,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from bentoml._internal.models import ModelStore
-
-
-expected_yaml = """\
-service: testservice
-name: test
-version: version
-bentoml_version: {bentoml_version}
-creation_time: {creation_time}
-labels:
-  label: stringvalue
-models:
-- model:v1
-- model2:latest
-"""
 
 
 def test_bento_info(tmpdir: "Path"):
@@ -50,6 +37,19 @@ def test_bento_info(tmpdir: "Path"):
     with open(bento_yaml_b_filename, "w", encoding="utf-8") as bento_yaml_b:
         bentoinfo_b.dump(bento_yaml_b)
 
+    expected_yaml = """\
+service: testservice
+name: test
+version: version
+bentoml_version: {bentoml_version}
+creation_time: {creation_time}
+labels:
+  label: stringvalue
+models:
+- model:v1
+- model2:latest
+"""
+
     with open(bento_yaml_b_filename, encoding="utf-8") as bento_yaml_b:
         assert bento_yaml_b.read() == expected_yaml.format(
             bentoml_version=BENTOML_VERSION,
@@ -62,11 +62,7 @@ def test_bento_info(tmpdir: "Path"):
         assert bentoinfo_b_from_yaml == bentoinfo_b
 
 
-@pytest.mark.usefixtures("change_test_dir")
-def test_bento(tmpdir: "Path", dummy_model_store: "ModelStore"):
-    storepath = os.path.join(tmpdir, "bentos")
-    os.makedirs(storepath, exist_ok=True)
-
+def build_test_bento(model_store: "ModelStore") -> Bento:
     bento_cfg = BentoBuildConfig(
         "simplebento.py:svc",
         additional_models=[],
@@ -88,21 +84,176 @@ def test_bento(tmpdir: "Path", dummy_model_store: "ModelStore"):
         },
     )
 
-    start = datetime.now(timezone.utc)
-    bento = Bento.create(
+    return Bento.create(
         bento_cfg,
         version="1.0",
         build_ctx="./simplebento",
-        model_store=dummy_model_store,
+        model_store=model_store,
     )
+
+
+def fs_identical(fs1: fs.base.FS, fs2: fs.base.FS):
+    for path in fs1.walk.dirs():
+        assert fs2.isdir(path)
+
+    for path in fs1.walk.files():
+        assert fs2.isfile(path)
+        assert fs1.readbytes(path) == fs2.readbytes(path)
+
+
+@pytest.mark.usefixtures("change_test_dir")
+def test_bento_export(tmpdir: "Path", dummy_model_store: "ModelStore"):
+    working_dir = os.getcwd()
+
+    testbento = build_test_bento(dummy_model_store)
+
+    os.chdir(working_dir)
+
+    cfg = BentoBuildConfig("bentoa.py:svc")
+    bentoa = Bento.create(cfg, build_ctx="./bentoa")
+
+    os.chdir(working_dir)
+
+    bentoa1 = Bento.create(cfg, build_ctx="./bentoa1")
+
+    os.chdir(working_dir)
+
+    cfg = BentoBuildConfig("bentob.py:svc")
+    bentob = Bento.create(cfg, build_ctx="./bentob")
+
+    bento = testbento
+    path = os.path.join(tmpdir, "testbento")
+    export_path = bento.export(path)
+    assert export_path == path + ".bento"
+    assert os.path.isfile(export_path)
+    imported_bento = Bento.import_from(export_path)
+    assert imported_bento.tag == bento.tag
+    assert imported_bento.info == bento.info
+    del imported_bento
+
+    bento = bentoa
+    path = os.path.join(tmpdir, "bentoa")
+    export_path = bento.export(path)
+    assert export_path == path + ".bento"
+    assert os.path.isfile(export_path)
+    imported_bento = Bento.import_from(export_path)
+    assert imported_bento.tag == bento.tag
+    assert imported_bento.info == bento.info
+    del imported_bento
+
+    bento = bentoa1
+    path = os.path.join(tmpdir, "bentoa1")
+    export_path = bento.export(path)
+    assert export_path == path + ".bento"
+    assert os.path.isfile(export_path)
+    imported_bento = Bento.import_from(export_path)
+    assert imported_bento.tag == bento.tag
+    assert imported_bento.info == bento.info
+    del imported_bento
+
+    bento = bentob
+    path = os.path.join(tmpdir, "bentob")
+    export_path = bento.export(path)
+    assert export_path == path + ".bento"
+    assert os.path.isfile(export_path)
+    imported_bento = Bento.import_from(export_path)
+    assert imported_bento.tag == bento.tag
+    assert imported_bento.info == bento.info
+    del imported_bento
+
+    bento = testbento
+    path = os.path.join(tmpdir, "testbento.bento")
+    export_path = bento.export(path)
+    assert export_path == path
+    assert os.path.isfile(export_path)
+    imported_bento = Bento.import_from(path)
+    assert imported_bento.tag == bento.tag
+    assert imported_bento.info == bento.info
+    del imported_bento
+
+    path = os.path.join(tmpdir, "testbento-parent")
+    os.mkdir(path)
+    export_path = bento.export(path)
+    assert export_path == os.path.join(path, bento._export_name + ".bento")
+    assert os.path.isfile(export_path)
+    imported_bento = Bento.import_from(export_path)
+    assert imported_bento.tag == bento.tag
+    assert imported_bento.info == bento.info
+    del imported_bento
+
+    path = os.path.join(tmpdir, "testbento-parent-2/")
+    with pytest.raises(ValueError):
+        export_path = bento.export(path)
+
+    path = os.path.join(tmpdir, "bento-dir")
+    os.mkdir(path)
+    export_path = bento.export(path)
+    assert export_path == os.path.join(path, bento._export_name + ".bento")
+    assert os.path.isfile(export_path)
+    imported_bento = Bento.import_from(export_path)
+    assert imported_bento.tag == bento.tag
+    assert imported_bento.info == bento.info
+    del imported_bento
+
+    path = "temp://pytest-some-temp"
+    export_path = bento.export(path)
+    assert export_path.endswith(
+        os.path.join("pytest-some-temp", bento._export_name + ".bento")
+    )
+    # because this is a tempdir, it's cleaned up immediately after creation...
+
+    path = "osfs://" + fs.path.join(str(tmpdir), "testbento-by-url")
+    export_path = bento.export(path)
+    assert export_path == os.path.join(tmpdir, "testbento-by-url.bento")
+    assert os.path.isfile(export_path)
+    imported_bento = Bento.import_from(export_path)
+    assert imported_bento.tag == bento.tag
+    assert imported_bento.info == bento.info
+    del imported_bento
+    imported_bento = Bento.import_from(path + ".bento")
+    assert imported_bento.tag == bento.tag
+    assert imported_bento.info == bento.info
+    del imported_bento
+
+    path = "osfs://" + fs.path.join(str(tmpdir), "testbento-by-url")
+    with pytest.raises(ValueError):
+        bento.export(path, subpath="/badsubpath")
+
+    path = "zip://" + fs.path.join(str(tmpdir), "testbento.zip")
+    export_path = bento.export(path)
+    assert export_path == path
+    imported_bento = Bento.import_from(export_path)
+    assert imported_bento.tag == bento.tag
+    assert imported_bento.info == bento.info
+    del imported_bento
+
+    path = os.path.join(tmpdir, "testbento-gz")
+    os.mkdir(path)
+    export_path = bento.export(path, output_format="gz")
+    assert export_path == os.path.join(path, bento._export_name + ".gz")
+    assert os.path.isfile(export_path)
+    imported_bento = Bento.import_from(export_path)
+    assert imported_bento.tag == bento.tag
+    assert imported_bento.info == bento.info
+    del imported_bento
+
+    path = os.path.join(tmpdir, "testbento-gz-1/")
+    with pytest.raises(ValueError):
+        bento.export(path, output_format="gz")
+
+
+@pytest.mark.usefixtures("change_test_dir")
+def test_bento(dummy_model_store: "ModelStore"):
+    start = datetime.now(timezone.utc)
+    bento = build_test_bento(dummy_model_store)
     end = datetime.now(timezone.utc)
 
     assert bento.info.bentoml_version == BENTOML_VERSION
     assert start <= bento.creation_time <= end
     # validate should fail
 
-    with bento._fs as fs:  # type: ignore
-        assert set(fs.listdir("/")) == {
+    with bento._fs as bento_fs:  # type: ignore
+        assert set(bento_fs.listdir("/")) == {
             "bento.yaml",
             "apis",
             "models",
@@ -110,5 +261,9 @@ def test_bento(tmpdir: "Path", dummy_model_store: "ModelStore"):
             "src",
             "env",
         }
-        assert set(fs.listdir("src")) == {"simplebento.py", "subdir", ".bentoignore"}
-        assert set(fs.listdir("src/subdir")) == {"somefile"}
+        assert set(bento_fs.listdir("src")) == {
+            "simplebento.py",
+            "subdir",
+            ".bentoignore",
+        }
+        assert set(bento_fs.listdir("src/subdir")) == {"somefile"}

--- a/tests/unit/_internal/test_store.py
+++ b/tests/unit/_internal/test_store.py
@@ -34,6 +34,10 @@ class DummyItem(StoreItem):
     _creation_time: datetime
     store: "DummyStore" = attr.field(init=False)
 
+    @staticmethod
+    def _export_ext() -> str:
+        return "bentodummy"
+
     @property
     def tag(self) -> Tag:
         return self._tag
@@ -67,7 +71,7 @@ class DummyStore(Store[DummyItem]):
 def test_store(tmpdir: "Path"):
     store = DummyStore(tmpdir)
 
-    open(os.path.join(tmpdir, ".DS_store"), "a")
+    open(os.path.join(tmpdir, ".DS_store"), "a", encoding="utf-8")
 
     DummyItem.store = store
     oldtime = datetime.now()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -75,7 +75,7 @@ def test_models(tmpdir: "Path"):
     with pytest.raises(NotImplementedError):
         bentoml.models.load_runner(testmodel2tag, _model_store=store)
 
-    export_path = os.path.join(tmpdir, "testmodel2")
+    export_path = os.path.join(tmpdir, "testmodel2.bentomodel")
     bentoml.models.export_model(testmodel2tag, export_path, _model_store=store)
     bentoml.models.delete(testmodel2tag, _model_store=store)
 
@@ -99,6 +99,6 @@ def test_models(tmpdir: "Path"):
     export_path_2 = os.path.join(tmpdir, "testmodel1")
     bentoml.models.export_model(testmodel1tag, export_path_2, _model_store=store)
     bentoml.models.delete(testmodel1tag, _model_store=store)
-    bentoml.models.import_model(export_path_2, _model_store=store)
+    bentoml.models.import_model(export_path_2 + ".bentomodel", _model_store=store)
 
     assert bentoml.models.get("testmodel", _model_store=store).tag == testmodel2tag


### PR DESCRIPTION
This is just the export implementation; will add tests and import etc. later but putting this up for review so we can talk about how this should work.

Currently, the API supports:
 - `bento.export("")` - export the bento to `name-version.bento` in the current directory. this isn't a default because it feels weird for the API to have a default; arguably this should be handled by the CLI.
 - `bento.export("dir")` - if `dir` is a directory, will output to `dir/name-version.bento`.
 - `bento.export("dir/")` - even if `dir` is not a directory, try to output to `dir/name-version.bento`. note this doesn't actually try to create the folder, so save for weird filesystems where directories don't need to be created this will error if `dir` doesn't exist.
 - `bento.export("/path/to/filename")` - if filename does not have a supported extension, will create `filename.bento`.
 - `bento.export("/path/to/filename.<supported extension>")` - will use the relevant format and not append anything to the filename.

For any of those, if prefixed with supported `FS` prefixes like `s3://` or `ftp://`, will work the same way. The only exception is that for those types no check that the given path already exists as a directory is performed, so the `bento.export("dir")` form will create `dir.bento` instead of `dir/name-version.bento`.