### PR TITLE
chore(ci): always enable actions on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-      - runners-1.0
+  pull_request
   schedule:
     - cron: '0 0 * * 1/2'
 


### PR DESCRIPTION
Noticed there's no CI on #2645; let's just have actions run on every PR?