### PR TITLE
feat: using pipeline registry and tests for transformers

### DIFF
--- a/.github/workflows/frameworks.yml
+++ b/.github/workflows/frameworks.yml
@@ -1283,12 +1283,22 @@ jobs:
         run: make tests-transformers
         shell: bash
 
+      - name: Run unit test for transformers
+        shell: bash
+        run: |
+          OPTS=(--cov=bentoml --cov-config=./setup.cfg --cov-report=xml:"transformers.unit.xml" --cov-report term-missing:skip-covered)
+          python -m pytest ./tests/integration/frameworks/test_transformers_unit.py "${OPTS[@]}" || ERR=1
+          if [ $ERR -eq 1 ]; then
+            echo "unit tests for transformers failed!"
+            exit 1
+          fi
+
       - name: Upload test coverage to Codecov
         if: ${{ needs.diff.outputs.transformers == 'true' }}
         uses: codecov/codecov-action@v2
         with:
           directory: ./
-          files: ./transformers.xml
+          files: ./transformers.xml,./transformers.unit.xml
           flags: transformers
           verbose: true
 

--- a/bentoml/_internal/external_typing/transformers.py
+++ b/bentoml/_internal/external_typing/transformers.py
@@ -7,6 +7,9 @@ from transformers.tokenization_utils import PreTrainedTokenizer
 from transformers.configuration_utils import PretrainedConfig
 from transformers.modeling_flax_utils import FlaxPreTrainedModel
 from transformers.tokenization_utils_fast import PreTrainedTokenizerFast
+from transformers.models.auto.auto_factory import (
+    _BaseAutoModelClass as BaseAutoModelClass,
+)  # type: ignore (private warning)
 from transformers.feature_extraction_sequence_utils import (
     SequenceFeatureExtractor as PreTrainedFeatureExtractor,
 )
@@ -20,4 +23,5 @@ __all__ = [
     "TransformersTokenizerType",
     "PreTrainedFeatureExtractor",
     "PretrainedConfig",
+    "BaseAutoModelClass",
 ]

--- a/bentoml/_internal/frameworks/transformers.py
+++ b/bentoml/_internal/frameworks/transformers.py
@@ -90,7 +90,11 @@ else:
 
 
 @attr.define
-class PipelineTask:
+class TransformersOptions(ModelOptions):
+    """Options for the Transformers model."""
+
+    task: str = attr.field(validator=attr.validators.instance_of(str))
+
     tf: t.Tuple[str] = attr.field(  # type: ignore (unfinished attr type)
         validator=attr.validators.deep_iterable(
             attr.validators.instance_of(str),
@@ -112,12 +116,6 @@ class PipelineTask:
         default=None,
     )
 
-
-@attr.define
-class TransformersOptions(PipelineTask, ModelOptions):
-    """Options for the Transformers model."""
-
-    task: str = attr.field(validator=attr.validators.instance_of(str), default=None)
     kwargs: t.Dict[str, t.Any] = attr.field(factory=dict)
 
 

--- a/bentoml/_internal/frameworks/transformers.py
+++ b/bentoml/_internal/frameworks/transformers.py
@@ -153,7 +153,7 @@ def _get_auto_class(val: str | Iterable[str]) -> AutoClassGenerator:
     if isinstance(val, str):
         if not hasattr(transformers, val):
             raise BentoMLException(
-                f"Given {val} is neither exists nor a valid Transformers auto class. For more information, please see https://huggingface.co/docs/transformers/model_doc/auto"
+                f"Given {val} is not a valid Transformers auto class. For more information, please see https://huggingface.co/docs/transformers/model_doc/auto"
             )
         yield getattr(transformers, val)
     elif isinstance(val, Iterable):

--- a/bentoml/_internal/frameworks/transformers.py
+++ b/bentoml/_internal/frameworks/transformers.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from bentoml.types import ModelSignature
     from bentoml.types import ModelSignatureDict
 
-    from ..external_typing import transformers as ext
+    from ..external_typing import transformers as transformers_ext
 
 __all__ = ["load_model", "save_model", "get_runnable", "get"]
 
@@ -130,7 +130,7 @@ def get(tag_like: str | Tag) -> Model:
 
 def _get_auto_class(
     val: str | Iterable[str],
-) -> t.Generator[ext.BaseAutoModelClass, None, None]:
+) -> t.Generator[transformers_ext.BaseAutoModelClass, None, None]:
     if isinstance(val, str):
         if not hasattr(transformers, val):
             raise BentoMLException(
@@ -149,7 +149,7 @@ def _get_auto_class(
 def load_model(
     bento_model: str | Tag | Model,
     **kwargs: t.Any,
-) -> ext.TransformersPipeline:
+) -> transformers_ext.TransformersPipeline:
     """
     Load the Transformers model from BentoML local modelstore with given name.
 
@@ -217,7 +217,7 @@ def load_model(
 
 def save_model(
     name: str,
-    pipeline: ext.TransformersPipeline,
+    pipeline: transformers_ext.TransformersPipeline,
     *,
     task_name: str | None = None,
     task_definition: t.Dict[str, t.Any] | None = None,

--- a/bentoml/_internal/frameworks/transformers.py
+++ b/bentoml/_internal/frameworks/transformers.py
@@ -95,13 +95,13 @@ class TransformersOptions(ModelOptions):
 
     task: str = attr.field(validator=attr.validators.instance_of(str))
 
-    tf: t.Tuple[str] = attr.field(  # type: ignore (unfinished attr type)
+    tf: t.Tuple[str] = attr.field(
         validator=attr.validators.deep_iterable(
             attr.validators.instance_of(str),
         ),  # type: ignore (unfinished attr type)
         factory=tuple,
     )
-    pt: t.Tuple[str] = attr.field(  # type: ignore (unfinished attr type)
+    pt: t.Tuple[str] = attr.field(
         validator=attr.validators.deep_iterable(
             attr.validators.instance_of(str),
         ),  # type: ignore (unfinished attr type)
@@ -134,7 +134,7 @@ def _get_auto_class(
     if isinstance(val, str):
         if not hasattr(transformers, val):
             raise BentoMLException(
-                f"Given {val} is neither exists nor valid transformers.AutoModel"
+                f"Given {val} is neither exists nor a valid Transformers AutoModel. For more information, please see https://huggingface.co/docs/transformers/model_doc/auto"
             )
         yield getattr(transformers, val)
     elif isinstance(val, Iterable):

--- a/bentoml/_internal/models/model.py
+++ b/bentoml/_internal/models/model.py
@@ -66,6 +66,8 @@ class ModelOptions:
     def with_options(self, **kwargs: t.Any) -> ModelOptions:
         return attr.evolve(self, **kwargs)
 
+    # NOTE: attr.asdict() presents a problem if attribute is a tuple, the serialized result would be a list.
+    # In these cases, the framework should override to_dict().
     def to_dict(self: ModelOptions) -> dict[str, t.Any]:
         return attr.asdict(self)
 

--- a/bentoml/_internal/utils/pkg.py
+++ b/bentoml/_internal/utils/pkg.py
@@ -10,6 +10,7 @@ except ImportError:
     import importlib_metadata
     from importlib_metadata import PackageNotFoundError
 
+# importlib will also be included here as a side-import
 import importlib.util
 
 from packaging.version import Version
@@ -19,9 +20,11 @@ __all__ = [
     "pkg_version_info",
     "get_pkg_version",
     "source_locations",
+    "find_spec",
 ]
 
 get_pkg_version = importlib_metadata.version
+find_spec = importlib.util.find_spec
 
 
 def pkg_version_info(pkg_name: str | ModuleType) -> tuple[int, int, int]:

--- a/scripts/ci/config.yml
+++ b/scripts/ci/config.yml
@@ -208,15 +208,15 @@ tf1:
 
 
 transformers:
-  <<: *tmpl
+  <<: *ntmpl
   dependencies:
     - "transformers"
     - "tensorflow_hub"
     - "-f https://download.pytorch.org/whl/torch_stable.html"
     - "torch==1.11.0"
-    - "jax==0.2.19"
-    - "jaxlib==0.1.70"
-    - "flax==0.3.4"
+    - "jax"
+    - "jaxlib"
+    - "flax"
     - "tensorflow"
     - "importlib_metadata"
     - "Pillow==8.4.0"

--- a/tests/integration/frameworks/models/__init__.py
+++ b/tests/integration/frameworks/models/__init__.py
@@ -42,6 +42,7 @@ class FrameworkTestModelInput:
     def check_output(self, outp: t.Any):
         if isinstance(self.expected, t.Callable):
             result = self.expected(outp)
+            print(result)
             if result is not None:
                 assert (
                     result

--- a/tests/integration/frameworks/models/transformers.py
+++ b/tests/integration/frameworks/models/transformers.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import typing as t
+from typing import TYPE_CHECKING
+
+import numpy as np
+from transformers import pipeline  # type: ignore (unfinished transformers type)
+from transformers.trainer_utils import set_seed
+
+import bentoml
+
+from . import FrameworkTestModel
+from . import FrameworkTestModelInput as Input
+from . import FrameworkTestModelConfiguration as Config
+
+framework = bentoml.transformers
+
+if TYPE_CHECKING:
+    from bentoml._internal.external_typing import transformers as transformers_ext
+
+    AnyDict = dict[str, t.Any]
+
+tiny_model = "hf-internal-testing/tiny-random-distilbert"
+
+set_seed(124)
+
+
+def text_classification_pipeline(
+    frameworks: list[str] = ["pt", "tf"]
+) -> t.Generator[transformers_ext.TransformersPipeline, None, None]:
+    yield from map(
+        lambda framework: pipeline(model=tiny_model, framework=framework), frameworks
+    )
+
+
+classification_pipeline: list[FrameworkTestModel] = [
+    FrameworkTestModel(
+        name="text_pipeline",
+        model=model,
+        configurations=[
+            Config(
+                test_inputs={
+                    "__call__": [
+                        Input(
+                            input_args=["i love you"],
+                            expected=lambda out: np.isclose(out["score"], 0.5035),
+                        )
+                    ],
+                },
+            ),
+        ],
+    )
+    for model in text_classification_pipeline()
+]
+
+# NOTE: when we need to add more test cases for different models
+#  create a list of FrameworkTestModel and append to 'models' list
+models = classification_pipeline

--- a/tests/integration/frameworks/models/transformers.py
+++ b/tests/integration/frameworks/models/transformers.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
 import typing as t
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
-import numpy as np
+import requests
+import transformers
+from PIL import Image
 from transformers import pipeline  # type: ignore (unfinished transformers type)
+from transformers.pipelines import get_task
+from transformers.pipelines import SUPPORTED_TASKS
+from transformers.testing_utils import (
+    nested_simplify,  # type: ignore (unfinished transformers type)
+)
 from transformers.trainer_utils import set_seed
+from transformers.pipelines.base import Pipeline
+from transformers.pipelines.base import GenericTensor
 
 import bentoml
 
@@ -16,43 +26,207 @@ from . import FrameworkTestModelConfiguration as Config
 framework = bentoml.transformers
 
 if TYPE_CHECKING:
+    from transformers.utils.generic import ModelOutput
+    from transformers.tokenization_utils_base import BatchEncoding
+
     from bentoml._internal.external_typing import transformers as transformers_ext
 
     AnyDict = dict[str, t.Any]
+    AnyList = list[t.Any]
+    PipelineGenerator = t.Generator[transformers_ext.TransformersPipeline, None, None]
 
-tiny_model = "hf-internal-testing/tiny-random-distilbert"
+tiny_text_model = "hf-internal-testing/tiny-random-distilbert"
+tiny_text_task = get_task(tiny_text_model)
+tiny_text_auto = "AutoModelForSequenceClassification"
 
 set_seed(124)
 
 
-def text_classification_pipeline(
-    frameworks: list[str] = ["pt", "tf"]
-) -> t.Generator[transformers_ext.TransformersPipeline, None, None]:
+class CustomPipeline(Pipeline):
+    def _sanitize_parameters(self, **kwargs: t.Any) -> tuple[AnyDict, AnyDict, AnyDict]:
+        preprocess_kwargs: AnyDict = {}
+        if "dummy_arg" in kwargs:
+            preprocess_kwargs["dummy_arg"] = kwargs["dummy_arg"]
+        return preprocess_kwargs, {}, {}
+
+    def preprocess(self, text: str, dummy_arg: int = 2) -> BatchEncoding | None:
+        if self.tokenizer:
+            input_ids = self.tokenizer(text, return_tensors="pt")
+            return input_ids
+
+    def _forward(
+        self, input_tensors: dict[str, GenericTensor], **parameters: AnyDict
+    ) -> ModelOutput:
+        return self.model(**input_tensors)  # type: ignore
+
+    def postprocess(self, model_outputs: ModelOutput, **parameters: AnyDict) -> t.Any:
+        print(model_outputs)
+        return model_outputs["logits"].softmax(-1).numpy()  # type: ignore (unfinished transformers type)
+
+
+def gen_kwargs(
+    task_name: str, model_name: str, model_auto: str, task_type: str
+) -> AnyDict:
+    task_definition = {
+        "impl": CustomPipeline,
+        **{
+            "task": task_name,
+            "tf": (),
+            "pt": (model_auto,),
+            "default": {"pt": (model_name,)},
+            "type": task_type,
+        },
+    }
+    return {"task_name": task_name, "task_definition": task_definition}
+
+
+def gen_task_pipeline(
+    model: str, task: str | None = None, *, frameworks: list[str] = ["pt", "tf"]
+) -> PipelineGenerator:
     yield from map(
-        lambda framework: pipeline(model=tiny_model, framework=framework), frameworks
+        lambda framework: pipeline(task=task, model=model, framework=framework),  # type: ignore (unfinished transformers type)
+        frameworks,
     )
 
 
-classification_pipeline: list[FrameworkTestModel] = [
+def expected_equal(
+    expected: list[AnyDict | AnyList],
+) -> t.Callable[[list[AnyDict | AnyList]], bool]:
+    def check_output(out: list[AnyDict | AnyList]) -> bool:
+        print(nested_simplify(out, decimals=4))
+        assert nested_simplify(out, decimals=4) == expected
+        return True
+
+    return check_output
+
+
+text_classification_pipeline: list[FrameworkTestModel] = [
     FrameworkTestModel(
         name="text_pipeline",
         model=model,
         configurations=[
             Config(
+                load_kwargs={"task": tiny_text_task},
                 test_inputs={
                     "__call__": [
                         Input(
                             input_args=["i love you"],
-                            expected=lambda out: np.isclose(out["score"], 0.5035),
+                            expected=expected_equal(
+                                [{"label": "LABEL_0", "score": 0.5036}]
+                            ),
                         )
                     ],
                 },
             ),
         ],
     )
-    for model in text_classification_pipeline()
+    for model in gen_task_pipeline(model=tiny_text_model)
+]
+
+tiny_image_model = "hf-internal-testing/tiny-random-vit"
+tiny_image_task = get_task(tiny_image_model)
+tiny_image_auto = "AutoModelForImageClassification"
+test_url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+
+image_classification: list[FrameworkTestModel] = [
+    FrameworkTestModel(
+        name="image_pipeline",
+        model=model,
+        configurations=[
+            Config(
+                load_kwargs={"task": tiny_image_task},
+                test_inputs={
+                    "__call__": [
+                        Input(
+                            input_args=[
+                                [
+                                    test_url,
+                                    Image.open(requests.get(test_url, stream=True).raw),
+                                ]
+                            ],
+                            expected=expected_equal(
+                                [
+                                    [
+                                        {"label": "LABEL_1", "score": 0.574},
+                                        {"label": "LABEL_0", "score": 0.426},
+                                    ],
+                                    [
+                                        {"label": "LABEL_1", "score": 0.574},
+                                        {"label": "LABEL_0", "score": 0.426},
+                                    ],
+                                ]
+                            ),
+                        )
+                    ],
+                },
+            ),
+        ],
+    )
+    for model in gen_task_pipeline(model=tiny_image_model)
+]
+
+custom_task = "custom-text-classification"
+
+# save_kwargs
+def create_save_kwargs() -> AnyDict:
+    save_kwargs = gen_kwargs(custom_task, tiny_text_model, tiny_text_auto, "text")
+    save_kwargs["task_definition"]["pt"] = (
+        getattr(transformers, save_kwargs["task_definition"]["pt"][0]),
+    )
+    return save_kwargs
+
+
+# inject custom task to SUPPORTED_TASKS
+try:
+    from transformers.pipelines import PIPELINE_REGISTRY  # type: ignore # noqa
+
+    PIPELINE_REGISTRY.register_pipeline(
+        custom_task, create_save_kwargs()["task_definition"]
+    )
+except ImportError:
+    SUPPORTED_TASKS[custom_task] = create_save_kwargs()["task_definition"]
+
+custom_kwargs = gen_kwargs(custom_task, tiny_text_model, tiny_text_auto, "text")
+load_kwargs = custom_kwargs["task_definition"]
+load_kwargs.pop("impl")
+
+
+def check_model(model: transformers_ext.TransformersPipeline, dct: AnyDict) -> None:
+    try:
+        from transformers.pipelines import PIPELINE_REGISTRY  # type: ignore # noqa
+
+        supported_tasks = PIPELINE_REGISTRY.supported_tasks
+    except ImportError:
+        supported_tasks = SUPPORTED_TASKS
+    assert custom_task in supported_tasks
+    assert supported_tasks[custom_task] == create_save_kwargs()["task_definition"]
+
+
+custom_pipeline: list[FrameworkTestModel] = [
+    FrameworkTestModel(
+        name="custom_pipeline",
+        model=model,
+        save_kwargs=create_save_kwargs(),
+        configurations=[
+            Config(
+                load_kwargs=load_kwargs,
+                test_inputs={
+                    "__call__": [
+                        Input(
+                            input_args=["i love you"],
+                            expected=expected_equal([[0.504, 0.496]]),
+                        )
+                    ],
+                },
+                check_model=check_model,
+            ),
+        ],
+    )
+    for model in gen_task_pipeline(
+        model=tiny_text_model, task=custom_task, frameworks=["pt"]
+    )
 ]
 
 # NOTE: when we need to add more test cases for different models
 #  create a list of FrameworkTestModel and append to 'models' list
-models = classification_pipeline
+models = text_classification_pipeline + image_classification + custom_pipeline

--- a/tests/integration/frameworks/models/transformers.py
+++ b/tests/integration/frameworks/models/transformers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import typing as t
-from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import requests
@@ -166,6 +165,7 @@ image_classification: list[FrameworkTestModel] = [
 ]
 
 custom_task = "custom-text-classification"
+
 
 # save_kwargs
 def create_save_kwargs() -> AnyDict:

--- a/tests/integration/frameworks/test_frameworks.py
+++ b/tests/integration/frameworks/test_frameworks.py
@@ -61,6 +61,7 @@ def test_model_options_init(
     ModelOptions = framework.ModelOptions
 
     for configuration in test_model.configurations:
+        print(configuration.load_kwargs)
         from_kwargs = ModelOptions(**configuration.load_kwargs)
         from_with_options = ModelOptions().with_options(**configuration.load_kwargs)
         assert from_kwargs == from_with_options

--- a/tests/integration/frameworks/test_transformers_unit.py
+++ b/tests/integration/frameworks/test_transformers_unit.py
@@ -19,13 +19,15 @@ set_seed(124)
 def test_get_auto_class():
     from bentoml._internal.frameworks.transformers import _get_auto_class
 
-    with pytest.raises(BentoMLException) as exc_info:
+    with pytest.raises(
+        BentoMLException, match="Given not_a_class is not a valid Transformers *"
+    ):
         _ = [i for i in _get_auto_class("not_a_class")]
-    assert "neither exists nor a valid Transformers auto class." in str(exc_info.value)
 
-    with pytest.raises(BentoMLException) as exc_info:
+    with pytest.raises(
+        BentoMLException, match="Given not_a_class is not a valid Transformers *"
+    ):
         _ = [i for i in _get_auto_class(["not_a_class"])]
-    assert "neither exists nor a valid Transformers auto class." in str(exc_info.value)
 
     with pytest.raises(
         BentoMLException,


### PR DESCRIPTION
Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>

- minor type ignore stubs
- add support to use `PIPELINE_REGISTRY` and backward compatible to older transformers versions.
- add validators for pipeline task type.
- add more related library version to framework context.