### PR TITLE
chore(ci): cover add_asgi_middleware in e2e tests

### DIFF
--- a/bentoml/_internal/server/cli/dev_api_server.py
+++ b/bentoml/_internal/server/cli/dev_api_server.py
@@ -39,6 +39,7 @@ def main(
             "backlog": backlog,
             "log_config": LOGGING_CONFIG,
             "workers": 1,
+            "lifespan": "on",
         }
         if psutil.WINDOWS:
             uvicorn_options["loop"] = "asyncio"

--- a/bentoml/_internal/server/service_app.py
+++ b/bentoml/_internal/server/service_app.py
@@ -5,6 +5,7 @@ import sys
 import typing as t
 import asyncio
 import logging
+import functools
 from typing import TYPE_CHECKING
 
 from simple_di import inject
@@ -246,7 +247,7 @@ class ServiceAppFactory(BaseAppFactory):
         on_startup = [self.bento_service.on_asgi_app_startup]
         if DeploymentContainer.development_mode.get():
             for runner in self.bento_service.runners:
-                on_startup.append(runner._init_local)  # type: ignore
+                on_startup.append(functools.partial(runner.init_local, quiet=True))
         else:
             for runner in self.bento_service.runners:
                 on_startup.append(runner.init_client)

--- a/tests/e2e/bento_server_general_features/tests/test_meta.py
+++ b/tests/e2e/bento_server_general_features/tests/test_meta.py
@@ -14,6 +14,8 @@ async def test_api_server_meta(host: str) -> None:
     assert status == 200
     status, _, _ = await async_request("GET", f"http://{host}/livez")
     assert status == 200
+    status, _, _ = await async_request("GET", f"http://{host}/ping")
+    assert status == 200
     status, _, _ = await async_request("GET", f"http://{host}/docs.json")
     assert status == 200
     status, _, _ = await async_request("GET", f"http://{host}/readyz")


### PR DESCRIPTION
This usage is highly dependent by custom deployment like bentoctl