### PR TITLE
bug: fix JSON io_descriptor validate_json option

### DIFF
--- a/bentoml/_internal/io_descriptors/json.py
+++ b/bentoml/_internal/io_descriptors/json.py
@@ -170,7 +170,10 @@ class JSON(IODescriptor[JSONType]):
         else:
             return json_obj
 
-    async def to_http_response(self, obj: JSONType, ctx: Context | None = None):
+    async def to_http_response(self, obj: JSONType | pydantic.BaseModel, ctx: Context | None = None):
+        if isinstance(obj, pydantic.BaseModel):
+            obj = obj.dict()
+
         json_str = json.dumps(
             obj,
             cls=self._json_encoder,

--- a/bentoml/_internal/io_descriptors/json.py
+++ b/bentoml/_internal/io_descriptors/json.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import typing as t
+import logging
 import dataclasses
 from typing import TYPE_CHECKING
 
@@ -38,6 +39,8 @@ if TYPE_CHECKING:
 JSONType = t.Union[str, t.Dict[str, t.Any], "pydantic.BaseModel"]
 
 MIME_TYPE_JSON = "application/json"
+
+logger = logging.getLogger(__name__)
 
 
 class DefaultJsonEncoder(json.JSONEncoder):  # pragma: no cover
@@ -137,7 +140,9 @@ class JSON(IODescriptor[JSONType]):
     def __init__(
         self,
         pydantic_model: t.Type[pydantic.BaseModel] | None = None,
+        *,
         json_encoder: t.Type[json.JSONEncoder] = DefaultJsonEncoder,
+        **kwargs,
     ):
         if pydantic_model is not None:
             if pydantic is None:
@@ -150,6 +155,12 @@ class JSON(IODescriptor[JSONType]):
 
         self._pydantic_model = pydantic_model
         self._json_encoder = json_encoder
+
+        # Backwards compatible API for version 1.0.0
+        if "validate_json" in kwargs:
+            logger.warning(
+                "validate_json option in bentoml.io.JSON has been deprecated, use a pydantic model to specify validation options instead"
+            )
 
     def input_type(self) -> "UnionType":
         return JSONType

--- a/bentoml/_internal/io_descriptors/json.py
+++ b/bentoml/_internal/io_descriptors/json.py
@@ -142,9 +142,8 @@ class JSON(IODescriptor[JSONType]):
     def __init__(
         self,
         pydantic_model: t.Type[pydantic.BaseModel] | None = None,
-        *,
+        validate_json: bool = True,
         json_encoder: t.Type[json.JSONEncoder] = DefaultJsonEncoder,
-        **kwargs,
     ):
         if pydantic_model is not None:
             assert issubclass(
@@ -154,8 +153,8 @@ class JSON(IODescriptor[JSONType]):
         self._pydantic_model = pydantic_model
         self._json_encoder = json_encoder
 
-        # Backwards compatible API for version 1.0.0
-        if "validate_json" in kwargs:
+        # Remove validate_json in version 1.1.0
+        if validate_json is False:
             logger.warning(
                 "validate_json option in bentoml.io.JSON has been deprecated, use a pydantic model to specify validation options instead"
             )

--- a/bentoml/_internal/io_descriptors/json.py
+++ b/bentoml/_internal/io_descriptors/json.py
@@ -142,7 +142,7 @@ class JSON(IODescriptor[JSONType]):
     def __init__(
         self,
         pydantic_model: t.Type[pydantic.BaseModel] | None = None,
-        validate_json: bool = True,
+        validate_json: bool | None = None,
         json_encoder: t.Type[json.JSONEncoder] = DefaultJsonEncoder,
     ):
         if pydantic_model is not None:
@@ -154,7 +154,7 @@ class JSON(IODescriptor[JSONType]):
         self._json_encoder = json_encoder
 
         # Remove validate_json in version 1.1.0
-        if validate_json is False:
+        if validate_json is not None:
             logger.warning(
                 "validate_json option in bentoml.io.JSON has been deprecated, use a pydantic model to specify validation options instead"
             )

--- a/bentoml/_internal/io_descriptors/json.py
+++ b/bentoml/_internal/io_descriptors/json.py
@@ -170,7 +170,9 @@ class JSON(IODescriptor[JSONType]):
         else:
             return json_obj
 
-    async def to_http_response(self, obj: JSONType | pydantic.BaseModel, ctx: Context | None = None):
+    async def to_http_response(
+        self, obj: JSONType | pydantic.BaseModel, ctx: Context | None = None
+    ):
         if isinstance(obj, pydantic.BaseModel):
             obj = obj.dict()
 

--- a/bentoml/_internal/io_descriptors/json.py
+++ b/bentoml/_internal/io_descriptors/json.py
@@ -11,14 +11,9 @@ from starlette.responses import Response
 
 from .base import IODescriptor
 from ..types import LazyType
+from ..utils import LazyLoader
 from ..utils.http import set_cookies
 from ...exceptions import BadInput
-from ...exceptions import MissingDependencyException
-
-try:
-    import pydantic
-except ImportError:
-    pydantic = None
 
 if TYPE_CHECKING:
     from types import UnionType
@@ -34,6 +29,13 @@ if TYPE_CHECKING:
         t.Type["pydantic.BaseModel"],
         t.Any,
     ]
+else:
+    pydantic = LazyLoader(
+        "pydantic",
+        globals(),
+        "pydantic",
+        exc_msg="`pydantic` must be installed to use `pydantic_model`, install with `pip install pydantic`",
+    )
 
 
 JSONType = t.Union[str, t.Dict[str, t.Any], "pydantic.BaseModel"]
@@ -145,10 +147,6 @@ class JSON(IODescriptor[JSONType]):
         **kwargs,
     ):
         if pydantic_model is not None:
-            if pydantic is None:
-                raise MissingDependencyException(
-                    "`pydantic` must be installed to use `pydantic_model`"
-                )
             assert issubclass(
                 pydantic_model, pydantic.BaseModel
             ), "`pydantic_model` must be a subclass of `pydantic.BaseModel`"

--- a/docs/source/concepts/service.rst
+++ b/docs/source/concepts/service.rst
@@ -269,30 +269,31 @@ JSON
 ~~~~
 
 The data type of a JSON IO descriptor can be specified through a Pydantic model. By setting 
-the :code:`validate_json` argument to `True`, the IO descriptor will strictly validate the input 
-based on the specified pydantic model. To learn more, see IO descrptor reference for 
+a pydantic model, the IO descriptor will validate the input based on the specified pydantic
+model and return. To learn more, see IO descrptor reference for
 :ref:`reference/api_io_descriptors:Structured Data with JSON`.
 
 .. code-block:: python
 
-    import typing as t
-    
+    from typing import Dict, Any
     from pydantic import BaseModel
 
     svc = bentoml.Service("iris_classifier")
 
-    class IrisInput(BaseModel):
+    class IrisFeatures(BaseModel):
         sepal_length: float
         sepal_width: float
         petal_length: float
         petal_width: float
 
     @svc.api(
-        input=JSON(pydantic_model=IrisInput, validate_json=True),
+        input=JSON(pydantic_model=IrisFeatures),
         output=JSON(),
     )
-    def classify(input_series: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
-        ...
+    def classify(input_series: IrisFeatures) -> Dict[str, Any]:
+        input_df = pd.DataFrame([input_data.dict()])
+        results = iris_clf_runner.predict.run(input_df).to_list()
+        return {"predictions": results}
 
 
 Built-in Types


### PR DESCRIPTION
## What does this PR address?
<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->

Currently, when using a JSON io descriptor with a pydantic class, the input data type also depends on the validate_json option with is very confusing. Essentially when a user provides a pydantic class, it is expected to receive an instance of that pydantic class as the inference API callback function's input parameter. However, currently, this is only the case when validate_json=True. If the user sets a pydantic model while setting validate_json=False, it will still pass in a regular dict to user-defined API function and completely ignore the pydantic option.

This PR proposes to remove the `validate_json` option and make sure the input value type to user-defined API function is consistent:

* if pydantic is None, the input value will be type object
* if pydantic is not None, the input value will be an instance of target pydantic class

As for validation logic, the user should be able to define via the pydantic class itself. E.g. user can set the pydantic class to allow extra fields or set some of the fields as optional. See the example here: https://github.com/bentoml/gallery/pull/146


This will be a breaking change since the validate_json option is being removed

## Before submitting:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
  those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?

## Who can help review?

Feel free to tag members/contributors who can help review your PR.
<!--
Feel free to ping any of the BentoML members for help on your issue, but don't ping more than three people 😊.
If you know how to use git blame, that is probably the easiest way.

Team members that you can ping:
- @parano
- @yubozhao
- @bojiang
- @ssheng
- @aarnphm
- @sauyon
- @larme
- @yetone
- @jjmachan
-->
