### PR TITLE
fix(tensorflow): register data container when eager execution is enabled

### DIFF
--- a/.github/workflows/frameworks.yml
+++ b/.github/workflows/frameworks.yml
@@ -1239,7 +1239,7 @@ jobs:
           fi
 
       - name: Upload test coverage to Codecov
-        if: ${{ needs.diff.outputs.tensorflow_v2 == 'true' }}
+        if: ${{ needs.diff.outputs.tf2 == 'true' }}
         uses: codecov/codecov-action@v2
         with:
           directory: ./

--- a/.github/workflows/frameworks.yml
+++ b/.github/workflows/frameworks.yml
@@ -1231,7 +1231,7 @@ jobs:
       - name: Run tensorflow_v2 without eager execution
         shell: bash
         run: |
-          OPTS=(--cov=bentoml --cov-config=./setup.cfg --cov-report=xml:"tf2.unit.no_eager.xml" --cov-report term-missing:skip-covered --disable-eager-execution)
+          OPTS=(--cov=bentoml --cov-config=./setup.cfg --cov-report=xml:"tf2.unit.no_eager.xml" --cov-report term-missing:skip-covered --disable-tf-eager-execution)
           python -m pytest ./tests/integration/frameworks/test_tensorflow_v2_unit.py "${OPTS[@]}" || ERR=1
           if [ $ERR -eq 1 ]; then
             echo "unit tests for tensorflow_v2 failed!"

--- a/.github/workflows/frameworks.yml
+++ b/.github/workflows/frameworks.yml
@@ -199,7 +199,8 @@ jobs:
               - *runner
               - bentoml/tensorflow.py
               - bentoml/_internal/frameworks/tensorflow_v2.py
-              - tests/integration/frameworks/test_tensorflow_v2_impl.py
+              - tests/integration/frameworks/models/tensorflow_v2.py
+              - tests/integration/frameworks/tensorflow_v2_unit.py
             keras_tf2:
               - *runner
               - *tf2

--- a/.github/workflows/frameworks.yml
+++ b/.github/workflows/frameworks.yml
@@ -1218,12 +1218,32 @@ jobs:
         run: make tests-tensorflow_v2
         shell: bash
 
+      - name: Run unit test for tensorflow_v2
+        shell: bash
+        run: |
+          OPTS=(--cov=bentoml --cov-config=./setup.cfg --cov-report=xml:"tf2.unit.xml" --cov-report term-missing:skip-covered)
+          python -m pytest ./tests/integration/frameworks/test_tensorflow_v2_unit.py "${OPTS[@]}" || ERR=1
+          if [ $ERR -eq 1 ]; then
+            echo "unit tests for tensorflow_v2 failed!"
+            exit 1
+          fi
+
+      - name: Run tensorflow_v2 without eager execution
+        shell: bash
+        run: |
+          OPTS=(--cov=bentoml --cov-config=./setup.cfg --cov-report=xml:"tf2.unit.no_eager.xml" --cov-report term-missing:skip-covered --disable-eager-execution)
+          python -m pytest ./tests/integration/frameworks/test_tensorflow_v2_unit.py "${OPTS[@]}" || ERR=1
+          if [ $ERR -eq 1 ]; then
+            echo "unit tests for tensorflow_v2 failed!"
+            exit 1
+          fi
+
       - name: Upload test coverage to Codecov
-        if: ${{ needs.diff.outputs.tf2 == 'true' }}
+        if: ${{ needs.diff.outputs.tensorflow_v2 == 'true' }}
         uses: codecov/codecov-action@v2
         with:
           directory: ./
-          files: ./tf2.xml
+          files: ./tf2.xml,./tf2.unit.xml,./tf2.unit.no_eager.xml
           flags: tensorflow
           verbose: true
 

--- a/bentoml/_internal/frameworks/tensorflow_v2.py
+++ b/bentoml/_internal/frameworks/tensorflow_v2.py
@@ -397,7 +397,7 @@ class TensorflowTensorContainer(
 
 
 DataContainerRegistry.register_container(
-    LazyType("tensorflow.python.framework.ops", "_EagerTensorBase"),
-    LazyType("tensorflow.python.framework.ops", "_EagerTensorBase"),
+    LazyType("tensorflow.python.framework.ops", "Tensor"),
+    LazyType("tensorflow.python.framework.ops", "Tensor"),
     TensorflowTensorContainer,
 )

--- a/bentoml/_internal/frameworks/tensorflow_v2.py
+++ b/bentoml/_internal/frameworks/tensorflow_v2.py
@@ -399,7 +399,7 @@ class TensorflowTensorContainer(
 # NOTE: we only register the TensorflowTensorContainer as if eager execution is enabled.
 if tf.executing_eagerly():
     DataContainerRegistry.register_container(
-        LazyType("tensorflow.python.framework.ops", "_EagerTensorBase"),
-        LazyType("tensorflow.python.framework.ops", "_EagerTensorBase"),
+        LazyType("tensorflow.python.framework.ops", "Tensor"),
+        LazyType("tensorflow.python.framework.ops", "Tensor"),
         TensorflowTensorContainer,
     )

--- a/bentoml/_internal/frameworks/tensorflow_v2.py
+++ b/bentoml/_internal/frameworks/tensorflow_v2.py
@@ -396,8 +396,10 @@ class TensorflowTensorContainer(
         return cls.batches_to_batch(batches, batch_dim)
 
 
-DataContainerRegistry.register_container(
-    LazyType("tensorflow.python.framework.ops", "Tensor"),
-    LazyType("tensorflow.python.framework.ops", "Tensor"),
-    TensorflowTensorContainer,
-)
+# NOTE: we only register the TensorflowTensorContainer as if eager execution is enabled.
+if tf.executing_eagerly():
+    DataContainerRegistry.register_container(
+        LazyType("tensorflow.python.framework.ops", "_EagerTensorBase"),
+        LazyType("tensorflow.python.framework.ops", "_EagerTensorBase"),
+        TensorflowTensorContainer,
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,7 +43,7 @@ def pytest_collection_modifyitems(config: "Config", items: t.List["Item"]) -> No
     for item in items:
         if "gpus" in item.keywords:
             item.add_marker(skip_gpus)
-        elif "requires_eager_execution" in item.keywords:
+        if "requires_eager_execution" in item.keywords:
             item.add_marker(requires_eager_execution)
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,11 +19,22 @@ def pytest_addoption(parser: "Parser") -> None:
     parser.addoption(
         "--gpus", action="store_true", default=False, help="run gpus related tests"
     )
+    parser.addoption(
+        "--disable-eager-execution",
+        action="store_true",
+        default=False,
+        help="Disable TF eager execution",
+    )
 
 
 def pytest_collection_modifyitems(config: "Config", items: t.List["Item"]) -> None:
-    if config.getoption("--gpus"):
+    if config.getoption("--disable-eager-execution"):
+        from tensorflow.python.framework.ops import disable_eager_execution
+
+        disable_eager_execution()
+    elif config.getoption("--gpus"):
         return
+
     skip_gpus = pytest.mark.skip(reason="need --gpus option to run")
     for item in items:
         if "gpus" in item.keywords:

--- a/tests/integration/frameworks/test_tensorflow_v2_unit.py
+++ b/tests/integration/frameworks/test_tensorflow_v2_unit.py
@@ -35,10 +35,9 @@ def assert_tensor_equal(t1: ext.TensorLike, t2: ext.TensorLike) -> None:
     assert tf.math.equal(t1, t2).numpy().all()
 
 
+@pytest.mark.requires_eager_execution
 @pytest.mark.parametrize("batch_axis", [0, 1])
 def test_tensorflow_container(batch_axis: int):
-    if not tf.executing_eagerly():
-        pytest.skip("This test requires eager execution")
 
     from bentoml._internal.frameworks.tensorflow_v2 import TensorflowTensorContainer
 
@@ -78,7 +77,7 @@ def test_register_container():
 
     assert not tf.executing_eagerly()
 
-    from bentoml._internal.frameworks.tensorflow_v2 import (  # type: ignore # noqa: F401
+    from bentoml._internal.frameworks.tensorflow_v2 import (  # type: ignore # noqa
         TensorflowTensorContainer,
     )
 

--- a/tests/integration/frameworks/test_tensorflow_v2_unit.py
+++ b/tests/integration/frameworks/test_tensorflow_v2_unit.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import typing as t
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from bentoml._internal.types import LazyType
+from bentoml._internal.runner.container import AutoContainer
+from bentoml._internal.runner.container import DataContainerRegistry
+from bentoml._internal.frameworks.tensorflow_v2 import TensorflowTensorContainer
+
+if TYPE_CHECKING:
+    from bentoml._internal.external_typing import tensorflow as ext
+
+    P = t.ParamSpec("P")
+
+
+def requires_disable_eager_execution(
+    function: t.Callable[P, None]
+) -> t.Callable[P, None]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
+        if tf.executing_eagerly():
+            pytest.skip(
+                "This test requires disable eager execution with 'tf.compat.v1.disable_eager_execution()'"
+            )
+        return function(*args, **kwargs)
+
+    return wrapper
+
+
+def assert_tensor_equal(t1: ext.TensorLike, t2: ext.TensorLike) -> None:
+    assert t1.shape == t2.shape
+    assert tf.math.equal(t1, t2).numpy().all()
+
+
+@pytest.mark.parametrize("batch_axis", [0, 1])
+def test_tensorflow_container(batch_axis: int):
+    one_batch: ext.TensorLike = tf.reshape(tf.convert_to_tensor(np.arange(6)), (2, 3))
+    batch_list: list[ext.TensorLike] = [one_batch, one_batch + 1]
+    merged_batch = tf.concat(batch_list, batch_axis)
+
+    batches, indices = TensorflowTensorContainer.batches_to_batch(
+        batch_list,
+        batch_dim=batch_axis,
+    )
+    assert batches.shape == merged_batch.shape
+    assert_tensor_equal(batches, merged_batch)
+    assert_tensor_equal(
+        TensorflowTensorContainer.batch_to_batches(
+            merged_batch,
+            indices=indices,
+            batch_dim=batch_axis,
+        )[0],
+        one_batch,
+    )
+    assert_tensor_equal(
+        TensorflowTensorContainer.from_payload(
+            TensorflowTensorContainer.to_payload(one_batch)
+        ),
+        one_batch,
+    )
+
+    assert_tensor_equal(
+        AutoContainer.from_payload(AutoContainer.to_payload(one_batch, batch_dim=0)),
+        one_batch,
+    )
+
+
+@requires_disable_eager_execution
+def test_disable_eager_execution():
+
+    assert not tf.executing_eagerly()
+    assert (
+        LazyType("tensorflow.python.framework.ops", "Tensor")
+        not in DataContainerRegistry.CONTAINER_BATCH_TYPE_MAP
+    )
+
+    assert (
+        LazyType("tensorflow.python.framework.ops", "Tensor")
+        not in DataContainerRegistry.CONTAINER_SINGLE_TYPE_MAP
+    )


### PR DESCRIPTION
<!--- Thanks for sending a pull request!

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).

- feat: (new feature for the user, not a new feature for build script)
- fix: (bug fix for the user, not a fix to a build script)
- docs: (changes to the documentation)
- style: (formatting, missing semicolons, etc; no production code change)
- refactor: (refactoring production code, eg. renaming a variable)
- perf: (code changes that improve performance)
- test: (adding missing tests, refactoring tests; no production code change)
- chore: (updating grunt tasks etc; no production code change)
- build: (changes that affect the build system or external dependencies)
- ci: (changes to configuration files and scripts)
- revert: (reverts a previous commit)
-->

tensorflow data container should not be of type `_EagerTensorBase`

By default if eager_execution is enabled, then `Tensor` is of type `EagerTensor`

context: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/ops.py#L1045

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
