### PR TITLE
chore: lock cattrs <= 21.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     aiofiles
     aiohttp<=3.8.1  # prevent it from installing preview release
     attrs>=21.1.0
-    cattrs==21.4.0
+    cattrs>=1.10.0,<=21.1.0
     chardet
     circus
     click>=7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     aiofiles
     aiohttp<=3.8.1  # prevent it from installing preview release
     attrs>=21.1.0
-    cattrs>=1.10.0
+    cattrs==21.4.0
     chardet
     circus
     click>=7.0


### PR DESCRIPTION
we will look into migrating to GenConverter after 1.0

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
