### PR TITLE
feat(server): implement runner app

### DIFF
--- a/bentoml/_internal/models/model.py
+++ b/bentoml/_internal/models/model.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
         str, bool | BatchDimType | AnyType | tuple[AnyType] | None
     ]
 
+
 logger = logging.getLogger(__name__)
 
 PYTHON_VERSION: str = f"{pyver.major}.{pyver.minor}.{pyver.micro}"
@@ -51,7 +52,13 @@ MODEL_YAML_FILENAME = "model.yaml"
 CUSTOM_OBJECTS_FILENAME = "custom_objects.pkl"
 
 
-class ModelOptions(UserDict):
+if TYPE_CHECKING:
+    ModelOptionsSuper = UserDict[str, t.Any]
+else:
+    ModelOptionsSuper = UserDict
+
+
+class ModelOptions(ModelOptionsSuper):
     @classmethod
     def with_options(cls, **kwargs: t.Any) -> ModelOptions:
         if len(kwargs) != 0:
@@ -87,11 +94,11 @@ class Model(StoreItem):
         return self._tag
 
     @property
-    def _fs(self) -> "FS":
+    def _fs(self) -> FS:
         return self.__fs
 
     @property
-    def info(self) -> "ModelInfo":
+    def info(self) -> ModelInfo:
         return self._info
 
     @property
@@ -278,7 +285,7 @@ class Model(StoreItem):
         name: str = "",
         cpu: int | None = None,
         nvidia_gpu: int | None = None,
-        custom_resources: dict[str, int | float] | None = None,
+        custom_resources: dict[str, float] | None = None,
         max_batch_size: int | None = None,
         max_latency_ms: int | None = None,
         method_configs: dict[str, dict[str, int]] | None = None,

--- a/bentoml/_internal/runner/container.py
+++ b/bentoml/_internal/runner/container.py
@@ -22,7 +22,8 @@ if TYPE_CHECKING:
 
 class Payload(t.NamedTuple):
     data: bytes
-    meta: t.Dict[str, t.Union[bool, int, float, str]]
+    meta: dict[str, bool | int | float | str]
+    container: str
 
 
 class DataContainer(t.Generic[SingleType, BatchType]):
@@ -32,7 +33,7 @@ class DataContainer(t.Generic[SingleType, BatchType]):
         data: bytes,
         meta: t.Optional[t.Dict[str, t.Union[bool, int, float, str]]] = None,
     ) -> Payload:
-        return Payload(data, dict(meta or dict(), container=cls.__name__))
+        return Payload(data, meta or {}, container=cls.__name__)
 
     @classmethod
     @abc.abstractmethod
@@ -61,15 +62,15 @@ class DataContainer(t.Generic[SingleType, BatchType]):
     @classmethod
     @abc.abstractmethod
     def batch_to_payloads(
-        cls, batch: BatchType, indices: list[int], batch_dim: int
+        cls, batch: BatchType, indices: t.Sequence[int], batch_dim: int
     ) -> t.List[Payload]:
         ...
 
     @classmethod
     @abc.abstractmethod
     def from_batch_payloads(
-        cls, payloads: t.List[Payload], batch_dim: int
-    ) -> t.Tuple[BatchType, t.List[int]]:
+        cls, payloads: t.Sequence[Payload], batch_dim: int
+    ) -> tuple[BatchType, list[int]]:
         ...
 
 
@@ -160,7 +161,7 @@ class NdarrayContainer(
     @inject
     def from_batch_payloads(  # pylint: disable=arguments-differ
         cls,
-        payloads: t.List[Payload],
+        payloads: t.Sequence[Payload],
         batch_dim: int = 0,
         plasma_db: "ext.PlasmaClient" = Provide[DeploymentContainer.plasma_db],
     ) -> t.Tuple["ext.NpNDArray", t.List[int]]:
@@ -351,55 +352,42 @@ register_builtin_containers()
 
 class AutoContainer(DataContainer[t.Any, t.Any]):
     @classmethod
-    def singles_to_batch(cls, singles: t.Any, batch_axis: int = 0):
-        container_cls = DataContainerRegistry.find_by_single_type(type(singles[0]))
-        return container_cls.singles_to_batch(singles, batch_axis=batch_axis)
-
-    @classmethod
-    def batch_to_singles(cls, batch: t.Any, batch_axis: int = 0) -> t.List[t.Any]:
-        container_cls = DataContainerRegistry.find_by_batch_type(type(batch))
-        return container_cls.batch_to_singles(batch, batch_axis=batch_axis)
-
-    @classmethod
-    def single_to_payload(cls, single: SingleType) -> Payload:  # type: ignore[override]
+    def to_payload(cls, single: t.Any) -> Payload:
         container_cls = DataContainerRegistry.find_by_single_type(type(single))
-        return container_cls.single_to_payload(single)
+        return container_cls.to_payload(single)
 
     @classmethod
-    def payload_to_single(
-        cls,
-        payload: Payload,
-    ) -> SingleType:  # type: ignore[override]
-        container_cls = DataContainerRegistry.find_by_name(
-            str(payload.meta.get("container"))
-        )
-        return container_cls.payload_to_single(payload)
+    def from_payload(cls, payload: Payload) -> tuple[t.Any, list[int]]:
+        container_cls = DataContainerRegistry.find_by_name(payload.container)
+        return container_cls.from_payload(payload)
 
     @classmethod
-    def payload_to_batch(cls, payload: Payload) -> BatchType:  # type: ignore[override]
-        container_cls = DataContainerRegistry.find_by_name(
-            str(payload.meta.get("container"))
-        )
-        return container_cls.payload_to_batch(payload)
+    def batches_to_batch(
+        cls, batches: t.Sequence[BatchType], batch_dim: int = 0
+    ) -> tuple[BatchType, list[int]]:
+        container_cls = DataContainerRegistry.find_by_batch_type(type(batches[0]))
+        return container_cls.batches_to_batch(batches, batch_dim)
 
     @classmethod
-    @abc.abstractmethod
-    def batch_to_payload(cls, batch: BatchType) -> Payload:  # type: ignore[override]
+    def batch_to_batches(
+        cls, batch: BatchType, indices: list[int], batch_dim: int = 0
+    ) -> list[BatchType]:
         container_cls = DataContainerRegistry.find_by_batch_type(type(batch))
-        return container_cls.batch_to_payload(batch)
-
-    @classmethod
-    def payloads_to_batch(cls, payload_list: t.Sequence[Payload], batch_axis: int = 0):
-        container_cls = DataContainerRegistry.find_by_name(
-            str(payload_list[0].meta.get("container"))
-        )
-        return container_cls.payloads_to_batch(payload_list, batch_axis=batch_axis)
+        return container_cls.batch_to_batches(batch, indices, batch_dim)
 
     @classmethod
     def batch_to_payloads(
         cls,
-        batch: BatchType,  # type: ignore[override]
-        batch_axis: int = 0,
+        batch: t.Any,
+        indices: list[int],
+        batch_dim: int = 0,
     ) -> t.List[Payload]:
         container_cls = DataContainerRegistry.find_by_batch_type(type(batch))
-        return container_cls.batch_to_payloads(batch, batch_axis=batch_axis)
+        return container_cls.batch_to_payloads(batch, indices, batch_dim)
+
+    @classmethod
+    def from_batch_payloads(
+        cls, payloads: list[Payload], batch_dim: int = 0
+    ) -> tuple[t.Any, list[int]]:
+        container_cls = DataContainerRegistry.find_by_name(payloads[0].container)
+        return container_cls.from_batch_payloads(payloads, batch_dim)

--- a/bentoml/_internal/runner/runnable.py
+++ b/bentoml/_internal/runner/runnable.py
@@ -6,6 +6,7 @@ import logging
 import functools
 from abc import ABC
 from typing import TYPE_CHECKING
+from collections.abc import Mapping
 
 if TYPE_CHECKING:
     WrappedMethod = t.TypeVar("WrappedMethod", bound=t.Callable[..., t.Any])
@@ -18,10 +19,9 @@ from bentoml._internal.types import LazyType
 logger = logging.getLogger(__name__)
 
 RUNNABLE_METHOD_MARK: str = "_bentoml_runnable_method"
-# BatchDimType: t.TypeAlias = t.Tuple[t.List[int] | int, t.List[int] | int] | int
-BatchDimType: t.TypeAlias = t.Union[
-    t.Tuple[t.Union[t.List[int], int], t.Union[t.List[int], int]], int
-]
+# not usable because attrs is unable to resolve the type at runtime
+# BatchDimType: t.TypeAlias = tuple[list[int] | int, list[int] | int] | int
+BatchDimType: t.TypeAlias = t.Union[t.Tuple[t.Union[t.List[int], int], int], int]
 
 
 class Runnable(ABC):
@@ -61,12 +61,16 @@ class Runnable(ABC):
         output_spec: AnyType | None = None,
     ) -> t.Callable[[WrappedMethod], WrappedMethod] | WrappedMethod:
         def method_decorator(meth: WrappedMethod) -> WrappedMethod:
+            params = inspect.signature(meth).parameters
+
+            mapped_batch_dim = BatchDimMapping(batch_dim, params)
+
             setattr(
                 meth,
                 RUNNABLE_METHOD_MARK,
                 RunnableMethodConfig(
                     batchable=batchable,
-                    batch_dim=batch_dim,
+                    batch_dim=mapped_batch_dim,
                     input_spec=input_spec,
                     output_spec=output_spec,
                 ),
@@ -88,9 +92,84 @@ class Runnable(ABC):
         }
 
 
+if TYPE_CHECKING:
+    BatchDimSuper = Mapping[str | int, int]
+else:
+    BatchDimSuper = Mapping
+
+
+class BatchDimMapping(BatchDimSuper):
+    args: list[int]
+    kwargs: dict[str, int]
+    ret: int
+    var_arg: int | None = None
+    var_kw: int | None = None
+
+    def __init__(
+        self, batch_dim: BatchDimType, params: t.Mapping[str, inspect.Parameter]
+    ):
+        def get_batch_dim(idx: int) -> int:
+            if isinstance(batch_dim, tuple):
+                if idx == -1:
+                    return batch_dim[1]
+                elif isinstance(batch_dim[0], list):
+                    return batch_dim[0][idx]
+                else:
+                    return batch_dim[0]
+            else:
+                return batch_dim
+
+        self.args = []
+        self.kwargs = {}
+        for i, (name, param) in enumerate(params.items()):
+            if param.kind in [
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            ]:
+                self.args.append(get_batch_dim(i))
+            elif param.kind == inspect.Parameter.KEYWORD_ONLY:
+                self.kwargs[name] = get_batch_dim(i)
+            elif param.kind == inspect.Parameter.VAR_KEYWORD:
+                self.var_kw = get_batch_dim(i)
+            else:
+                self.var_arg = get_batch_dim(i)
+
+        self.ret = get_batch_dim(-1)
+
+    def __getitem__(self, key: str | int) -> int:
+        if isinstance(key, int):
+            if key < 0:
+                return self.ret
+            if key < len(self.args):
+                return self.args[key]
+            elif self.var_arg is not None:
+                return self.var_arg
+            else:
+                raise KeyError(f"{key} not found")
+        else:
+            try:
+                res = self.kwargs[key]
+            except KeyError:
+                if self.var_kw is not None:
+                    res = self.var_kw
+                else:
+                    raise
+
+            return res
+
+    def __iter__(self) -> t.Iterator[str | int]:
+        for i, _ in enumerate(self.args):
+            yield i
+        for key in self.kwargs:
+            yield key
+
+    def __len__(self) -> int:
+        return len(self.args) + len(self.kwargs)
+
+
 @attr.define()
 class RunnableMethodConfig:
     batchable: bool
-    batch_dim: BatchDimType
+    batch_dim: BatchDimMapping
     input_spec: AnyType | t.Tuple[AnyType, ...] | None = None
     output_spec: AnyType | None = None

--- a/bentoml/_internal/runner/strategy.py
+++ b/bentoml/_internal/runner/strategy.py
@@ -6,16 +6,10 @@ import logging
 
 import attr
 
+from .resource import Resource
 from .runnable import Runnable
 
 logger = logging.getLogger(__name__)
-
-
-@attr.define(frozen=True)
-class Resource:
-    cpu: int = attr.field()
-    nvidia_gpu: int = attr.field()
-    custom_resources: t.Dict[str, t.Union[float, int]] = attr.field(factory=dict)
 
 
 class Strategy(abc.ABC):

--- a/bentoml/_internal/server/cli/api_server.py
+++ b/bentoml/_internal/server/cli/api_server.py
@@ -64,6 +64,10 @@ def main(
         If True, start the server as a bare worker. Else, start a standalone server
         with a supervisor process.
     """
+    from ...configuration.containers import DeploymentContainer
+
+    DeploymentContainer.api_server_config.development_mode.set(False)
+
     if not as_worker:
         # Start a standalone server with a supervisor process
         from circus.watcher import Watcher
@@ -99,8 +103,6 @@ def main(
 
     log_level = "info"
     if runner_map is not None:
-        from ...configuration.containers import DeploymentContainer
-
         DeploymentContainer.remote_runner_mapping.set(json.loads(runner_map))
     svc = bentoml.load(
         bento_identifier, working_dir=working_dir, change_global_cwd=True

--- a/bentoml/_internal/server/cli/dev_api_server.py
+++ b/bentoml/_internal/server/cli/dev_api_server.py
@@ -29,6 +29,9 @@ def main(
     import uvicorn  # type: ignore
 
     from ...configuration import get_debug_mode
+    from ...configuration.containers import DeploymentContainer
+
+    DeploymentContainer.api_server_config.development_mode.set(True)
 
     ServiceContext.component_name_var.set("dev_api_server")
 

--- a/bentoml/_internal/server/cli/runner.py
+++ b/bentoml/_internal/server/cli/runner.py
@@ -88,7 +88,8 @@ def main(
     ServiceContext.component_name_var.set(runner_name)
 
     svc = load(bento_identifier, working_dir=working_dir, change_global_cwd=True)
-    runner = svc.runners[runner_name]
+    runner = next(filter(lambda r: r.name == runner_name, svc.runners))
+
     app = t.cast("ASGI3Application", RunnerAppFactory(runner)())
 
     parsed = urlparse(bind)

--- a/bentoml/_internal/server/instruments.py
+++ b/bentoml/_internal/server/instruments.py
@@ -77,7 +77,7 @@ class MetricsMiddleware:
             return
 
         service_version = (
-            self.bento_service.version if self.bento_service.version is not None else ""
+            self.bento_service.tag.version if self.bento_service.tag is not None else ""
         )
         endpoint = scope["path"]
         START_TIME_VAR.set(default_timer())

--- a/bentoml/_internal/server/runner_app.py
+++ b/bentoml/_internal/server/runner_app.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import json
 import typing as t
 import asyncio
 import logging
-import functools
 from typing import TYPE_CHECKING
 from functools import partial
 
@@ -11,6 +12,7 @@ from ..runner.utils import Params
 from ..runner.utils import PAYLOAD_META_HEADER
 from ..runner.utils import multipart_to_payload_params
 from ..server.base_app import BaseAppFactory
+from ..runner.container import Payload
 from ..runner.container import AutoContainer
 from ..marshal.dispatcher import CorkDispatcher
 from ..configuration.containers import DeploymentContainer
@@ -29,11 +31,14 @@ if TYPE_CHECKING:
     from ..runner.runner import RunnerMethod
 
 
+T = t.TypeVar("T")
+
+
 class RunnerAppFactory(BaseAppFactory):
     def __init__(
         self,
-        runner: "Runner",
-        instance_id: t.Optional[int] = None,
+        runner: Runner,
+        instance_id: int | None = None,
     ) -> None:
         self.runner = runner
         self.instance_id = instance_id
@@ -59,19 +64,19 @@ class RunnerAppFactory(BaseAppFactory):
     @property
     def on_startup(self) -> t.List[t.Callable[[], None]]:
         on_startup = super().on_startup
-        on_startup.insert(0, self.runner.init_local)
+        on_startup.insert(0, self.runner._init_local)  # type: ignore
         return on_startup
 
     @property
     def on_shutdown(self) -> t.List[t.Callable[[], None]]:
-        on_shutdown = super().on_shutdown
-        on_shutdown.insert(0, self.runner.destroy)
+        on_shutdown = [self.runner.destroy]
         for dispatcher in self.dispatchers.values():
-            on_shutdown.insert(0, dispatcher.shutdown)
+            on_shutdown.append(dispatcher.shutdown)
+        on_shutdown.extend(super().on_shutdown)
         return on_shutdown
 
     @property
-    def routes(self) -> t.List["BaseRoute"]:
+    def routes(self) -> t.List[BaseRoute]:
         """
         Setup routes for Runner server, including:
 
@@ -86,10 +91,10 @@ class RunnerAppFactory(BaseAppFactory):
 
         routes = super().routes
         for method in self.runner.runner_methods:
-            path = "/" if method.name == "__call__" else method.name
-            if not method.runnable_method_config.batchable:
+            path = "/" if method.name == "__call__" else "/" + method.name
+            if method.runnable_method_config.batchable:
                 _func = self.dispatchers[method.name](
-                    functools.partial(self._async_cork_run, runner_method=method)
+                    self._async_cork_run(runner_method=method)
                 )
                 routes.append(
                     Route(
@@ -102,28 +107,26 @@ class RunnerAppFactory(BaseAppFactory):
                 routes.append(
                     Route(
                         path=path,
-                        endpoint=functools.partial(
-                            self.async_run, runner_method=method
-                        ),
+                        endpoint=self.async_run(runner_method=method),
                         methods=["POST"],
                     )
                 )
         return routes
 
     @property
-    def middlewares(self) -> t.List["Middleware"]:
+    def middlewares(self) -> list[Middleware]:
         middlewares = super().middlewares
 
         # otel middleware
         import opentelemetry.instrumentation.asgi as otel_asgi  # type: ignore[import]
         from starlette.middleware import Middleware
 
-        def client_request_hook(span: "Span", _scope: t.Dict[str, t.Any]) -> None:
+        def client_request_hook(span: Span, _scope: t.Dict[str, t.Any]) -> None:
             if span is not None:
                 span_id: int = span.context.span_id
                 ServiceContext.request_id_var.set(span_id)
 
-        def client_response_hook(span: "Span", _message: t.Any) -> None:
+        def client_response_hook(span: Span, _message: t.Any) -> None:
             if span is not None:
                 ServiceContext.request_id_var.set(None)
 
@@ -155,58 +158,104 @@ class RunnerAppFactory(BaseAppFactory):
 
         return middlewares
 
-    async def _async_cork_run(
+    def _async_cork_run(
         self,
-        runner_method: "RunnerMethod",
-        requests: t.Iterable["Request"],
-    ) -> t.List["Response"]:
+        runner_method: RunnerMethod,
+    ) -> t.Callable[[t.Iterable[Request]], t.Coroutine[None, None, list[Response]]]:
         from starlette.responses import Response
 
-        assert self._is_ready
+        async def _run(requests: t.Iterable[Request]) -> list[Response]:
+            assert self._is_ready
 
-        params_list = await asyncio.gather(
-            *tuple(multipart_to_payload_params(r) for r in requests)
-        )
-        params = Params.agg(
-            params_list,
-            lambda i: AutoContainer.payloads_to_batch(
-                i,
-                batch_axis=runner_method.runnable_method_config.batch_dim,
-            ),
-        )
-        batch_ret = await runner_method.async_run(*params.args, **params.kwargs)
-        payloads = AutoContainer.batch_to_payloads(
-            batch_ret,
-            batch_axis=runner_method.runnable_method_config.batch_dim,
-        )
-        return [
-            Response(
+            params_list = await asyncio.gather(
+                *tuple(multipart_to_payload_params(r) for r in requests)
+            )
+
+            batch_dim = runner_method.runnable_method_config.batch_dim
+
+            indices: list[int] = []
+
+            i = 0
+            batch_args: list[t.Any] = []
+            while i in batch_dim.args:
+                args = [param.args[i] for param in params_list]
+                batched_arg, indices = AutoContainer.from_batch_payloads(
+                    args, batch_dim=batch_dim[i]
+                )
+                batch_args.append(batched_arg)
+                i += 1
+
+            found = True
+            while found:
+                found = False
+                args: list[t.Any] = []
+                for params in params_list:
+                    if len(params.args) > i:
+                        args.append(None)
+                        continue
+                    else:
+                        found = True
+                        args.append(params.args[i])
+                if found:
+                    batched_arg, indices = AutoContainer.from_batch_payloads(
+                        args, batch_dim=batch_dim[i]
+                    )
+                    batch_args.append(batched_arg)
+                    i += 1
+
+            kwargs: dict[str, list[Payload | None]] = {}
+            for i, params in enumerate(params_list):
+                for kwarg in params.kwargs:
+                    kwarg_list: list[Payload | None] = kwargs.get(kwarg, [None] * i)
+                    kwarg_list.append(params.kwargs[kwarg])
+                    kwargs[kwarg] = kwarg_list
+
+            batch_kwargs = {}
+            for kwarg, payloads in kwargs.items():
+                batch_kwargs[kwargs], indices = AutoContainer.from_batch_payloads(
+                    payloads, batch_dim=batch_dim[kwarg]
+                )
+
+            batch_ret = await runner_method.async_run(*batch_args, **batch_kwargs)
+
+            payloads = AutoContainer.batch_to_payloads(
+                batch_ret,
+                indices,
+                batch_dim=batch_dim[-1],
+            )
+            return [
+                Response(
+                    payload.data,
+                    headers={
+                        PAYLOAD_META_HEADER: json.dumps(payload.meta),
+                        "Server": f"BentoML-Runner/{self.runner.name}/{runner_method.name}/{self.instance_id}",
+                    },
+                )
+                for payload in payloads
+            ]
+
+        return _run
+
+    def async_run(
+        self,
+        runner_method: RunnerMethod,
+    ) -> t.Callable[[Request], t.Coroutine[None, None, Response]]:
+        from starlette.responses import Response
+
+        async def _run(request: Request) -> Response:
+            assert self._is_ready
+
+            logger.info(request)
+            params = await multipart_to_payload_params(request)
+            params = params.map(AutoContainer.from_payload)
+            ret = await runner_method.async_run(*params.args, **params.kwargs)
+            payload = AutoContainer.to_payload(ret)
+            return Response(
                 payload.data,
                 headers={
                     PAYLOAD_META_HEADER: json.dumps(payload.meta),
                     "Server": f"BentoML-Runner/{self.runner.name}/{runner_method.name}/{self.instance_id}",
                 },
             )
-            for payload in payloads
-        ]
 
-    async def async_run(
-        self,
-        runner_method: "RunnerMethod",
-        request: "Request",
-    ) -> "Response":
-        from starlette.responses import Response
-
-        assert self._is_ready
-
-        params = await multipart_to_payload_params(request)
-        params = params.map(AutoContainer.payload_to_single)
-        ret = await runner_method.async_run(*params.args, **params.kwargs)
-        payload = AutoContainer.single_to_payload(ret)
-        return Response(
-            payload.data,
-            headers={
-                PAYLOAD_META_HEADER: json.dumps(payload.meta),
-                "Server": f"BentoML-Runner/{self.runner.name}/{runner_method.name}/{self.instance_id}",
-            },
-        )
+        return _run

--- a/bentoml/_internal/utils/analytics/usage_stats.py
+++ b/bentoml/_internal/utils/analytics/usage_stats.py
@@ -137,24 +137,20 @@ def _track_serve_init(
             api_output_types=[api.output_type for api in bento.info.apis],
         )
     else:
-        from ...frameworks.common.model_runner import BaseModelRunner
-        from ...frameworks.common.model_runner import BaseModelSimpleRunner
-
         event_properties = ServeInitEvent(
             serve_id=serve_info.serve_id,
             serve_from_bento=False,
             production=production,
             bento_creation_timestamp=None,
             num_of_models=len(
-                [
-                    r
-                    for r in svc.runners
-                    if isinstance(r, (BaseModelRunner, BaseModelSimpleRunner))
-                ]
+                set(
+                    svc.models
+                    + [model for runner in svc.runners for model in runner.models]
+                )
             ),
             num_of_runners=len(svc.runners),
             num_of_apis=len(svc.apis.keys()),
-            runner_types=[type(v).__name__ for v in svc.runners.values()],
+            runner_types=[type(v).__name__ for v in svc.runners],
             api_input_types=[api.input.__class__.__name__ for api in svc.apis.values()],
             api_output_types=[
                 api.output.__class__.__name__ for api in svc.apis.values()

--- a/bentoml/_internal/utils/formparser.py
+++ b/bentoml/_internal/utils/formparser.py
@@ -140,17 +140,17 @@ async def populate_multipart_requests(request: Request) -> t.Dict[str, Request]:
     content_type_header = request.headers.get("Content-Type")
     content_type, _ = multipart.parse_options_header(content_type_header)
     assert content_type in (b"multipart/form-data", b"multipart/mixed")
-    stream = t.cast(t.AsyncGenerator[bytes, None], request.stream())
+    stream = request.stream()
     multipart_parser = MultiPartParser(request.headers, stream)
     try:
         form = await multipart_parser.parse()
     except multipart.MultipartParseError:
         raise BentoMLException("Invalid multipart requests")
 
-    reqs = dict()  # type: t.Dict[str, Request]
+    reqs: dict[str, Request] = dict()
     for field_name, headers, data in form:
         scope = dict(request.scope)
-        ori_headers = dict(scope.get("headers", list()))
+        ori_headers = dict(scope.get("headers", dict()))
         ori_headers = t.cast(t.Dict[bytes, bytes], ori_headers)
         ori_headers.update(dict(headers))
         scope["headers"] = list(ori_headers.items())

--- a/bentoml/models.py
+++ b/bentoml/models.py
@@ -7,6 +7,8 @@ from contextlib import contextmanager
 from simple_di import inject
 from simple_di import Provide
 
+from bentoml._internal.models.model import ModelSignature
+
 from ._internal.tag import Tag
 from ._internal.utils import calc_dir_size
 from ._internal.models import Model
@@ -224,7 +226,7 @@ def create(
     name: str,
     *,
     module: str = "",
-    signatures: dict[str, dict[str, bool]],
+    signatures: dict[str, dict[str, bool]] | dict[str, ModelSignature],
     labels: dict[str, t.Any] | None = None,
     options: ModelOptions | None = None,
     custom_objects: dict[str, t.Any] | None = None,


### PR DESCRIPTION
`*args` and `**kwargs` are now handled like so:

```python
@Runnable.method(batchable=True, batch_dim=([1], 0))
def my_runner_method(*args):
    ...
```

Will have all arguments to `my_runner_method` batched with index 1.

Probably worth looking at this later, but for now this is probably good enough.