### PR TITLE
fix(cli): cli encoding error on Windows

### DIFF
--- a/bentoml/_internal/cli/__init__.py
+++ b/bentoml/_internal/cli/__init__.py
@@ -1,4 +1,5 @@
 import click
+import psutil
 
 from bentoml import __version__ as BENTOML_VERSION
 
@@ -29,6 +30,11 @@ def create_bentoml_cli():
     add_model_management_commands(cli)
     add_serve_command(cli)
     add_containerize_command(cli)
+
+    if psutil.WINDOWS:
+        import sys
+
+        sys.stdout.reconfigure(encoding="utf-8")  # type: ignore
 
     return cli
 


### PR DESCRIPTION
<!--- Thanks for sending a pull request!

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).

- feat: (new feature for the user, not a new feature for build script)
- fix: (bug fix for the user, not a fix to a build script)
- docs: (changes to the documentation)
- style: (formatting, missing semicolons, etc; no production code change)
- refactor: (refactoring production code, eg. renaming a variable)
- perf: (code changes that improve performance)
- test: (adding missing tests, refactoring tests; no production code change)
- chore: (updating grunt tasks etc; no production code change)
- build: (changes that affect the build system or external dependencies)
- ci: (changes to configuration files and scripts)
- revert: (reverts a previous commit)
-->

## Description
<!--- Describe your changes in detail -->
We are using `subprocess.check_output().encode()` to evoke other commands. But for Windows cmd.exe, the default encoding is not utf-8. So all features calling other commands like that will fail by default on Windows now.
<!--- Attach screenshots here if appropriate. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it is based on a conversation in slack channel, pls quote related messages here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `make format` and
  `make lint` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly