### PR TITLE
chore: generic components name for supervisor

### DIFF
--- a/bentoml/__main__.py
+++ b/bentoml/__main__.py
@@ -1,4 +1,4 @@
 if __name__ == "__main__":
-    from bentoml._internal.cli import create_bentoml_cli
+    from bentoml._internal.cli import cli
 
-    create_bentoml_cli()()
+    cli()

--- a/bentoml/_internal/cli/__init__.py
+++ b/bentoml/_internal/cli/__init__.py
@@ -12,6 +12,10 @@ from .model_management import add_model_management_commands
 
 
 def create_bentoml_cli():
+    from ..context import component_context
+
+    component_context.component_name = "cli"
+
     CONTEXT_SETTINGS = {"help_option_names": ("-h", "--help")}
 
     @click.group(cls=BentoMLCommandGroup, context_settings=CONTEXT_SETTINGS)

--- a/bentoml/_internal/cli/bento_server.py
+++ b/bentoml/_internal/cli/bento_server.py
@@ -111,6 +111,10 @@ def add_serve_command(cli: click.Group) -> None:
         if sys.path[0] != working_dir:
             sys.path.insert(0, working_dir)
 
+        from ..context import component_context
+
+        component_context.component_name = "supervisor"
+
         if production:
             if reload:
                 logger.warning(

--- a/bentoml/_internal/cli/bento_server.py
+++ b/bentoml/_internal/cli/bento_server.py
@@ -111,10 +111,6 @@ def add_serve_command(cli: click.Group) -> None:
         if sys.path[0] != working_dir:
             sys.path.insert(0, working_dir)
 
-        from ..context import component_context
-
-        component_context.component_name = "cli"
-
         if production:
             if reload:
                 logger.warning(

--- a/bentoml/_internal/cli/bento_server.py
+++ b/bentoml/_internal/cli/bento_server.py
@@ -113,7 +113,7 @@ def add_serve_command(cli: click.Group) -> None:
 
         from ..context import component_context
 
-        component_context.component_name = "supervisor"
+        component_context.component_name = "cli"
 
         if production:
             if reload:


### PR DESCRIPTION
When initializing we can see some empty dict when init. This is due to when
initializing circus supervisor doesn't have a components name.

```bash
2022-07-06T23:48:18-0700 [DEBUG] [] Default runner method set to `predict`, it can be accessed both via `runner.run` and `runner.predict.async_run`
2022-07-06T23:48:19-0700 [DEBUG] [] Default runner method set to `predict`, it can be accessed both via `runner.run` and `runner.predict.async_run`
2022-07-06T23:48:19-0700 [DEBUG] [] 'iris_classifier' loaded from '/Users/aarnphm/workspace/playground': bentoml.Service(name="iris_classifier", import_str="service:svc", working_dir="/Users/aarnphm/workspace/playground")
2022-07-06T23:48:19-0700 [INFO] [] Starting development BentoServer from "." running on http://127.0.0.1:3000 (Press CTRL+C to quit)
```

This PR address this. `supervisor` is a sufficient name
