### PR TITLE
fix: extract correct desired Python version

### DIFF
--- a/bentoml/_internal/bento/docker/init.sh
+++ b/bentoml/_internal/bento/docker/init.sh
@@ -20,9 +20,9 @@ if [ $# -eq 0 ] || [ $1 == "ensure_python" ] ; then
   if [ -f ./env/python/version.txt ]; then
     PY_VERSION_SAVED=$(cat ./env/python/version.txt)
     # remove PATCH version - since most patch version only contains backwards compatible
-    # bug fixes and the BentoML defautl docker base image will include the latest
+    # bug fixes and the BentoML default docker base image will include the latest
     # patch version of each Python minor release
-    DESIRED_PY_VERSION=${PY_VERSION_SAVED:0:3} # returns 3.7, 3.8 or 3.9
+    DESIRED_PY_VERSION=${PY_VERSION_SAVED%.*} # returns major.minor
     CURRENT_PY_VERSION=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 
     if [[ "$DESIRED_PY_VERSION" == "$CURRENT_PY_VERSION" ]]; then


### PR DESCRIPTION
## Description

This PR proposes a fix for the way that the desired Python version of the Docker image is extracted by the `init.sh`.

## Motivation and Context

Currently, the `init.sh` script used by BentoML infers the desired Python version by slicing the value of the saved Python version, retrieving the first three chars. But if the saved Python version is >3.9 (such as 3.10), the script returns 3.1 as the desired Python version, which is incorrect.

The proposed change uses parameter expansion to remove the patch version from the saved Python version, fixing the issue.

## How Has This Been Tested?

I was unable to test the entire script, but I tested the area affected, and can confirm that it works. Since parameter expansion is native to bash, this modification should not break the code.

## Checklist:

- [ ] My code follows the bentoml code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly