### PR TITLE
fix: Fix onnx mlir artifact

### DIFF
--- a/bentoml/frameworks/onnxmlir.py
+++ b/bentoml/frameworks/onnxmlir.py
@@ -93,8 +93,8 @@ class OnnxMlirModelArtifact(BentoServiceArtifact):
         self._model_so_path = None
 
     def _saved_model_file_path(self, base_path):
-        self._model_so_path = os.path.join(base_path, self.name + '.so')
-        return os.path.join(base_path, self.name + '.so')
+        self._model_so_path = os.path.join(base_path, self.name + ".so")
+        return os.path.join(base_path, self.name + ".so")
 
     def pack(self, onnxmlir_model_so, metadata=None):
         # pylint:disable=arguments-renamed

--- a/bentoml/frameworks/onnxmlir.py
+++ b/bentoml/frameworks/onnxmlir.py
@@ -117,7 +117,7 @@ class OnnxMlirModelArtifact(BentoServiceArtifact):
             raise MissingDependencyException(
                 "PyRuntime package library must be in python path"
             )
-        return ExecutionSession(self._model_so_path, "run_main_graph")
+        return ExecutionSession(self._model_so_path)
 
     def get(self):
         if not self._inference_session:


### PR DESCRIPTION
## Description, motivation and context
BentoML is used as one of the serving environments for onnx-mlir compiled model artifacts and a recent change in the number of entry points to the compiled model left our serving environment clients in a broken state. This PR fixes that and allows us to clients to resume normal use of BentoML for serving onnx-mlir compiled models.

## How Has This Been Tested?
Due to confusion on most people's parts on driving this manually inside of the onnx-mlir docker container, these tests will be driven through PR status logic and documentation will be introduced down the road so we don't face trouble like this again.

## Checklist:
- [ ] My code follows the bentoml code style, both `make format` and
  `make lint` script have passed
  ([instructions](https://github.com/bentoml/BentoML/blob/master/DEVELOPMENT.md#style-check-and-auto-formatting-your-code)). (A two line change is introduced following community standards based on review of a commit made by @aarnphm. A more thorough review of style checking and auto-formatting will be done as we bring onnx-mlir to BentoML v1.0.0).
- [ ] My change reduces project test coverage and requires unit tests to be added (Not applicable for this change)
- [ ] I have added unit tests covering my code change (Not applicable for this change)
- [ ] My change requires a change to the documentation (Better documentation to be added down the road).
- [ ] I have updated the documentation accordingly (Better documentation to be added down the road).