### PR TITLE
fix: Bug fix for 2596

### DIFF
--- a/bentoml/_internal/bento/docker/templates/base.j2
+++ b/bentoml/_internal/bento/docker/templates/base.j2
@@ -95,7 +95,7 @@ RUN --mount=type=cache,mode=0777,target=/root/.cache/pip \
 # else we will try to install from requirements.txt.
 RUN --mount=type=cache,mode=0777,target=/root/.cache/pip bash <<EOF
 if [ -f {{ __python_pip_args__ }} ]; then
-  EXTRA_PIP_INSTALL_ARGS="`cat /home/bentoml/bento/env/python/pip_args.txt`"
+  EXTRA_PIP_INSTALL_ARGS="`cat __python_pip_args__`"
 fi
 if [ -f {{ __python_requirements_lock__ }} ]; then
   echo "Installing pip packages from 'requirements.lock.txt'.."

--- a/bentoml/_internal/bento/docker/templates/base.j2
+++ b/bentoml/_internal/bento/docker/templates/base.j2
@@ -95,15 +95,15 @@ RUN --mount=type=cache,mode=0777,target=/root/.cache/pip \
 # else we will try to install from requirements.txt.
 RUN --mount=type=cache,mode=0777,target=/root/.cache/pip bash <<EOF
 if [ -f {{ __python_pip_args__ }} ]; then
-  EXTRA_PIP_INSTALL_ARGS=$(cat {{ __python_pip_args__ }})
+  EXTRA_PIP_INSTALL_ARGS="`cat /home/bentoml/bento/env/python/pip_args.txt`"
 fi
 if [ -f {{ __python_requirements_lock__ }} ]; then
   echo "Installing pip packages from 'requirements.lock.txt'.."
-  {{ bento__pip_cmd }} install -r {{ __python_requirements_lock__ }} -U $EXTRA_PIP_INSTALL_ARGS
+  {{ bento__pip_cmd }} install -r {{ __python_requirements_lock__ }} -U \$EXTRA_PIP_INSTALL_ARGS
 else
   if [ -f {{ __python_requirements_txt__ }} ]; then
     echo "Installing pip packages from 'requirements.txt'.."
-    {{ bento__pip_cmd }} install -r {{ __python_requirements_txt__ }} -U $EXTRA_PIP_INSTALL_ARGS
+    {{ bento__pip_cmd }} install -r {{ __python_requirements_txt__ }} -U \$EXTRA_PIP_INSTALL_ARGS
   fi
 fi
 EOF
@@ -112,7 +112,7 @@ EOF
 RUN bash <<EOF
 if [ -d {{ expands_bento_path("env", "python", "wheels", bento_path=bento__path) }} ]; then
   echo "Installing wheels.."
-  {{ bento__pip_cmd }} install {{ expands_bento_path("env", "python", "wheels", "*.whl", bento_path=bento__path) }} -U $EXTRA_PIP_INSTALL_ARGS
+  {{ bento__pip_cmd }} install {{ expands_bento_path("env", "python", "wheels", "*.whl", bento_path=bento__path) }} -U \$EXTRA_PIP_INSTALL_ARGS
 fi
 EOF
 

--- a/bentoml/_internal/bento/docker/templates/base.j2
+++ b/bentoml/_internal/bento/docker/templates/base.j2
@@ -95,7 +95,7 @@ RUN --mount=type=cache,mode=0777,target=/root/.cache/pip \
 # else we will try to install from requirements.txt.
 RUN --mount=type=cache,mode=0777,target=/root/.cache/pip bash <<EOF
 if [ -f {{ __python_pip_args__ }} ]; then
-  EXTRA_PIP_INSTALL_ARGS="`cat __python_pip_args__`"
+  EXTRA_PIP_INSTALL_ARGS="`cat {{ __python_pip_args__ }}`"
 fi
 if [ -f {{ __python_requirements_lock__ }} ]; then
   echo "Installing pip packages from 'requirements.lock.txt'.."


### PR DESCRIPTION
Safe cat of pip_args.txt in case there are mulitple options
Escape references to EXTRA_PIP_INSTALL_ARGS so they are evaluated correctly

## Description
cat of pip_args.txt was not safe if there are multiple options, i.e. there's a space between two options
references to variables created in a heredoc scripts need to be escaped with a single preceeding slash

## Motivation and Context
I was unable to build a container that referenced my internal package index.

## How Has This Been Tested?
Tested rebuild of containers with this change

## Checklist:
There is no python code change, just a tweak to the docker file template.
No documentation change.

I hope that is all enough? Thanks!

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] My code follows the bentoml code style, both `make format` and
  `make lint` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [ ] My change reduces project test coverage and requires unit tests to be added
- [ ] I have added unit tests covering my code change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly