### PR TITLE
style: github naming

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -150,7 +150,7 @@ contributing to the project, helping other users and discuss all things MLOps.
    reference/index
    faq
    Community <https://l.linklyhq.com/l/ktOX>
-   Github <https://github.com/bentoml/BentoML>
+   GitHub <https://github.com/bentoml/BentoML>
 
 .. spelling::
 


### PR DESCRIPTION
Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>

fix GitHub naming from toctree from `Github` to `GitHub`
