### PR TITLE
refactor(build_config): pathspec to a separate class

### DIFF
--- a/bentoml/_internal/bento/build_config.py
+++ b/bentoml/_internal/bento/build_config.py
@@ -719,7 +719,7 @@ class BentoPatternSpec:
         self,
         path: str,
         *,
-        recurse_exclude_spec: t.Iterable[t.Tuple[str, PathSpec]] | None = None,
+        recurse_exclude_spec: t.Optional[t.Iterable[t.Tuple[str, PathSpec]]] = None,
     ) -> bool:
         # to determine whether a path is included or not.
         # NOTE that if dir_path is not None, then we also need to pass in ctx_fs


### PR DESCRIPTION
refactor include, exclude pathspec to `BentoPatternSpec`. `BentoPatternSpec` has a `includes` which returns a boolean whether a file is included in spec or not:
```python
BentoPatternSpec(build_config).includes(path)
```
by default `includes` will only respect `bentofile.yaml`.

To get specs from .bentoignore recursively use `BentoPatternSpec.from_path(path)`.

Finally to use both `bentofile.yaml` and `.bentoignore` add a `recurse_exclude_spec` iterator to `BentoPatternSpec.includes`


Basically the behaviour is the same as before, but this refactors help with internal features that want to interact with `bentofile.yaml` include and exclude programmatically.

is used in #2533 

Will discuss more about implementation.