### PR TITLE
fix: Fix broken link to Contribute.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ There are many ways to contribute to the project:
 - Report issues you're facing and "Thumbs up" on issues and feature requests that are relevant to you.
 - Investigate bugs and reviewing other developer's pull requests.
 - Contributing code or documentation to the project by submitting a Github pull request. See the [development guide](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md).
-- See more in the [contributing guide](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md>).
+- See more in the [contributing guide](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md).
 
 ---
 


### PR DESCRIPTION
## Description
404 Error Found!
[404 error](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md%3E)
![Screenshot (54)](https://user-images.githubusercontent.com/46255642/155388144-770573b3-6961-4df8-989b-487d78d0eedd.png)


## Motivation
It solves the broken link to the user to redirect to the correct Contribute page

## Checklist:
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly