### PR TITLE
Better options for `bentoml build`

### DIFF
--- a/bentoml/_internal/cli/bento_management.py
+++ b/bentoml/_internal/cli/bento_management.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import json
 import logging
@@ -259,11 +260,23 @@ def add_bento_management_commands(
         yatai_client.push_bento(bento_obj, force=force)
 
     @cli.command(help="Build a new Bento from current directory")
-    @click.argument("build_ctx", type=click.Path(), default=".")
-    @click.option("-f", "--bentofile", type=click.STRING, default="bentofile.yaml")
+    @click.argument("build_ctx", type=click.Path(), required=False, default=None)
+    @click.option("-f", "--bentofile", type=click.STRING, default=None)
+    @click.option("-t", "--tag", type=click.STRING, default=None)
     @click.option("--version", type=click.STRING, default=None)
-    def build(build_ctx, bentofile, version):
+    def build(build_ctx, bentofile, tag, version):
+        if bentofile is None:
+            bentofile = "bentofile.yaml"
+
+        if build_ctx is None:
+            if bentofile is not None:
+                build_ctx = os.path.dirname(bentofile)
+                if build_ctx == "":
+                    build_ctx = "."
+            else:
+                build_ctx = "."
+
         if sys.path[0] != build_ctx:
             sys.path.insert(0, build_ctx)
 
-        build_bentofile(bentofile, build_ctx=build_ctx, version=version)
+        build_bentofile(bentofile, build_ctx=build_ctx, version=version, tag=tag)

--- a/bentoml/bentos.py
+++ b/bentoml/bentos.py
@@ -301,6 +301,7 @@ def build_bentofile(
     *,
     version: t.Optional[str] = None,
     build_ctx: t.Optional[str] = None,
+    tag: t.Optional[t.Union[str, Tag]] = None,
     _bento_store: "BentoStore" = Provide[BentoMLContainer.bento_store],
     _model_store: "ModelStore" = Provide[BentoMLContainer.model_store],
 ) -> "Bento":
@@ -329,6 +330,7 @@ def build_bentofile(
         build_config=build_config,
         version=version,
         build_ctx=build_ctx,
+        tag=tag,
         model_store=_model_store,
     ).save(_bento_store)
     logger.info(


### PR DESCRIPTION
Adds two features to `bentoml build`:
 - can now set the tag of the output bento (like `docker build`) with `--tag <bento>:<ver>` or `--tag <bento> --version <ver>`
 - `build_ctx` is now automatically guessed from the `bentofile` parameter if the `bentofile` parameter is absolute, so commands like `bentoml build -f /path/to/bento/bentofile.yaml` should work as expected.

/cc @bojiang 
