### PR TITLE
fix: import model from S3

### DIFF
--- a/bentoml/_internal/exportable.py
+++ b/bentoml/_internal/exportable.py
@@ -161,7 +161,7 @@ class Exportable(ABC):
                     fs.copy.copy_dir(input_fs, subpath, tempfs, filename)
                 else:
                     input_fs = fs.open_fs(input_uri)
-                    fs.copy.copy_file(input_fs, subpath, input_fs, filename)
+                    fs.copy.copy_file(input_fs, subpath, tempfs, filename)
 
                 res = cls._from_compressed(tempfs.getsyspath(filename), input_format)
 


### PR DESCRIPTION
## Description
There was an error when importing a model from S3 using the command:
```
bentoml models import s3://my-bucket/models/my_model.bentomodel
```
The first error appeared in `copy.py` file from `fs` package:
```
TypeError: copy() got an unexpected keyword argument 'preserve_time'.
```
After removing this param on `fs` package for testing, the error changed:
```
botocore.exceptions.ClientError: An error occurred (InvalidRequest) when calling the CopyObject operation: This copy request is illegal because it is trying to copy an object to itself without changing the object's metadata, storage class, website redirect location or encryption attributes.
```
When looking into file `exportable.py`, I noticed an error on `copy_file` method, that was trying to copy a file over itself.
After a change, the errors gone...  and nothing is related to `fs` package.  That's ok.

## Motivation and Context
I was trying to use a S3 bucket to store my models.  Exporting was fine but error on importing a model back to my local model store.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Saved a picklable_model with `save` method.
- Exported the model to a S3 bucket using API:
```
bentoml.models.export_model(tag,'s3://my-bucket/models/my_model.bentomodel')
```
- Cleared local model store;
- Ran command:
```
bentoml models import s3://my-bucket/models/my_model.bentomodel
```
@timliubentoml helped me on testing with Slack support. Thanks Tim!

Bentoml v1.0.0a6

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [] My code follows the bentoml code style, both `make format` and
  `make lint` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly