### PR TITLE
chore: better error message when containerize failed

### DIFF
--- a/bentoml/bentos.py
+++ b/bentoml/bentos.py
@@ -250,11 +250,9 @@ def containerize(
     env["DOCKER_SCAN_SUGGEST"] = "false"
     logger.info(f"Building docker image for {bento}...")
     try:
-        subprocess.check_output(
-            docker_build_cmd, cwd=bento.path, env=env, stderr=subprocess.STDOUT
-        )
+        subprocess.check_output(docker_build_cmd, cwd=bento.path, env=env)
     except subprocess.CalledProcessError as e:
-        logger.error(f"Failed building docker image: {e.stdout.decode()}")
+        logger.error(f"Failed building docker image: {e}")
     else:
         logger.info(f'Successfully built docker image "{docker_image_tag}"')
 

--- a/bentoml/bentos.py
+++ b/bentoml/bentos.py
@@ -249,8 +249,14 @@ def containerize(
     env = os.environ.copy()
     env["DOCKER_SCAN_SUGGEST"] = "false"
     logger.info(f"Building docker image for {bento}...")
-    subprocess.check_output(docker_build_cmd, cwd=bento.path, env=env)
-    logger.info(f'Successfully built docker image "{docker_image_tag}"')
+    try:
+        subprocess.check_output(
+            docker_build_cmd, cwd=bento.path, env=env, stderr=subprocess.STDOUT
+        )
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed building docker image: {e.stdout.decode()}")
+    else:
+        logger.info(f'Successfully built docker image "{docker_image_tag}"')
 
 
 __all__ = [


### PR DESCRIPTION
<!--- Thanks for sending a pull request!

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).

- feat: (new feature for the user, not a new feature for build script)
- fix: (bug fix for the user, not a fix to a build script)
- docs: (changes to the documentation)
- style: (formatting, missing semicolons, etc; no production code change)
- refactor: (refactoring production code, eg. renaming a variable)
- perf: (code changes that improve performance)
- test: (adding missing tests, refactoring tests; no production code change)
- chore: (updating grunt tasks etc; no production code change)
- build: (changes that affect the build system or external dependencies)
- ci: (changes to configuration files and scripts)
- revert: (reverts a previous commit)
-->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->

Instead of showing a stacktrace error message, print an easy-to-read error message when `bentoml containerize` failed. E.g. when the docker daemon is not running, it will do:

```
> bentoml containerize iris_classifier:23qseuez5c4yhuqj 

03/01/2022 21:30:44 INFO     [cli] Building docker image for
                             Bento(tag="iris_classifier:23qseuez5c4yhuqj")...
03/01/2022 21:30:44 ERROR    [cli] Failed building docker image: Cannot connect to the Docker daemon at
                             unix:///var/run/docker.sock. Is the docker daemon running?
```

Previously it will show a stacktrace like the following:

```
> bentoml containerize iris_classifier:23qseuez5c4yhuqj     

03/01/2022 21:33:41 INFO     [cli] Building docker image for
                             Bento(tag="iris_classifier:23qseuez5c4yhuqj")...
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
ERRO[0000] Can't close tar writer: io: read/write on closed pipe
Traceback (most recent call last):
  File "/Users/chaoyuyang/.pyenv/versions/3.8.12/bin/bentoml", line 33, in <module>
    sys.exit(load_entry_point('bentoml', 'console_scripts', 'bentoml')())
  File "/Users/chaoyuyang/.pyenv/versions/3.8.12/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/chaoyuyang/.pyenv/versions/3.8.12/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/chaoyuyang/.pyenv/versions/3.8.12/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/chaoyuyang/.pyenv/versions/3.8.12/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/chaoyuyang/.pyenv/versions/3.8.12/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/chaoyuyang/workspace/BentoML/bentoml/_internal/cli/click_utils.py", line 154, in wrapper
    return func(*args, **kwargs)
  File "/Users/chaoyuyang/workspace/BentoML/bentoml/_internal/cli/click_utils.py", line 130, in wrapper
    return_value = func(*args, **kwargs)
  File "/Users/chaoyuyang/workspace/BentoML/bentoml/_internal/cli/click_utils.py", line 108, in wrapper
    return func(*args, **kwargs)
  File "/Users/chaoyuyang/workspace/BentoML/bentoml/_internal/cli/containerize.py", line 58, in containerize
    return containerize_bento(
  File "/Users/chaoyuyang/.pyenv/versions/3.8.12/lib/python3.8/site-packages/simple_di/__init__.py", line 124, in _
    return func(*_inject_args(bind.args), **_inject_kwargs(bind.kwargs))
  File "/Users/chaoyuyang/workspace/BentoML/bentoml/bentos.py", line 252, in containerize
    subprocess.check_output(docker_build_cmd, cwd=bento.path, env=env)
  File "/Users/chaoyuyang/.pyenv/versions/3.8.12/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/Users/chaoyuyang/.pyenv/versions/3.8.12/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['docker', 'build', '.', '-f', 'env/docker/Dockerfile', '-t', 'iris_classifier:23qseuez5c4yhuqj']' returned non-zero exit status 1.
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `make format` and
  `make lint` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly