### PR TITLE
fix: install.sh should be optional if python is not specified

### DIFF
--- a/bentoml/_internal/bento/build_config.py
+++ b/bentoml/_internal/bento/build_config.py
@@ -29,11 +29,6 @@ from ...exceptions import BentoMLException
 from ..configuration import CLEAN_BENTOML_VERSION
 from .build_dev_bentoml_whl import build_bentoml_editable_wheel
 
-if version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 if TYPE_CHECKING:
     from attr import Attribute
     from fs.base import FS
@@ -415,6 +410,9 @@ class PythonOptions:
                 f'Build option python: `no_index="{self.no_index}"` found, will ignore `index_url` and `extra_index_url` option when installing PyPI packages.'
             )
 
+    def is_empty(self) -> bool:
+        return not self.requirements_txt and not self.packages
+
     def write_to_bento(self, bento_fs: "FS", build_ctx: str) -> None:
         py_folder = fs.path.join("env", "python")
         wheels_folder = fs.path.join(py_folder, "wheels")
@@ -434,73 +432,22 @@ class PythonOptions:
                 whl_file = resolve_user_filepath(whl_file, build_ctx)
                 copy_file_to_fs_folder(whl_file, bento_fs, wheels_folder)
 
-        if self.requirements_txt is not None:
-            requirements_txt_file = resolve_user_filepath(
-                self.requirements_txt, build_ctx
-            )
-            copy_file_to_fs_folder(
-                requirements_txt_file,
-                bento_fs,
-                py_folder,
-                dst_filename="requirements.txt",
-            )
-        elif self.packages is not None:
-            with bento_fs.open(fs.path.join(py_folder, "requirements.txt"), "w") as f:
-                f.write("\n".join(self.packages))
-        else:
-            # Return early if no python packages were specified
-            return
-
+        pip_compile_compat: t.List[str] = []
         pip_args: t.List[str] = []
         if self.index_url:
-            pip_args.extend(["--index-url", self.index_url])
+            pip_compile_compat.extend(["--index-url", self.index_url])
         if self.trusted_host:
             for host in self.trusted_host:
-                pip_args.extend(["--trusted-host", host])
+                pip_compile_compat.extend(["--trusted-host", host])
         if self.find_links:
             for link in self.find_links:
-                pip_args.extend(["--find-links", link])
+                pip_compile_compat.extend(["--find-links", link])
         if self.extra_index_url:
             for url in self.extra_index_url:
-                pip_args.extend(["--extra-index-url", url])
-
-        if self.lock_packages:
-            # Note: "--allow-unsafe" is required for including setuptools in the
-            # generated requirements.lock.txt file, and setuptool is required by
-            # pyfilesystem2. Once pyfilesystem2 drop setuptools as dependency, we can
-            # remove the "--allow-unsafe" flag here.
-
-            # Note: "--generate-hashes" is purposefully not used here because it will
-            # break if user includes PyPI package from version control system
-
-            pip_compile_in = bento_fs.getsyspath(
-                fs.path.combine(py_folder, "requirements.txt")
-            )
-            pip_compile_out = bento_fs.getsyspath(
-                fs.path.combine(py_folder, "requirements.lock.txt")
-            )
-            pip_compile_args = [pip_compile_in]
-            pip_compile_args.extend(pip_args)
-            pip_compile_args.extend(
-                [
-                    "--quiet",
-                    "--allow-unsafe",
-                    "--no-header",
-                    f"--output-file={pip_compile_out}",
-                ]
-            )
-            logger.info("Locking PyPI package versions..")
-            cmd = [sys.executable, "-m", "piptools", "compile"]
-            cmd.extend(pip_compile_args)
-            try:
-                subprocess.check_call(cmd)
-            except subprocess.CalledProcessError as e:
-                logger.error(f"Failed locking PyPI packages: {e}")
-                logger.error(
-                    "Falling back to using user-provided package requirement specifier, equivalent to `lock_packages=False`"
-                )
+                pip_compile_compat.extend(["--extra-index-url", url])
 
         # add additional pip args that does not apply to pip-compile
+        pip_args.extend(pip_compile_compat)
         if self.no_index:
             pip_args.append("--no-index")
         if self.pip_args:
@@ -558,6 +505,59 @@ fi
                     """
             )
             f.write(install_script_content)
+
+        if self.requirements_txt is not None:
+            requirements_txt_file = resolve_user_filepath(
+                self.requirements_txt, build_ctx
+            )
+            copy_file_to_fs_folder(
+                requirements_txt_file,
+                bento_fs,
+                py_folder,
+                dst_filename="requirements.txt",
+            )
+        elif self.packages is not None:
+            with bento_fs.open(fs.path.join(py_folder, "requirements.txt"), "w") as f:
+                f.write("\n".join(self.packages))
+        else:
+            # Return early if no python packages were specified
+            return
+
+        if self.lock_packages and not self.is_empty():
+            # Note: "--allow-unsafe" is required for including setuptools in the
+            # generated requirements.lock.txt file, and setuptool is required by
+            # pyfilesystem2. Once pyfilesystem2 drop setuptools as dependency, we can
+            # remove the "--allow-unsafe" flag here.
+
+            # Note: "--generate-hashes" is purposefully not used here because it will
+            # break if user includes PyPI package from version control system
+
+            pip_compile_in = bento_fs.getsyspath(
+                fs.path.combine(py_folder, "requirements.txt")
+            )
+            pip_compile_out = bento_fs.getsyspath(
+                fs.path.combine(py_folder, "requirements.lock.txt")
+            )
+            pip_compile_args = [pip_compile_in]
+            pip_compile_args.extend(pip_compile_compat)
+            pip_compile_args.extend(
+                [
+                    "--quiet",
+                    "--allow-unsafe",
+                    "--no-header",
+                    f"--output-file={pip_compile_out}",
+                ]
+            )
+            logger.info("Locking PyPI package versions..")
+            cmd = [sys.executable, "-m", "piptools", "compile"]
+            cmd.extend(pip_compile_args)
+            try:
+                subprocess.check_call(cmd)
+            except subprocess.CalledProcessError as e:
+                logger.error(f"Failed locking PyPI packages: {e}")
+                logger.error(
+                    "Falling back to using user-provided package requirement specifier, equivalent to `lock_packages=False`"
+                )
 
     def with_defaults(self) -> "PythonOptions":
         # Convert from user provided options to actual build options with default values

--- a/bentoml/_internal/bento/build_config.py
+++ b/bentoml/_internal/bento/build_config.py
@@ -33,11 +33,6 @@ if TYPE_CHECKING:
     from attr import Attribute
     from fs.base import FS
 
-if version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
-
 logger = logging.getLogger(__name__)
 
 
@@ -581,7 +576,9 @@ def _python_options_structure_hook(d: t.Any, _: t.Type[PythonOptions]) -> Python
 
 bentoml_cattr.register_structure_hook(PythonOptions, _python_options_structure_hook)
 
-OptionsCls: TypeAlias = t.Union[DockerOptions, CondaOptions, PythonOptions]
+
+if TYPE_CHECKING:
+    OptionsCls = t.Union[DockerOptions, CondaOptions, PythonOptions]
 
 
 def dict_options_converter(

--- a/bentoml/_internal/bento/build_config.py
+++ b/bentoml/_internal/bento/build_config.py
@@ -433,7 +433,6 @@ class PythonOptions:
                 copy_file_to_fs_folder(whl_file, bento_fs, wheels_folder)
 
         pip_compile_compat: t.List[str] = []
-        pip_args: t.List[str] = []
         if self.index_url:
             pip_compile_compat.extend(["--index-url", self.index_url])
         if self.trusted_host:
@@ -447,6 +446,7 @@ class PythonOptions:
                 pip_compile_compat.extend(["--extra-index-url", url])
 
         # add additional pip args that does not apply to pip-compile
+        pip_args: t.List[str] = []
         pip_args.extend(pip_compile_compat)
         if self.no_index:
             pip_args.append("--no-index")

--- a/bentoml/_internal/bento/build_config.py
+++ b/bentoml/_internal/bento/build_config.py
@@ -579,6 +579,8 @@ bentoml_cattr.register_structure_hook(PythonOptions, _python_options_structure_h
 
 if TYPE_CHECKING:
     OptionsCls = t.Union[DockerOptions, CondaOptions, PythonOptions]
+else:
+    OptionsCls = type
 
 
 def dict_options_converter(

--- a/bentoml/_internal/bento/docker/templates/_macros.j2
+++ b/bentoml/_internal/bento/docker/templates/_macros.j2
@@ -24,7 +24,7 @@ EOF
 {%- endmacro -%}
 
 {%- macro run_script(path, echo_msg, run_args="") -%}
-# Running {{ echo_msg }} if exists
+# Running {{ echo_msg }}
 RUN {{ additional_run_arg }} bash <<EOF
 set -euxo pipefail
 

--- a/bentoml/_internal/bento/docker/templates/_macros.j2
+++ b/bentoml/_internal/bento/docker/templates/_macros.j2
@@ -22,3 +22,16 @@ fi
 EOF
 
 {%- endmacro -%}
+
+{%- macro run_script(path, echo_msg, additional_run_arg="") -%}
+# Running {{ echo_msg }} if exists
+RUN {{ additional_run_arg }} bash <<EOF
+set -euxo pipefail
+
+if [ -f {{ path }} ]; then
+  echo "{{ echo_msg }}..."
+  chmod +x {{ path }}
+  {{ path }}
+fi
+EOF
+{%- endmacro -%}

--- a/bentoml/_internal/bento/docker/templates/_macros.j2
+++ b/bentoml/_internal/bento/docker/templates/_macros.j2
@@ -23,7 +23,7 @@ EOF
 
 {%- endmacro -%}
 
-{%- macro run_script(path, echo_msg, additional_run_arg="") -%}
+{%- macro run_script(path, echo_msg, run_args="") -%}
 # Running {{ echo_msg }} if exists
 RUN {{ additional_run_arg }} bash <<EOF
 set -euxo pipefail

--- a/bentoml/_internal/bento/docker/templates/base.j2
+++ b/bentoml/_internal/bento/docker/templates/base.j2
@@ -57,7 +57,7 @@ COPY --chown={{ bento__user }}:{{ bento__user }} . ./
 {% block SETUP_BENTO_COMPONENTS %}
 
 {% set __install_python_scripts__ = expands_bento_path("env", "python", "install.sh", bento_path=bento__path) %}
-{{ common.run_script(__install_python_scripts__, "install.sh to install python packages", additional_run_arg="--mount=type=cache,mode=0777,target=/root/.cache/pip") }}
+{{ common.run_script(__install_python_scripts__, "install.sh to install python packages", run_args="--mount=type=cache,mode=0777,target=/root/.cache/pip") }}
 
 {% set __setup_script__ = expands_bento_path("env", "docker", "setup_script", bento_path=bento__path) %}
 {{ common.run_script(__setup_script__, "user setup scripts") }}

--- a/bentoml/_internal/bento/docker/templates/base.j2
+++ b/bentoml/_internal/bento/docker/templates/base.j2
@@ -1,5 +1,6 @@
 {# BENTOML INTERNAL #}
 {# users can use these values #}
+{% import '_macros.j2' as common %}
 {% set bento__entrypoint = bento__entrypoint | default(expands_bento_path("env", "docker", "entrypoint.sh", bento_path=bento__path)) %}
 # syntax = docker/dockerfile:1.4-labs
 #
@@ -56,20 +57,10 @@ COPY --chown={{ bento__user }}:{{ bento__user }} . ./
 {% block SETUP_BENTO_COMPONENTS %}
 
 {% set __install_python_scripts__ = expands_bento_path("env", "python", "install.sh", bento_path=bento__path) %}
-RUN --mount=type=cache,mode=0777,target=/root/.cache/pip \
-    chmod +x {{ __install_python_scripts__ }} && \
-    bash {{ __install_python_scripts__ }}
+{{ common.run_script(__install_python_scripts__, "install.sh to install python packages", additional_run_arg="--mount=type=cache,mode=0777,target=/root/.cache/pip") }}
 
-# Run user setup scripts if exists
-RUN bash <<EOF
-set -euxo pipefail
-
-if [ -f {{ expands_bento_path("env", "docker", "setup_script", bento_path=bento__path) }} ]; then
-  echo "Running user setup script.."
-  chmod +x {{ expands_bento_path("env", "docker", "setup_script", bento_path=bento__path) }}
-  {{ expands_bento_path("env", "docker", "setup_script", bento_path=bento__path) }}
-fi
-EOF
+{% set __setup_script__ = expands_bento_path("env", "docker", "setup_script", bento_path=bento__path) %}
+{{ common.run_script(__setup_script__, "user setup scripts") }}
 
 {% endblock %}
 


### PR DESCRIPTION
Address #2666

also address one bug where if only wheels arguments is specified, it should
still respect content of wheels folder and install with given args

Also address a bug where if conda is specified without python field, install.sh should still be available.

Will update #2539 after this got merged. We should have unittest for 1.0