### PR TITLE
fix(conda): python installation order

### DIFF
--- a/bentoml/_internal/bento/docker/templates/miniconda_alpine.j2
+++ b/bentoml/_internal/bento/docker/templates/miniconda_alpine.j2
@@ -1,7 +1,6 @@
 {% import '_macros.j2' as common %}
 {% extends "base_alpine.j2" %}
 {% block SETUP_BENTO_COMPONENTS %}
-{{ super() }}
-
 {{ common.setup_conda(__python_version__, bento__path) }}
+{{ super() }}
 {% endblock %}

--- a/bentoml/_internal/bento/docker/templates/miniconda_debian.j2
+++ b/bentoml/_internal/bento/docker/templates/miniconda_debian.j2
@@ -1,7 +1,6 @@
 {% import '_macros.j2' as common %}
 {% extends "base_debian.j2" %}
 {% block SETUP_BENTO_COMPONENTS %}
-{{ super() }}
-
 {{ common.setup_conda(__python_version__, bento__path) }}
+{{ super() }}
 {% endblock %}


### PR DESCRIPTION
it should install python first when using conda
