### PR TITLE
fix: onnx framework added providers

### DIFF
--- a/bentoml/frameworks/onnx.py
+++ b/bentoml/frameworks/onnx.py
@@ -22,11 +22,7 @@ def _is_path_like(path):
 
 
 def _is_onnx_model_file(path):
-    return (
-        _is_path_like(path)
-        and os.path.isfile(path)
-        and str(path).lower().endswith(".onnx")
-    )
+    return _is_path_like(path) and os.path.isfile(path) and str(path).lower().endswith(".onnx")
 
 
 class OnnxModelArtifact(BentoServiceArtifact):
@@ -93,23 +89,69 @@ class OnnxModelArtifact(BentoServiceArtifact):
     >>> svc.save()
     """
 
-    def __init__(self, name, backend="onnxruntime"):
+
+    """
+    dnchoi example code
+
+    new feature:
+    ONNX framework get instance -> name, backend, providers(added)
+
+    Ex)
+    import bentoml
+    import cv2
+    import numpy as np
+    from bentoml import BentoService, artifacts, env
+    from bentoml.adapters import JsonInput, JsonOutput
+    from bentoml.artifact import OnnxModelArtifact
+    from svc.object_detector.detector import model_predict
+
+    @bentoml.env(
+        infer_pip_packages=True,
+        pip_packages=["onnxruntime-gpu"],
+        requirements_txt_file="./requirements.txt",
+        docker_base_image="bentoml/model-server:0.13.1-slim-py38",
+    )
+    @bentoml.artifacts(
+        [
+            OnnxModelArtifact(
+                "model",
+                backend="onnxruntime-gpu",
+                providers=["CUDAExecutionProvider", "CPUExecutionProvider"]
+            )
+        ]
+    )
+    class api_service(BentoService):
+        @bentoml.api(
+            input=JsonInput(
+                http_input_example=[
+                    {
+                        "uuid": "401c739d-d94c-4bd2-a795-9a8740e655b4",
+                        "picture": "/9j/4AAQSkZJRgABAQAAAQ...",
+                    }
+                ],
+            ),
+            output=JsonOutput(),
+            batch=False,
+        )
+        def predict(self, parsed_json):
+            response = model_predict.detect(self.artifacts.model, parsed_json)
+            return response
+
+    """
+    def __init__(self, name, backend="onnxruntime", providers=None):
         super().__init__(name)
         if backend not in SUPPORTED_ONNX_BACKEND:
-            raise BentoMLException(
-                f'"{backend}" runtime is currently not supported for OnnxModelArtifact'
-            )
+            raise BentoMLException(f'"{backend}" runtime is currently not supported for OnnxModelArtifact')
         self.backend = backend
         self._inference_session = None
+        self._provider = providers
         self._onnx_model_path = None
         self._model_proto = None
 
     def _saved_model_file_path(self, base_path):
         return os.path.join(base_path, self.name + ".onnx")
 
-    def pack(
-        self, path_or_model_proto, metadata=None
-    ):  # pylint:disable=arguments-renamed
+    def pack(self, path_or_model_proto, metadata=None):  # pylint:disable=arguments-renamed
         if _is_onnx_model_file(path_or_model_proto):
             self._onnx_model_path = path_or_model_proto
         else:
@@ -120,13 +162,11 @@ class OnnxModelArtifact(BentoServiceArtifact):
                     self._model_proto = path_or_model_proto
                 else:
                     raise InvalidArgument(
-                        "onnx.ModelProto or a .onnx model file path is required to "
-                        "pack an OnnxModelArtifact"
+                        "onnx.ModelProto or a .onnx model file path is required to " "pack an OnnxModelArtifact"
                     )
             except ImportError:
                 raise InvalidArgument(
-                    "onnx.ModelProto or a .onnx model file path is required to pack "
-                    "an OnnxModelArtifact"
+                    "onnx.ModelProto or a .onnx model file path is required to pack " "an OnnxModelArtifact"
                 )
 
         assert self._onnx_model_path or self._model_proto, (
@@ -152,30 +192,22 @@ class OnnxModelArtifact(BentoServiceArtifact):
                 import onnxruntime
             except ImportError:
                 raise MissingDependencyException(
-                    f'"{self.backend}" package is required for inference with '
-                    f'"{self.backend}" as backend"'
+                    f'"{self.backend}" package is required for inference with ' f'"{self.backend}" as backend"'
                 )
 
             if self._model_proto:
-                logger.info(
-                    "Initializing onnxruntime InferenceSession with onnx.ModelProto "
-                    "instance"
-                )
-                return onnxruntime.InferenceSession(
-                    self._model_proto.SerializeToString()
-                )
+                logger.info("Initializing onnxruntime InferenceSession with onnx.ModelProto " "instance")
+                return onnxruntime.InferenceSession(self._model_proto.SerializeToString())
             elif self._onnx_model_path:
                 logger.info(
-                    "Initializing onnxruntime InferenceSession from onnx file:"
-                    f"'{self._onnx_model_path}'"
+                    "Initializing onnxruntime InferenceSession from onnx file:" f"'{self._onnx_model_path}'"
                 )
-                return onnxruntime.InferenceSession(self._onnx_model_path)
+                return onnxruntime.InferenceSession(self._onnx_model_path, providers=self._provider)
             else:
                 raise BentoMLException("OnnxModelArtifact in bad state")
         else:
             raise BentoMLException(
-                f'"{self.backend}" runtime is currently not supported for '
-                f"OnnxModelArtifact"
+                f'"{self.backend}" runtime is currently not supported for ' f"OnnxModelArtifact"
             )
 
     def get(self):
@@ -196,6 +228,5 @@ class OnnxModelArtifact(BentoServiceArtifact):
             onnx.save_model(self._model_proto, self._saved_model_file_path(dst))
         else:
             raise InvalidArgument(
-                "onnx.ModelProto or a model file path is required to pack an "
-                "OnnxModelArtifact"
+                "onnx.ModelProto or a model file path is required to pack an " "OnnxModelArtifact"
             )


### PR DESCRIPTION
# fix: onnx framework added providers option

## Description
Added provider option when creating onnxruntime session.
When you get an instance of onnx framework, you need to add a provider.
- Changed __init__ function
![스크린샷 2022-05-19 오전 11 38 00](https://user-images.githubusercontent.com/70907162/169192417-9219e550-ffb2-41b6-848e-456eb46d797f.png)
- Changed _get_onnx_inference_session function
![스크린샷 2022-05-19 오전 11 39 04](https://user-images.githubusercontent.com/70907162/169192545-36348912-5e26-45af-893d-44c749ad34ff.png)

- Bento service example code, add providers
![스크린샷 2022-05-19 오전 11 41 33](https://user-images.githubusercontent.com/70907162/169192892-0bcc48dd-1113-49fa-a87a-6c0a777873e6.png)