### PR TITLE
perf(templates): cache python installation via conda

### DIFF
--- a/bentoml/_internal/bento/docker/templates/_macros.j2
+++ b/bentoml/_internal/bento/docker/templates/_macros.j2
@@ -1,4 +1,5 @@
-{%- macro conda_instalation(python_version, environment_yml) -%}
+{%- macro setup_conda(python_version, bento_path) -%}
+{% set environment_yml=expands_bento_path("env", "conda", "environment.yml", bento_path=bento_path) %}
 
 RUN --mount=type=cache,mode=0777,target=/opt/conda/pkgs bash <<EOF
 set -euxo pipefail

--- a/bentoml/_internal/bento/docker/templates/_macros.j2
+++ b/bentoml/_internal/bento/docker/templates/_macros.j2
@@ -1,13 +1,10 @@
-{%- macro conda_install_python(python_version_full) -%}
+{%- macro conda_install_python(python_version) -%}
 
 RUN --mount=type=cache,mode=0777,target=/opt/conda/pkgs bash <<EOF
 set -euxo pipefail
 
-SAVED_PYTHON_VERSION={{ python_version_full }}
-PYTHON_VERSION=${SAVED_PYTHON_VERSION%.*}
-
 echo "Installing Python $PYTHON_VERSION with conda..."
-conda install -y -n base pkgs/main::python=$PYTHON_VERSION pip
+conda install -y -n base pkgs/main::python={{ python_version }} pip
 EOF
 
 {%- endmacro -%}

--- a/bentoml/_internal/bento/docker/templates/_macros.j2
+++ b/bentoml/_internal/bento/docker/templates/_macros.j2
@@ -1,0 +1,31 @@
+{%- macro conda_install_python(python_version_full) -%}
+
+RUN --mount=type=cache,mode=0777,target=/opt/conda/pkgs bash <<EOF
+set -euxo pipefail
+
+SAVED_PYTHON_VERSION={{ python_version_full }}
+PYTHON_VERSION=${SAVED_PYTHON_VERSION%.*}
+
+echo "Installing Python $PYTHON_VERSION with conda..."
+conda install -y -n base pkgs/main::python=$PYTHON_VERSION pip
+EOF
+
+{%- endmacro -%}
+
+
+{%- macro conda_setup_pip_interop(environment_yml) -%}
+
+RUN --mount=type=cache,mode=0777,target=/opt/conda/pkgs bash <<EOF
+set -euxo pipefail
+
+if [ -f {{ environment_yml }} ]; then
+  # set pip_interop_enabled to improve conda-pip interoperability. Conda can use
+  # pip-installed packages to satisfy dependencies.
+  echo "Updating conda base environment with environment.yml"
+  conda config --set pip_interop_enabled True
+  conda env update -n base -f {{ environment_yml }}
+  conda clean --all
+fi
+EOF
+
+{%- endmacro -%}

--- a/bentoml/_internal/bento/docker/templates/_macros.j2
+++ b/bentoml/_internal/bento/docker/templates/_macros.j2
@@ -1,4 +1,4 @@
-{%- macro conda_install_python(python_version) -%}
+{%- macro conda_instalation(python_version, environment_yml) -%}
 
 RUN --mount=type=cache,mode=0777,target=/opt/conda/pkgs bash <<EOF
 set -euxo pipefail
@@ -6,11 +6,6 @@ set -euxo pipefail
 echo "Installing Python $PYTHON_VERSION with conda..."
 conda install -y -n base pkgs/main::python={{ python_version }} pip
 EOF
-
-{%- endmacro -%}
-
-
-{%- macro conda_setup_pip_interop(environment_yml) -%}
 
 RUN --mount=type=cache,mode=0777,target=/opt/conda/pkgs bash <<EOF
 set -euxo pipefail

--- a/bentoml/_internal/bento/docker/templates/base.j2
+++ b/bentoml/_internal/bento/docker/templates/base.j2
@@ -13,30 +13,7 @@
 {% block SETUP_BENTO_BASE_IMAGE %}
 FROM {{ __base_image__ }} as cached
 
-FROM {{ __base_image__ }} as base
-
-{% set __cached__ = [] %}
-{% for key in __supported_architectures__ if key not in __cached__ %}
-  {% if 'arm64' in key or 'aarch64' in key %}
-  {% do __cached__.append(key) %}
-FROM base as base-arm64
-  {% elif 'armhf' in key or 'armel' in key %}
-  {% do __cached__.append(key) %}
-FROM base as base-arm
-  {% elif 'i386' in key %}
-  {% do __cached__.append(key) %}
-FROM base as base-386
-  {% else %}
-  {% do __cached__.append(key) %}
-FROM base as base-{{ key }}
-  {% endif %}
-{% endfor %}
-
-FROM base-${TARGETARCH}
-
-ARG TARGETARCH
-
-ARG TARGETPLATFORM
+FROM {{ __base_image__ }}
 
 ENV LANG=C.UTF-8
 

--- a/bentoml/_internal/bento/docker/templates/miniconda_alpine.j2
+++ b/bentoml/_internal/bento/docker/templates/miniconda_alpine.j2
@@ -4,7 +4,5 @@
 {% block SETUP_BENTO_ENVARS %}
 {{ super() }}
 
-{{ common.conda_install_python(__python_version__) }}
-
-{{ common.conda_setup_pip_interop(__environment_yml__) }}
+{{ common.conda_instalation(__python_version__, __environment_yml__) }}
 {% endblock %}

--- a/bentoml/_internal/bento/docker/templates/miniconda_alpine.j2
+++ b/bentoml/_internal/bento/docker/templates/miniconda_alpine.j2
@@ -1,24 +1,10 @@
+{% import '_macros.j2' as common %}
 {% extends "base_alpine.j2" %}
 {% set __environment_yml__=expands_bento_path("env", "conda", "environment.yml", bento_path=bento__path) %}
 {% block SETUP_BENTO_ENVARS %}
 {{ super() }}
 
-RUN --mount=type=cache,mode=0777,target=/opt/conda/pkgs bash <<EOF
-set -euxo pipefail
+{{ common.conda_install_python(__python_version_full__) }}
 
-SAVED_PYTHON_VERSION={{ __python_version_full__ }}
-PYTHON_VERSION=${SAVED_PYTHON_VERSION%.*}
-
-echo "Installing Python $PYTHON_VERSION with conda..."
-conda install -y -n base pkgs/main::python=$PYTHON_VERSION pip
-
-if [ -f {{ __environment_yml__ }} ]; then
-  # set pip_interop_enabled to improve conda-pip interoperability. Conda can use
-  # pip-installed packages to satisfy dependencies.
-  echo "Updating conda base environment with environment.yml"
-  conda config --set pip_interop_enabled True
-  conda env update -n base -f {{ __environment_yml__ }}
-  conda clean --all
-fi
-EOF
+{{ common.conda_setup_pip_interop(__environment_yml__) }}
 {% endblock %}

--- a/bentoml/_internal/bento/docker/templates/miniconda_alpine.j2
+++ b/bentoml/_internal/bento/docker/templates/miniconda_alpine.j2
@@ -1,7 +1,7 @@
 {% import '_macros.j2' as common %}
 {% extends "base_alpine.j2" %}
 {% set __environment_yml__=expands_bento_path("env", "conda", "environment.yml", bento_path=bento__path) %}
-{% block SETUP_BENTO_ENVARS %}
+{% block SETUP_BENTO_COMPONENTS %}
 {{ super() }}
 
 {{ common.conda_instalation(__python_version__, __environment_yml__) }}

--- a/bentoml/_internal/bento/docker/templates/miniconda_alpine.j2
+++ b/bentoml/_internal/bento/docker/templates/miniconda_alpine.j2
@@ -1,8 +1,7 @@
 {% import '_macros.j2' as common %}
 {% extends "base_alpine.j2" %}
-{% set __environment_yml__=expands_bento_path("env", "conda", "environment.yml", bento_path=bento__path) %}
 {% block SETUP_BENTO_COMPONENTS %}
 {{ super() }}
 
-{{ common.conda_instalation(__python_version__, __environment_yml__) }}
+{{ common.setup_conda(__python_version__, bento__path) }}
 {% endblock %}

--- a/bentoml/_internal/bento/docker/templates/miniconda_alpine.j2
+++ b/bentoml/_internal/bento/docker/templates/miniconda_alpine.j2
@@ -4,7 +4,7 @@
 {% block SETUP_BENTO_ENVARS %}
 {{ super() }}
 
-{{ common.conda_install_python(__python_version_full__) }}
+{{ common.conda_install_python(__python_version__) }}
 
 {{ common.conda_setup_pip_interop(__environment_yml__) }}
 {% endblock %}

--- a/bentoml/_internal/bento/docker/templates/miniconda_debian.j2
+++ b/bentoml/_internal/bento/docker/templates/miniconda_debian.j2
@@ -4,7 +4,5 @@
 {% block SETUP_BENTO_ENVARS %}
 {{ super() }}
 
-{{ common.conda_install_python(__python_version__) }}
-
-{{ common.conda_setup_pip_interop(__environment_yml__) }}
+{{ common.conda_instalation(__python_version__, __environment_yml__) }}
 {% endblock %}

--- a/bentoml/_internal/bento/docker/templates/miniconda_debian.j2
+++ b/bentoml/_internal/bento/docker/templates/miniconda_debian.j2
@@ -1,8 +1,7 @@
 {% import '_macros.j2' as common %}
 {% extends "base_debian.j2" %}
-{% set __environment_yml__=expands_bento_path("env", "conda", "environment.yml", bento_path=bento__path) %}
 {% block SETUP_BENTO_COMPONENTS %}
 {{ super() }}
 
-{{ common.conda_instalation(__python_version__, __environment_yml__) }}
+{{ common.setup_conda(__python_version__, bento__path) }}
 {% endblock %}

--- a/bentoml/_internal/bento/docker/templates/miniconda_debian.j2
+++ b/bentoml/_internal/bento/docker/templates/miniconda_debian.j2
@@ -1,7 +1,7 @@
 {% import '_macros.j2' as common %}
 {% extends "base_debian.j2" %}
 {% set __environment_yml__=expands_bento_path("env", "conda", "environment.yml", bento_path=bento__path) %}
-{% block SETUP_BENTO_ENVARS %}
+{% block SETUP_BENTO_COMPONENTS %}
 {{ super() }}
 
 {{ common.conda_instalation(__python_version__, __environment_yml__) }}

--- a/bentoml/_internal/bento/docker/templates/miniconda_debian.j2
+++ b/bentoml/_internal/bento/docker/templates/miniconda_debian.j2
@@ -4,7 +4,7 @@
 {% block SETUP_BENTO_ENVARS %}
 {{ super() }}
 
-{{ common.conda_install_python(__python_version_full__) }}
+{{ common.conda_install_python(__python_version__) }}
 
 {{ common.conda_setup_pip_interop(__environment_yml__) }}
 {% endblock %}

--- a/bentoml/_internal/bento/docker/templates/miniconda_debian.j2
+++ b/bentoml/_internal/bento/docker/templates/miniconda_debian.j2
@@ -1,24 +1,10 @@
+{% import '_macros.j2' as common %}
 {% extends "base_debian.j2" %}
 {% set __environment_yml__=expands_bento_path("env", "conda", "environment.yml", bento_path=bento__path) %}
 {% block SETUP_BENTO_ENVARS %}
 {{ super() }}
 
-RUN --mount=type=cache,mode=0777,target=/opt/conda/pkgs bash <<EOF
-set -euxo pipefail
+{{ common.conda_install_python(__python_version_full__) }}
 
-SAVED_PYTHON_VERSION={{ __python_version_full__ }}
-PYTHON_VERSION=${SAVED_PYTHON_VERSION%.*}
-
-echo "Installing Python $PYTHON_VERSION with conda..."
-conda install -y -n base pkgs/main::python=$PYTHON_VERSION pip
-
-if [ -f {{ __environment_yml__ }} ]; then
-  # set pip_interop_enabled to improve conda-pip interoperability. Conda can use
-  # pip-installed packages to satisfy dependencies.
-  echo "Updating conda base environment with environment.yml"
-  conda config --set pip_interop_enabled True
-  conda env update -n base -f {{ __environment_yml__ }}
-  conda clean --all
-fi
-EOF
+{{ common.conda_setup_pip_interop(__environment_yml__) }}
 {% endblock %}

--- a/bentoml/_internal/bento/gen.py
+++ b/bentoml/_internal/bento/gen.py
@@ -55,8 +55,8 @@ class ReservedEnv:
     base_image: str
     supported_architectures: list[str]
     bentoml_version: str = attr.field(default=CLEAN_BENTOML_VERSION)
-    python_version_full: str = attr.field(
-        default=f"{version_info.major}.{version_info.minor}.{version_info.micro}"
+    python_version: str = attr.field(
+        default=f"{version_info.major}.{version_info.minor}"
     )
 
     def todict(self):


### PR DESCRIPTION
- cached pip installation process with conda
- take advantage of jinja2 macros for conda snippets.

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
