### PR TITLE
docs: Add model in bentoml.pytorch.save_model() pytorch integration example

### DIFF
--- a/docs/source/frameworks/pytorch.rst
+++ b/docs/source/frameworks/pytorch.rst
@@ -28,7 +28,7 @@ Here's an example using PyTorch with BentoML:
     model = NGramLanguageModeler(len(vocab), EMBEDDING_DIM, CONTEXT_SIZE)
 
     # save the model to model store:
-    tag = bentoml.pytorch.save_model("ngrams", )
+    tag = bentoml.pytorch.save_model("ngrams", model)
 
     # get a BentoModel (a reference to model in model store) by tag:
     metadata = bentoml.models.get(tag)


### PR DESCRIPTION
In the pytorch section of framework-specific guides, model was not specified in the save_model() call.