### PR TITLE
chore: minor log fixes

### DIFF
--- a/bentoml/_internal/runner/runner.py
+++ b/bentoml/_internal/runner/runner.py
@@ -90,12 +90,17 @@ class Runner:
         """
 
         if name is None:
-            name = runnable_class.__name__
+            lname = runnable_class.__name__.lower()
+            logger.warning(
+                f"Using lowercased runnable class name '{lname}' for runner."
+            )
+        else:
+            lname = name.lower()
 
-        lname = name.lower()
-
-        if name != lname:
-            logger.warning(f"Converting runner name '{name}' to lowercase: '{lname}'")
+            if name != lname:
+                logger.warning(
+                    f"Converting runner name '{name}' to lowercase: '{lname}'"
+                )
 
         try:
             validate_tag_str(lname)

--- a/bentoml/_internal/server/cli/runner.py
+++ b/bentoml/_internal/server/cli/runner.py
@@ -91,7 +91,7 @@ def main(
         arbiter.start()
         return
 
-    component_context.component_name = f"runner-{runner_name}:{worker_id}"
+    component_context.component_name = f"runner:{runner_name}:{worker_id}"
     from ...log import configure_server_logging
 
     configure_server_logging()

--- a/tests/unit/_internal/runner/test_runner.py
+++ b/tests/unit/_internal/runner/test_runner.py
@@ -19,7 +19,14 @@ def test_runner(caplog):
     assert (
         "bentoml._internal.runner.runner",
         logging.WARNING,
-        "Converting runner name 'DummyRunnable' to lowercase: 'dummyrunnable'",
+        "Using lowercased runnable class name 'dummyrunnable' for runner.",
+    ) in caplog.record_tuples
+
+    named_runner = Runner(DummyRunnable, name="UPPERCASE_name")
+    assert (
+        "bentoml._internal.runner.runner",
+        logging.WARNING,
+        "Converting runner name 'UPPERCASE_name' to lowercase: 'uppercase_name'",
     ) in caplog.record_tuples
 
     named_runner = Runner(DummyRunnable, name="test_name")


### PR DESCRIPTION
More clear log message when using runnable class name as runner name, and use colon for separating runner component names.