### PR TITLE
fix(runner): thread limiter doesn't take effect

### DIFF
--- a/bentoml/_internal/runner/runner_handle/local.py
+++ b/bentoml/_internal/runner/runner_handle/local.py
@@ -21,7 +21,10 @@ if TYPE_CHECKING:
     R = t.TypeVar("R")
 
 
-class CustomCapacityLimiter:
+# This is a quick hack around anyio.CapacityLimiter where
+# we set local variable to use ThreadLocal. This ensures that
+# our LocalRunnerRef will only run in exactly one thread.
+class LocalCapacityLimiter:
     local = threading.local()
 
     def __init__(self, total_tokens: float = 40):
@@ -68,5 +71,5 @@ class LocalRunnerRef(RunnerHandle):
         return await anyio.to_thread.run_sync(
             functools.partial(method, **kwargs),
             *args,
-            limiter=CustomCapacityLimiter(1),  # type: ignore
+            limiter=LocalCapacityLimiter(1),  # type: ignore
         )

--- a/bentoml/_internal/runner/runner_handle/local.py
+++ b/bentoml/_internal/runner/runner_handle/local.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     R = t.TypeVar("R")
 
 
-# This is a quick hack around anyio.CapacityLimiter where
+# This is a quick workaround anyio.CapacityLimiter where
 # we set local variable to use ThreadLocal. This ensures that
 # our LocalRunnerRef will only run in exactly one thread.
 class LocalCapacityLimiter:


### PR DESCRIPTION
## What does this PR address?
<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->

Background
-------------
Accoring to the doc of anyio https://anyio.readthedocs.io/en/stable/api.html#anyio.to_thread.run_sync , setting up the limiter should limit the thread count that used for this task. The default limiter is 40 threads, will take effect with `async_run(limiter=None)` during test.
But the limiter wont take effect once specified, like `async_run(limiter=anyio.CapacityLimiter(1))`. The limit gone. Threads count can reach a large number.

To reproduce
--------------

test on the general feature project under e2e tests.

Start 1000 requests at the same time:
```python
import aiohttp

client = aiohttp.ClientSession()
await asyncio.gather(*(client.post("http://127.0.0.1:3000/echo_json", json=[1]) for i in range(1000)))
```

For the 1.0 version: 
```
(tf2@py3.7)  bojiang ➜  BentoML git:(fix) ✗ cat /proc/1723529/status
Name:   python
Umask:  0022
State:  R (running)
Tgid:   1723529
Ngid:   0
Pid:    1723529
PPid:   1723257
TracerPid:      0
Uid:    1000    1000    1000    1000
Gid:    1000    1000    1000    1000
FDSize: 128
Groups: 24 25 29 30 44 46 108 115 118 1000
NStgid: 1723529
NSpid:  1723529
NSpgid: 1723529
NSsid:  1723529
VmPeak:  4340156 kB
VmSize:  4340156 kB
VmLck:         0 kB
VmPin:         0 kB
VmHWM:    179588 kB
VmRSS:    179588 kB
RssAnon:          119116 kB
RssFile:           60472 kB
RssShmem:              0 kB
VmData:   935296 kB
VmStk:       132 kB
VmExe:      2180 kB
VmLib:    243824 kB
VmPTE:      1152 kB
VmSwap:        0 kB
HugetlbPages:          0 kB
CoreDumping:    0
THP_enabled:    1
Threads:        102
SigQ:   0/47671
SigPnd: 0000000000000000
ShdPnd: 0000000000000000
SigBlk: 0000000000000000
SigIgn: 0000000001001000
SigCgt: 0000000180004002
CapInh: 0000000000000000
CapPrm: 0000000000000000
CapEff: 0000000000000000
CapBnd: 000001ffffffffff
CapAmb: 0000000000000000
NoNewPrivs:     0
Seccomp:        0
Seccomp_filters:        0
Speculation_Store_Bypass:       thread vulnerable
SpeculationIndirectBranch:      conditional enabled
Cpus_allowed:   3f
Cpus_allowed_list:      0-5
Mems_allowed:   00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000001
Mems_allowed_list:      0
voluntary_ctxt_switches:        1451
nonvoluntary_ctxt_switches:     2335

```
found `Threads:        102`

with this PR:
```
(tf2@py3.7)  bojiang ➜  BentoML git:(fix) cat /proc/1735866/status
Name:   python
Umask:  0022
State:  S (sleeping)
Tgid:   1735866
Ngid:   0
Pid:    1735866
PPid:   1735526
TracerPid:      0
Uid:    1000    1000    1000    1000
Gid:    1000    1000    1000    1000
FDSize: 128
Groups: 24 25 29 30 44 46 108 115 118 1000
NStgid: 1735866
NSpid:  1735866
NSpgid: 1735866
NSsid:  1735866
VmPeak:   637496 kB
VmSize:   576472 kB
VmLck:         0 kB
VmPin:         0 kB
VmHWM:    157028 kB
VmRSS:    157028 kB
RssAnon:           96704 kB
RssFile:           60324 kB
RssShmem:              0 kB
VmData:   115188 kB
VmStk:       132 kB
VmExe:      2180 kB
VmLib:    243824 kB
VmPTE:       544 kB
VmSwap:        0 kB
HugetlbPages:          0 kB
CoreDumping:    0
THP_enabled:    1
Threads:        3
SigQ:   0/47671
SigPnd: 0000000000000000
ShdPnd: 0000000000000000
SigBlk: 0000000000000000
SigIgn: 0000000001001000
SigCgt: 0000000180004002
CapInh: 0000000000000000
CapPrm: 0000000000000000
CapEff: 0000000000000000
CapBnd: 000001ffffffffff
CapAmb: 0000000000000000
NoNewPrivs:     0
Seccomp:        0
Seccomp_filters:        0
Speculation_Store_Bypass:       thread vulnerable
SpeculationIndirectBranch:      conditional enabled
Cpus_allowed:   3f
Cpus_allowed_list:      0-5
Mems_allowed:   00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000001
Mems_allowed_list:      0
voluntary_ctxt_switches:        2117
nonvoluntary_ctxt_switches:     1034
```

## Before submitting:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
  those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?

## Who can help review?

Feel free to tag members/contributors who can help review your PR.
<!--
Feel free to ping any of the BentoML members for help on your issue, but don't ping more than three people 😊.
If you know how to use git blame, that is probably the easiest way.

Team members that you can ping:
- @parano
- @yubozhao
- @bojiang
- @ssheng
- @aarnphm
- @sauyon
- @larme
- @yetone
- @jjmachan
-->
