### PR TITLE
fix: transformers API docs

### DIFF
--- a/docs/source/frameworks/transformers.rst
+++ b/docs/source/frameworks/transformers.rst
@@ -12,8 +12,8 @@ Compatibility
 BentoML requires Transformers version 4 or above. For other versions of Transformers, consider using a 
 :ref:`concepts/runner:Custom Runner`.
 
-When constructing a :ref:`bentofile.yaml <concepts/bento:Bento Build Options>`, include `transformers` and the machine learning 
-framework of the model, e.g. `pytorch`, `tensorflow`, or `jax`.
+When constructing a :ref:`bentofile.yaml <concepts/bento:Bento Build Options>`, include ``transformers`` and the machine learning 
+framework of the model, e.g. ``pytorch``, ``tensorflow``, or ``jax``.
 
 .. tab-set::
 

--- a/docs/source/frameworks/transformers.rst
+++ b/docs/source/frameworks/transformers.rst
@@ -1,5 +1,5 @@
 ============
-Hugging Face
+Transformers
 ============
 
 `🤗 Transformers <https://huggingface.co/docs/transformers/main/en/index>`_ is a library that helps download and fine-tune popular 

--- a/docs/source/reference/frameworks/transformers.rst
+++ b/docs/source/reference/frameworks/transformers.rst
@@ -1,13 +1,12 @@
 ============
-Hugging Face
+Transformers
 ============
 
 .. admonition:: About this page
 
    This is an API reference for 🤗 Transformers in BentoML. Please refer to
-   :ref:`Hugging Face guide <frameworks/transformers:Hugging Face>` for more information about how to use 
+   :ref:`Transformers guide <frameworks/transformers:Transformers>` for more information about how to use 
    Hugging Face Transformers in BentoML.
-
 
 .. currentmodule:: bentoml.transformers
 


### PR DESCRIPTION
Transformers docs should be called `Transformers` not `HuggingFace` (since
HuggingFace is the company )
