### PR TITLE
chore(onnx): adding onnxruntime-silicon for m1 devices

### DIFF
--- a/bentoml/_internal/frameworks/onnx.py
+++ b/bentoml/_internal/frameworks/onnx.py
@@ -236,7 +236,7 @@ def save_model(
         import importlib_metadata
 
     # prefer "onnxruntime-gpu" over "onnxruntime" for framework versioning
-    _PACKAGE = ["onnxruntime-gpu", "onnxruntime"]
+    _PACKAGE = ["onnxruntime-gpu", "onnxruntime", "onnxruntime-silicon"]
     for p in _PACKAGE:
         try:
             _onnxruntime_version = get_pkg_version(p)


### PR DESCRIPTION
On M1 machine, onnxruntime hasn't provided a wheel yet. There is a package
called `onnxruntime-silicon` that enables M1 devices to use `onnxruntime`

This PR adds `onnxruntime-silicon` to version checking for saving onnx model.
