### PR TITLE
fix(store): use >= for time checking

### DIFF
--- a/bentoml/_internal/store.py
+++ b/bentoml/_internal/store.py
@@ -173,7 +173,7 @@ class Store(ABC, t.Generic[Item]):
             # item generation is most likely successful, link latest path
             if (
                 not self._fs.exists(_tag.latest_path())
-                or self.get(_tag).creation_time > self.get(_tag.name).creation_time
+                or self.get(_tag).creation_time >= self.get(_tag.name).creation_time
             ):
                 with self._fs.open(_tag.latest_path(), "w") as latest_file:
                     latest_file.write(_tag.version)


### PR DESCRIPTION
This deals with the fact that we only store times with second precision; this should not be an issue in practice because users should not be using "latest" in production code as it's meant as a convenience for local development.
