### PR TITLE
fix: create wheels directory when BENTOML_BUNDLE_LOCAL_BUILD=True

### DIFF
--- a/bentoml/_internal/bento/build_config.py
+++ b/bentoml/_internal/bento/build_config.py
@@ -398,7 +398,7 @@ class PythonOptions:
     def write_to_bento(self, bento_fs: "FS", build_ctx: str) -> None:
         py_folder = fs.path.join("env", "python")
         wheels_folder = fs.path.join(py_folder, "wheels")
-        bento_fs.makedirs(py_folder, recreate=True)
+        bento_fs.makedirs(wheels_folder, recreate=True)
 
         # Save the python version of current build environment
         with bento_fs.open(fs.path.join(py_folder, "version.txt"), "w") as f:

--- a/bentoml/_internal/bento/build_dev_bentoml_whl.py
+++ b/bentoml/_internal/bento/build_dev_bentoml_whl.py
@@ -60,7 +60,7 @@ def build_bentoml_editable_wheel(target_path: str) -> None:
                 ],
             )
             # copy the built wheel file to target directory
-            shutil.copytree(dist_dir, target_path)  # type: ignore
+            shutil.copytree(dist_dir, target_path, dirs_exist_ok=True)  # type: ignore
     else:
         logger.info(
             "Custom BentoML build is detected. For a Bento to use the same build at serving time, add your custom BentoML build to the pip packages list, e.g. `packages=['git+https://github.com/bentoml/bentoml.git@13dfb36']`"


### PR DESCRIPTION
<!--- Thanks for sending a pull request!

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).

- feat: (new feature for the user, not a new feature for build script)
- fix: (bug fix for the user, not a fix to a build script)
- docs: (changes to the documentation)
- style: (formatting, missing semicolons, etc; no production code change)
- refactor: (refactoring production code, eg. renaming a variable)
- perf: (code changes that improve performance)
- test: (adding missing tests, refactoring tests; no production code change)
- chore: (updating grunt tasks etc; no production code change)
- build: (changes that affect the build system or external dependencies)
- ci: (changes to configuration files and scripts)
- revert: (reverts a previous commit)
-->

## Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
- Wheels folder should be created when BENTOML_BUNDLE_LOCAL_BUILD=True
- set `dirs_exist_ok` since wheels folder will be created via `write_to_bento`
- address #2618

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] My code follows the bentoml code style, both `make format` and
  `make lint` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)).
- [x] My change reduces project test coverage and requires unit tests to be added
- [x] I have added unit tests covering my code change
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
