### PR TITLE
fix: reload on windows

### DIFF
--- a/bentoml/_internal/server/__init__.py
+++ b/bentoml/_internal/server/__init__.py
@@ -111,7 +111,7 @@ def serve_development(
         watchers,
         sockets=circus_sockets,
         plugins=plugins,
-        debug=True,
+        debug=True if sys.platform != "win32" else False,
     )
     ensure_prometheus_dir()
 

--- a/bentoml/_internal/server/__init__.py
+++ b/bentoml/_internal/server/__init__.py
@@ -106,6 +106,10 @@ def serve_development(
                 "bentoml_home": bentoml_home,
             },
         ]
+    if sys.platform == "win32":
+        logger.warning(
+            "Due to circus limitations, output from reloader plugin will not be shown on Windows."
+        )
 
     arbiter = create_standalone_arbiter(
         watchers,


### PR DESCRIPTION
--reload should work on Windows 

The issue lies at enabling `debug` for Circus plugin.

By default this enable plugins stdout and stderr to be pipe through the
supervisor, however,this only works on UNIX system.


This PR should enable windows user to use --reload. Current caveats is that the
output from the reloader plugin won't be pipe out to stdout

This should fix #2675 