### PR TITLE
fix: catboost predict params special case to 'predict' only

### DIFF
--- a/bentoml/_internal/frameworks/catboost.py
+++ b/bentoml/_internal/frameworks/catboost.py
@@ -245,7 +245,7 @@ def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
 
             self.predict_fns: dict[str, t.Callable[..., t.Any]] = {}
             for method_name in bento_model.info.signatures:
-
+                # `task_type` argument is only supported for the `predict` method
                 if method_name == "predict":
                     self.predict_params = {"task_type": "CPU"}
 

--- a/bentoml/_internal/frameworks/catboost.py
+++ b/bentoml/_internal/frameworks/catboost.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import types
 import typing as t
 import logging
 from typing import TYPE_CHECKING
@@ -269,6 +270,9 @@ def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
                     params_["task_type"] = "CPU"
 
             res = self.predict_fns[method_name](input_data, **params_)
+            if isinstance(res, types.GeneratorType):
+                # staged_predict cases
+                return np.asarray(next(res))
             return np.asarray(res)  # type: ignore (incomplete np types)
 
         CatBoostRunnable.add_method(

--- a/bentoml/_internal/frameworks/catboost.py
+++ b/bentoml/_internal/frameworks/catboost.py
@@ -231,10 +231,6 @@ def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
             super().__init__()
             self.model = load_model(bento_model)
 
-            self.predict_params = {
-                "task_type": "CPU",
-            }
-
             # check for resources
             available_gpus = os.getenv("CUDA_VISIBLE_DEVICES", "")
             if available_gpus not in ("", "-1"):
@@ -249,6 +245,10 @@ def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
 
             self.predict_fns: dict[str, t.Callable[..., t.Any]] = {}
             for method_name in bento_model.info.signatures:
+
+                if method_name == "predict":
+                    self.predict_params = {"task_type": "CPU"}
+
                 try:
                     self.predict_fns[method_name] = getattr(self.model, method_name)
                 except AttributeError:

--- a/tests/integration/frameworks/models/catboost.py
+++ b/tests/integration/frameworks/models/catboost.py
@@ -32,7 +32,7 @@ def generator_accurate_to(
     expected, accuracy: float
 ) -> t.Callable[[ext.NpNdArray], bool]:
     def check(out):
-        score = metrics.accuracy_score(expected, next(out))
+        score = metrics.accuracy_score(expected, out)
         return score >= accuracy
 
     return check


### PR DESCRIPTION
Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>

`task_type` is only available for `predict()` callback

@yetone might be good to note that for now we only support `task_type` to `CPU`
inside docs
