### PR TITLE
fix(dev-server): fix logging for reload

### DIFF
--- a/bentoml/_internal/server/__init__.py
+++ b/bentoml/_internal/server/__init__.py
@@ -16,6 +16,7 @@ from simple_di import Provide
 
 from bentoml import load
 
+from ..log import SERVER_LOGGING_CONFIG
 from ..utils import reserve_free_port
 from ..resource import CpuResource
 from ..utils.uri import path_to_uri
@@ -116,6 +117,8 @@ def serve_development(
         sockets=circus_sockets,
         plugins=plugins,
         debug=True if sys.platform != "win32" else False,
+        loggerconfig=SERVER_LOGGING_CONFIG,
+        loglevel=logging.WARNING,
     )
     ensure_prometheus_dir()
 

--- a/bentoml/_internal/utils/circus/watchfilesplugin.py
+++ b/bentoml/_internal/utils/circus/watchfilesplugin.py
@@ -11,6 +11,8 @@ from threading import Thread
 import fs
 from circus.plugins import CircusPlugin
 
+from ...log import configure_server_logging
+from ...context import component_context
 from ...utils.pkg import source_locations
 from ....exceptions import MissingDependencyException
 from ...configuration import is_pypi_installed_bentoml
@@ -37,6 +39,9 @@ class ServiceReloaderPlugin(CircusPlugin):
 
     def __init__(self, *args: t.Any, **config: t.Any):
         assert "working_dir" in config, "`working_dir` is required"
+
+        configure_server_logging()
+        component_context.component_name = "observer"
 
         super().__init__(*args, **config)
 


### PR DESCRIPTION
A somewhat hacky workaround to circus configuring logging when `debug` is set to true.