### PR TITLE
refactor: move from Converter to GenConverter

### DIFF
--- a/bentoml/_internal/bento/bento.py
+++ b/bentoml/_internal/bento/bento.py
@@ -15,9 +15,9 @@ import pathspec
 import fs.errors
 import fs.mirror
 from fs.copy import copy_file
-from cattr.gen import override  # type: ignore (incomplete cattr types)
+from cattr.gen import override
 from cattr.gen import make_dict_structure_fn
-from cattr.gen import make_dict_unstructure_fn  # type: ignore (incomplete cattr types)
+from cattr.gen import make_dict_unstructure_fn
 from simple_di import inject
 from simple_di import Provide
 

--- a/bentoml/_internal/bento/bento.py
+++ b/bentoml/_internal/bento/bento.py
@@ -16,6 +16,7 @@ import fs.errors
 import fs.mirror
 from fs.copy import copy_file
 from cattr.gen import override  # type: ignore (incomplete cattr types)
+from cattr.gen import make_dict_structure_fn
 from cattr.gen import make_dict_unstructure_fn  # type: ignore (incomplete cattr types)
 from simple_di import inject
 from simple_di import Provide
@@ -92,9 +93,9 @@ python:
 @attr.define(repr=False, auto_attribs=False)
 class Bento(StoreItem):
     _tag: Tag = attr.field()
-    __fs: "FS" = attr.field()
+    __fs: FS = attr.field()
 
-    _info: "BentoInfo"
+    _info: BentoInfo
 
     _model_store: ModelStore
     _doc: t.Optional[str] = None
@@ -104,7 +105,7 @@ class Bento(StoreItem):
         return "bento"
 
     @__fs.validator  # type:ignore # attrs validators not supported by pyright
-    def check_fs(self, _attr: t.Any, new_fs: "FS"):
+    def check_fs(self, _attr: t.Any, new_fs: FS):
         try:
             new_fs.makedir("models", recreate=True)
         except fs.errors.ResourceReadOnly:
@@ -125,11 +126,11 @@ class Bento(StoreItem):
         return self._tag
 
     @property
-    def _fs(self) -> "FS":
+    def _fs(self) -> FS:
         return self.__fs
 
     @property
-    def info(self) -> "BentoInfo":
+    def info(self) -> BentoInfo:
         return self._info
 
     @classmethod
@@ -270,7 +271,7 @@ class Bento(StoreItem):
         return res
 
     @classmethod
-    def from_fs(cls, item_fs: "FS") -> "Bento":
+    def from_fs(cls, item_fs: FS) -> Bento:
         try:
             with item_fs.open(BENTO_YAML_FILENAME, "r", encoding="utf-8") as bento_yaml:
                 info = BentoInfo.from_yaml_file(bento_yaml)
@@ -340,55 +341,47 @@ class BentoStore(Store[Bento]):
         super().__init__(base_path, Bento)
 
 
-@attr.define(frozen=True, on_setattr=None)
+@attr.frozen
 class BentoRunnerInfo:
     name: str
     runnable_type: str
-    models: t.List[str] = attr.field(factory=list)
-    resource_config: t.Optional[t.Dict[str, t.Any]] = attr.field(default=None)
+    models: list[str] = attr.field(factory=list)
+    resource_config: dict[str, t.Any] | None = attr.field(default=None)
 
     @classmethod
-    def from_runner(cls, r: Runner) -> "BentoRunnerInfo":
-        # Add runner default resource quota and batching config here
+    def from_runner(cls, r: Runner) -> BentoRunnerInfo:
+        # TODO: Add runner default resource quota and batching config here
         return cls(
-            name=r.name,  # type: ignore
-            runnable_type=r.runnable_class.__name__,  # type: ignore
-            models=[str(model.tag) for model in r.models],  # type: ignore
-            resource_config=r.resource_config,  # type: ignore
+            name=r.name,
+            runnable_type=r.runnable_class.__name__,
+            models=[str(model.tag) for model in r.models],
+            resource_config=r.resource_config,
         )
 
 
-# Remove after attrs support ForwardRef natively
-attr.resolve_types(BentoRunnerInfo, globals(), locals())
-
-
-@attr.define(frozen=True, on_setattr=None)
+@attr.frozen
 class BentoApiInfo:
     name: str
     input_type: str
     output_type: str
 
     @classmethod
-    def from_inference_api(cls, api: "InferenceAPI") -> "BentoApiInfo":
+    def from_inference_api(cls, api: InferenceAPI) -> BentoApiInfo:
         return cls(
-            name=api.name,  # type: ignore
-            input_type=api.input.__class__.__name__,  # type: ignore
-            output_type=api.output.__class__.__name__,  # type: ignore
+            name=api.name,
+            input_type=api.input.__class__.__name__,
+            output_type=api.output.__class__.__name__,
         )
 
 
-# Remove after attrs support ForwardRef natively
-attr.resolve_types(BentoApiInfo, globals(), locals())
-
-
-@attr.define(frozen=True, on_setattr=None)
+@attr.frozen
 class BentoModelInfo:
     tag: Tag = attr.field(converter=Tag.from_taglike)
     module: str
     creation_time: datetime
 
     @classmethod
-    def from_bento_model(cls, bento_model: "Model") -> "BentoModelInfo":
+    def from_bento_model(cls, bento_model: Model) -> BentoModelInfo:
         return cls(
             tag=bento_model.tag,
             module=bento_model.info.module,
@@ -396,25 +389,21 @@ class BentoModelInfo:
         )
 
 
-# Remove after attrs support ForwardRef natively
-attr.resolve_types(BentoModelInfo, globals(), locals())
-
-
-@attr.define(repr=False, frozen=True, on_setattr=None)
+@attr.frozen(repr=False)
 class BentoInfo:
     tag: Tag
     service: str = attr.field(
         converter=lambda svc: svc if isinstance(svc, str) else svc._import_str
-    )  # type: ignore[reportPrivateUsage]
-    name: str = attr.field(init=False)  # converted from tag in __attrs_post_init__
-    version: str = attr.field(init=False)  # converted from tag in __attrs_post_init__
+    )
+    name: str = attr.field(init=False)
+    version: str = attr.field(init=False)
     bentoml_version: str = attr.field(default=BENTOML_VERSION)
     creation_time: datetime = attr.field(factory=lambda: datetime.now(timezone.utc))
 
-    labels: t.Dict[str, t.Any] = attr.field(factory=dict)
-    models: t.List[BentoModelInfo] = attr.field(factory=list)
-    runners: t.List[BentoRunnerInfo] = attr.field(factory=list)
-    apis: t.List[BentoApiInfo] = attr.field(factory=list)
+    labels: dict[str, t.Any] = attr.field(factory=dict)
+    models: list[BentoModelInfo] = attr.field(factory=list)
+    runners: list[BentoRunnerInfo] = attr.field(factory=list)
+    apis: list[BentoApiInfo] = attr.field(factory=list)
     docker: DockerOptions = attr.field(factory=lambda: DockerOptions().with_defaults())
     python: PythonOptions = attr.field(factory=lambda: PythonOptions().with_defaults())
     conda: CondaOptions = attr.field(factory=lambda: CondaOptions().with_defaults())
@@ -427,13 +416,13 @@ class BentoInfo:
         self.validate()
 
     def to_dict(self) -> t.Dict[str, t.Any]:
-        return bentoml_cattr.unstructure(self)  # type: ignore (incomplete cattr types)
+        return bentoml_cattr.unstructure(self)
 
     def dump(self, stream: t.IO[t.Any]):
         return yaml.dump(self, stream, sort_keys=False)
 
     @classmethod
-    def from_yaml_file(cls, stream: t.IO[t.Any]) -> "BentoInfo":
+    def from_yaml_file(cls, stream: t.IO[t.Any]) -> BentoInfo:
         try:
             yaml_content = yaml.safe_load(stream)
         except yaml.YAMLError as exc:
@@ -470,9 +459,7 @@ class BentoInfo:
                         models,
                     )
                 )
-
         try:
-            # type: ignore[attr-defined]
             return bentoml_cattr.structure(yaml_content, cls)
         except KeyError as e:
             raise BentoMLException(f"Missing field {e} in {BENTO_YAML_FILENAME}")
@@ -482,13 +469,19 @@ class BentoInfo:
         ...
 
 
-# Remove after attrs support ForwardRef natively
-attr.resolve_types(BentoInfo, globals(), locals())
-
+bentoml_cattr.register_structure_hook_func(
+    lambda cls: issubclass(cls, BentoInfo),
+    make_dict_structure_fn(
+        BentoInfo,
+        bentoml_cattr,
+        name=override(omit=True),
+        version=override(omit=True),
+    ),
+)
 bentoml_cattr.register_unstructure_hook(
     BentoInfo,
     # Ignore tag, tag is saved via the name and version field
-    make_dict_unstructure_fn(BentoInfo, bentoml_cattr, tag=override(omit=True)),  # type: ignore
+    make_dict_unstructure_fn(BentoInfo, bentoml_cattr, tag=override(omit=True)),
 )
 
 

--- a/bentoml/_internal/cli/__init__.py
+++ b/bentoml/_internal/cli/__init__.py
@@ -13,9 +13,9 @@ from .model_management import add_model_management_commands
 
 def create_bentoml_cli():
     # exclude traceback from the click library
-    from rich.traceback import install
+    # from rich.traceback import install
 
-    install(suppress=[click])
+    # install(suppress=[click])
 
     CONTEXT_SETTINGS = {"help_option_names": ("-h", "--help")}
 

--- a/bentoml/_internal/models/model.py
+++ b/bentoml/_internal/models/model.py
@@ -18,9 +18,9 @@ import fs.errors
 import fs.mirror
 import cloudpickle  # type: ignore (no cloudpickle types)
 from fs.base import FS
-from cattr.gen import override  # type: ignore (incomplete cattr types)
+from cattr.gen import override
 from cattr.gen import make_dict_structure_fn
-from cattr.gen import make_dict_unstructure_fn  # type: ignore (incomplete cattr types)
+from cattr.gen import make_dict_unstructure_fn
 from simple_di import inject
 from simple_di import Provide
 

--- a/bentoml/_internal/models/model.py
+++ b/bentoml/_internal/models/model.py
@@ -19,6 +19,7 @@ import fs.mirror
 import cloudpickle  # type: ignore (no cloudpickle types)
 from fs.base import FS
 from cattr.gen import override  # type: ignore (incomplete cattr types)
+from cattr.gen import make_dict_structure_fn
 from cattr.gen import make_dict_unstructure_fn  # type: ignore (incomplete cattr types)
 from simple_di import inject
 from simple_di import Provide
@@ -41,11 +42,12 @@ if TYPE_CHECKING:
     from ..types import AnyType
     from ..types import PathType
 
-    class ModelSignatureDict(t.TypedDict, total=False):
-        batch_dim: tuple[int, int] | int
-        batchable: bool
-        input_spec: tuple[AnyType] | AnyType | None
-        output_spec: AnyType | None
+
+class ModelSignatureDict(t.TypedDict, total=False):
+    batchable: bool
+    batch_dim: tuple[int, int] | int | None
+    input_spec: tuple[AnyType] | AnyType | None
+    output_spec: AnyType | None
 
 
 T = t.TypeVar("T")
@@ -317,7 +319,7 @@ class ModelStore(Store[Model]):
 @attr.frozen
 class ModelContext:
     framework_name: str
-    framework_versions: t.Dict[str, str]
+    framework_versions: dict[str, str]
     bentoml_version: str = attr.field(default=BENTOML_VERSION)
     python_version: str = attr.field(default=PYTHON_VERSION)
 
@@ -328,11 +330,7 @@ class ModelContext:
         return bentoml_cattr.structure(data, ModelContext)
 
     def to_dict(self: ModelContext) -> dict[str, str | dict[str, str]]:
-        return bentoml_cattr.unstructure(self)  # type: ignore (incomplete cattr types)
-
-
-# Remove after attrs support ForwardRef natively
-attr.resolve_types(ModelContext, globals(), locals())
+        return bentoml_cattr.unstructure(self)
 
 
 @attr.frozen
@@ -361,24 +359,28 @@ class ModelSignature:
             If there are multiple arguments to the predict method and there is only one batch
             dimension supplied, all arguments will use that batch dimension.
 
-            Example: .. code-block:: python
-                # Save two models with `predict` method that supports taking input batches on the
-                dimension 0 and the other on dimension 1: bentoml.pytorch.save_model("demo0",
-                model_0, signatures={"predict": {"batchable": True, "batch_dim": 0}})
-                bentoml.pytorch.save_model("demo1", model_1, signatures={"predict": {"batchable":
-                True, "batch_dim": 1}})
+            Example:
 
-                # if the following calls are batched, the input to the actual predict method on the
-                # model.predict method would be [[1, 2], [3, 4], [5, 6]] runner0 =
-                bentoml.pytorch.get("demo0:latest").to_runner() runner0.init_local()
-                runner0.predict.run(np.array([[1, 2], [3, 4]])) runner0.predict.run(np.array([[5,
-                6]]))
+                .. code-block:: python
 
-                # if the following calls are batched, the input to the actual predict method on the
-                # model.predict would be [[1, 2, 5], [3, 4, 6]] runner1 =
-                bentoml.pytorch.get("demo1:latest").to_runner() runner1.init_local()
-                runner1.predict.run(np.array([[1, 2], [3, 4]])) runner1.predict.run(np.array([[5],
-                [6]]))
+                    # Save two models with `predict` method that supports taking input batches on the
+                    dimension 0 and the other on dimension 1:
+
+                    bentoml.pytorch.save_model("demo0", model_0, signatures={"predict": {"batchable": True, "batch_dim": 0}})
+                    bentoml.pytorch.save_model("demo1", model_1, signatures={"predict": {"batchable": True, "batch_dim": 1}})
+
+                    # if the following calls are batched, the input to the actual predict method on the
+                    # model.predict method would be [[1, 2], [3, 4], [5, 6]]
+                    runner0 = bentoml.pytorch.get("demo0:latest").to_runner() runner0.init_local()
+                    runner0.predict.run(np.array([[1, 2], [3, 4]]))
+                    runner0.predict.run(np.array([[5, 6]]))
+
+                    # if the following calls are batched, the input to the actual predict method on the
+                    # model.predict would be [[1, 2, 5], [3, 4, 6]]
+                    runner1 = bentoml.pytorch.get("demo1:latest").to_runner()
+                    runner1.init_local()
+                    runner1.predict.run(np.array([[1, 2], [3, 4]]))
+                    runner1.predict.run(np.array([[5], [6]]))
 
             Expert API:
 
@@ -393,18 +395,14 @@ class ModelSignature:
     """
 
     batchable: bool = False
-    batch_dim: t.Tuple[int, int] = (0, 0)
+    batch_dim: tuple[int, int] = (0, 0)
     # TODO: define input/output spec struct
     input_spec: t.Any = None
     output_spec: t.Any = None
 
     @staticmethod
     def from_dict(data: ModelSignatureDict) -> ModelSignature:
-        if "batch_dim" in data and isinstance(data["batch_dim"], int):
-            formated_data = dict(data, batch_dim=(data["batch_dim"], data["batch_dim"]))
-        else:
-            formated_data = data
-        return bentoml_cattr.structure(formated_data, ModelSignature)
+        return bentoml_cattr.structure(data, ModelSignature)
 
     @staticmethod
     def convert_signatures_dict(
@@ -416,17 +414,19 @@ class ModelSignature:
         }
 
 
-# Remove after attrs support ForwardRef natively
-attr.resolve_types(ModelSignature, globals(), locals())
+ModelSignaturesType = dict[str, ModelSignature] | dict[str, ModelSignatureDict]
 
 
-if TYPE_CHECKING:
-    ModelSignaturesType: t.TypeAlias = (
-        dict[str, ModelSignature] | dict[str, ModelSignatureDict]
-    )
+def model_signature_decoder(data: t.Any, _: t.Type[ModelSignature]) -> ModelSignature:
+    if "batch_dim" in data and isinstance(data["batch_dim"], int):
+        current_batch_dim = data["batch_dim"]
+        data["batch_dim"] = (current_batch_dim, current_batch_dim)
+    return ModelSignature(**data)
 
 
-def model_signature_encoder(model_signature: ModelSignature) -> dict[str, t.Any]:
+def model_signature_unstructure_hook(
+    model_signature: ModelSignature,
+) -> dict[str, t.Any]:
     encoded: dict[str, t.Any] = {
         "batchable": model_signature.batchable,
     }
@@ -440,7 +440,10 @@ def model_signature_encoder(model_signature: ModelSignature) -> dict[str, t.Any]
     return encoded
 
 
-bentoml_cattr.register_unstructure_hook(ModelSignature, model_signature_encoder)
+bentoml_cattr.register_structure_hook(ModelSignature, model_signature_decoder)
+bentoml_cattr.register_unstructure_hook(
+    ModelSignature, model_signature_unstructure_hook
+)
 
 
 @attr.define(repr=False, eq=False, frozen=True)
@@ -449,21 +452,18 @@ class ModelInfo:
     name: str
     version: str
     module: str
-    labels: t.Dict[str, str] = attr.field(validator=label_validator)
-    _options: t.Dict[str, t.Any]
-    # TODO: make metadata a MetadataDict; this works around a bug in attrs
-    metadata: t.Dict[str, t.Any] = attr.field(
-        validator=metadata_validator, converter=dict
-    )
+    labels: dict[str, str] = attr.field(validator=label_validator)
+    _options: dict[str, t.Any]
+    metadata: MetadataDict = attr.field(validator=metadata_validator, converter=dict)
     context: ModelContext = attr.field()
-    signatures: t.Dict[str, ModelSignature] = attr.field(
+    signatures: dict[str, ModelSignature] = attr.field(
         converter=ModelSignature.convert_signatures_dict
     )
     api_version: str
     creation_time: datetime
 
-    _cached_module: t.Optional[ModuleType] = None
-    _cached_options: t.Optional[ModelOptions] = None
+    _cached_module: ModuleType | None = None
+    _cached_options: ModelOptions | None = None
 
     def __init__(
         self,
@@ -481,6 +481,9 @@ class ModelInfo:
             object.__setattr__(self, "_cached_options", options)
             options = options.to_dict()
 
+        if creation_time is None:
+            creation_time = datetime.now(timezone.utc)
+
         self.__attrs_init__(  # type: ignore
             tag=tag,
             name=tag.name,
@@ -492,7 +495,7 @@ class ModelInfo:
             context=context,
             signatures=signatures,
             api_version=api_version,
-            creation_time=creation_time or datetime.now(timezone.utc),
+            creation_time=creation_time,
         )
         self.validate()
 
@@ -570,8 +573,8 @@ class ModelInfo:
     def dump(self, stream: io.StringIO | None = None) -> io.BytesIO | None:
         return yaml.safe_dump(self.to_dict(), stream=stream, sort_keys=False)  # type: ignore (bad yaml types)
 
-    @staticmethod
-    def from_yaml_file(stream: t.IO[t.Any]):
+    @classmethod
+    def from_yaml_file(cls, stream: t.IO[t.Any]) -> ModelInfo:
         try:
             yaml_content = yaml.safe_load(stream)
         except yaml.YAMLError as exc:  # pragma: no cover - simple error handling
@@ -580,12 +583,8 @@ class ModelInfo:
 
         if not isinstance(yaml_content, dict):
             raise BentoMLException(f"malformed {MODEL_YAML_FILENAME}")
-
         yaml_content["tag"] = str(
-            Tag(
-                t.cast(str, yaml_content["name"]),
-                t.cast(str, yaml_content["version"]),
-            )
+            Tag(t.cast(str, yaml_content["name"]), t.cast(str, yaml_content["version"]))
         )
         del yaml_content["name"]
         del yaml_content["version"]
@@ -599,11 +598,8 @@ class ModelInfo:
             del yaml_content["context"]["pip_dependencies"]
             yaml_content["context"]["framework_versions"] = {}
 
-        # weird cattrs workaround
-        yaml_content["_options"] = t.cast(t.Dict[str, t.Any], yaml_content["options"])
-
         try:
-            model_info = bentoml_cattr.structure(yaml_content, ModelInfo)
+            model_info = bentoml_cattr.structure(yaml_content, cls)
         except TypeError as e:  # pragma: no cover - simple error handling
             raise BentoMLException(f"unexpected field in {MODEL_YAML_FILENAME}: {e}")
         return model_info
@@ -614,13 +610,20 @@ class ModelInfo:
         ...
 
 
-# Remove after attrs support ForwardRef natively
-attr.resolve_types(ModelInfo, globals(), locals())
-
+bentoml_cattr.register_structure_hook_func(
+    lambda cls: issubclass(cls, ModelInfo),
+    make_dict_structure_fn(
+        ModelInfo,
+        bentoml_cattr,
+        name=override(omit=True),
+        version=override(omit=True),
+        _options=override(rename="options"),
+    ),
+)
 bentoml_cattr.register_unstructure_hook_func(
     lambda cls: issubclass(cls, ModelInfo),
     # Ignore tag, tag is saved via the name and version field
-    make_dict_unstructure_fn(  # type: ignore (incomplete types)
+    make_dict_unstructure_fn(
         ModelInfo,
         bentoml_cattr,
         tag=override(omit=True),

--- a/bentoml/_internal/tag.py
+++ b/bentoml/_internal/tag.py
@@ -131,8 +131,5 @@ class Tag:
         return fs.path.combine(self.name, "latest")
 
 
-# Remove after attrs support ForwardRef natively
-attr.resolve_types(Tag, globals(), locals())
-
 bentoml_cattr.register_structure_hook(Tag, lambda d, _: Tag.from_taglike(d))  # type: ignore[misc]
 bentoml_cattr.register_unstructure_hook(Tag, str)

--- a/bentoml/_internal/types.py
+++ b/bentoml/_internal/types.py
@@ -52,13 +52,10 @@ if TYPE_CHECKING:
 else:
     PathType = t.Union[str, os.PathLike]
 
-ValueType = t.Union[
-    str, bytes, bool, int, float, complex, datetime, date, time, timedelta
-]
-MetadataType = t.Union[
-    ValueType, list[ValueType], dict[str, ValueType], tuple[ValueType]
-]
-
+ValueType = (
+    str | bytes | bool | int | float | complex | datetime | date | time | timedelta
+)
+MetadataType = ValueType | list[ValueType] | dict[str, ValueType] | tuple[ValueType]
 MetadataDict = dict[str, MetadataType]
 
 JSONSerializable = t.NewType("JSONSerializable", object)

--- a/bentoml/_internal/types.py
+++ b/bentoml/_internal/types.py
@@ -50,7 +50,7 @@ JSON_CHARSET = "utf-8"
 if TYPE_CHECKING:
     PathType = str | os.PathLike[str]
 else:
-    PathType = str | os.PathLike
+    PathType = t.Union[str, os.PathLike]
 
 ValueType = (
     str | bytes | bool | int | float | complex | datetime | date | time | timedelta

--- a/bentoml/_internal/types.py
+++ b/bentoml/_internal/types.py
@@ -52,10 +52,12 @@ if TYPE_CHECKING:
 else:
     PathType = t.Union[str, os.PathLike]
 
-ValueType = (
-    str | bytes | bool | int | float | complex | datetime | date | time | timedelta
-)
-MetadataType = ValueType | list[ValueType] | dict[str, ValueType] | tuple[ValueType]
+ValueType = t.Union[
+    str, bytes, bool, int, float, complex, datetime, date, time, timedelta
+]
+MetadataType = t.Union[
+    ValueType, list[ValueType], dict[str, ValueType], tuple[ValueType]
+]
 
 MetadataDict = dict[str, MetadataType]
 

--- a/bentoml/_internal/utils/cattr.py
+++ b/bentoml/_internal/utils/cattr.py
@@ -16,7 +16,7 @@ else:
     bentoml_cattr = Converter(forbid_extra_keys=True)
 
 from attr import fields
-from cattr import override  # type: ignore
+from cattr.gen import override
 from cattr.gen import AttributeOverride
 
 

--- a/bentoml/_internal/utils/cattr.py
+++ b/bentoml/_internal/utils/cattr.py
@@ -3,12 +3,19 @@ from __future__ import annotations
 import typing as t
 from datetime import datetime
 
-import cattr
+from .pkg import pkg_version_info
+
+cattr_major_minor = pkg_version_info("cattrs")
+if cattr_major_minor[:2] <= (22, 2):
+    from cattr import GenConverter as Converter
+else:
+    from cattr import Converter
+
 from attr import fields
 from cattr import override  # type: ignore
 from cattr.gen import AttributeOverride
 
-bentoml_cattr = cattr.Converter()
+bentoml_cattr = Converter(forbid_extra_keys=True)
 
 
 def omit_if_init_false(cls: t.Any) -> dict[str, AttributeOverride]:
@@ -19,7 +26,7 @@ def omit_if_default(cls: t.Any) -> dict[str, AttributeOverride]:
     return {f.name: override(omit_if_default=True) for f in fields(cls)}
 
 
-def datetime_decoder(dt_like: str | datetime, _: t.Any) -> datetime:
+def datetime_structure_hook(dt_like: str | datetime, _: t.Any) -> datetime:
     if isinstance(dt_like, str):
         return datetime.fromisoformat(dt_like)
     elif isinstance(dt_like, datetime):
@@ -28,5 +35,5 @@ def datetime_decoder(dt_like: str | datetime, _: t.Any) -> datetime:
         raise Exception(f"Unable to parse datetime from '{dt_like}'")
 
 
-bentoml_cattr.register_unstructure_hook(datetime, lambda dt: dt.isoformat())  # type: ignore
-bentoml_cattr.register_structure_hook(datetime, datetime_decoder)
+bentoml_cattr.register_structure_hook(datetime, datetime_structure_hook)
+bentoml_cattr.register_unstructure_hook(datetime, lambda dt: dt.isoformat())

--- a/bentoml/_internal/utils/cattr.py
+++ b/bentoml/_internal/utils/cattr.py
@@ -7,15 +7,17 @@ from .pkg import pkg_version_info
 
 cattr_major_minor = pkg_version_info("cattrs")
 if cattr_major_minor[:2] <= (22, 2):
-    from cattr import GenConverter as Converter
+    from cattr import Converter
+
+    bentoml_cattr = Converter()
 else:
     from cattr import Converter
+
+    bentoml_cattr = Converter(forbid_extra_keys=True)
 
 from attr import fields
 from cattr import override  # type: ignore
 from cattr.gen import AttributeOverride
-
-bentoml_cattr = Converter(forbid_extra_keys=True)
 
 
 def omit_if_init_false(cls: t.Any) -> dict[str, AttributeOverride]:

--- a/bentoml/_internal/utils/cattr.py
+++ b/bentoml/_internal/utils/cattr.py
@@ -3,21 +3,17 @@ from __future__ import annotations
 import typing as t
 from datetime import datetime
 
-from .pkg import pkg_version_info
-
-cattr_major_minor = pkg_version_info("cattrs")
-if cattr_major_minor[:2] <= (22, 2):
-    from cattr import Converter
-
-    bentoml_cattr = Converter()
-else:
-    from cattr import Converter
-
-    bentoml_cattr = Converter(forbid_extra_keys=True)
-
 from attr import fields
+from cattr import Converter
 from cattr.gen import override
 from cattr.gen import AttributeOverride
+
+from .pkg import pkg_version_info
+
+if pkg_version_info("cattrs")[:2] <= (22, 2):
+    bentoml_cattr = Converter()
+else:
+    bentoml_cattr = Converter(forbid_extra_keys=True)
 
 
 def omit_if_init_false(cls: t.Any) -> dict[str, AttributeOverride]:

--- a/bentoml/_internal/utils/pkg.py
+++ b/bentoml/_internal/utils/pkg.py
@@ -7,6 +7,7 @@ except ImportError:
 
 get_pkg_version = importlib_metadata.version
 
+
 # mimic the behaviour of version_info assuming the pkg follows semver
 def pkg_version_info(pkg_name: str) -> tuple[int, int, int]:
     return tuple(map(int, get_pkg_version(pkg_name).split(".")[:3]))

--- a/bentoml/_internal/utils/pkg.py
+++ b/bentoml/_internal/utils/pkg.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
 try:
     import importlib.metadata as importlib_metadata
 except ImportError:
     import importlib_metadata
 
 get_pkg_version = importlib_metadata.version
+
+# mimic the behaviour of version_info assuming the pkg follows semver
+def pkg_version_info(pkg_name: str) -> tuple[int, int, int]:
+    return tuple(map(int, get_pkg_version(pkg_name).split(".")[:3]))


### PR DESCRIPTION
fix: GenConverter compatible for ModelInfo

feat: GenConverter

chore: fetch upstream

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>

Mainly for testing CI