### PR TITLE
feat: add support for excluding urls from tracing

### DIFF
--- a/bentoml/_internal/configuration/__init__.py
+++ b/bentoml/_internal/configuration/__init__.py
@@ -45,7 +45,7 @@ def expand_env_var(env_var: str) -> str:
 
 def clean_bentoml_version(bentoml_version: str) -> str:
     post_version = bentoml_version.split("+")[0]
-    match = re.match(r"^(\d+)\.(\d+)\.(post)?(\d+)(?:(a|rc)\d)*", post_version)
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:(a|rc)\d)*", post_version)
     if match is None:
         raise BentoMLException("Errors while parsing BentoML version.")
     return match.group()

--- a/bentoml/_internal/configuration/__init__.py
+++ b/bentoml/_internal/configuration/__init__.py
@@ -45,7 +45,7 @@ def expand_env_var(env_var: str) -> str:
 
 def clean_bentoml_version(bentoml_version: str) -> str:
     post_version = bentoml_version.split("+")[0]
-    match = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:(a|rc)\d)*", post_version)
+    match = re.match(r"^(\d+)\.(\d+)\.(post)?(\d+)(?:(a|rc)\d)*", post_version)
     if match is None:
         raise BentoMLException("Errors while parsing BentoML version.")
     return match.group()

--- a/bentoml/_internal/configuration/containers.py
+++ b/bentoml/_internal/configuration/containers.py
@@ -116,6 +116,7 @@ SCHEMA = Schema(
         "tracing": {
             "type": Or(And(str, Use(str.lower), _check_tracing_type), None),
             "sample_rate": Or(And(float, lambda i: i >= 0 and i <= 1), None),
+            "excluded_urls": Or(str, None),
             Optional("zipkin"): {"url": Or(str, None)},
             Optional("jaeger"): {"address": Or(str, None), "port": Or(int, None)},
         },
@@ -407,6 +408,15 @@ class _BentoMLContainerClass:
             return provider
         else:
             return provider
+
+    @providers.SingletonFactory
+    @staticmethod
+    def tracing_excluded_urls(
+        excluded_urls: t.Optional[str] = Provide[config.tracing.excluded_urls],
+    ):
+        from opentelemetry.util.http import parse_excluded_urls
+
+        return parse_excluded_urls(excluded_urls)
 
     # Mapping from runner name to RunnerApp file descriptor
     remote_runner_mapping = providers.Static[t.Dict[str, str]]({})

--- a/bentoml/_internal/configuration/default_configuration.yaml
+++ b/bentoml/_internal/configuration/default_configuration.yaml
@@ -41,6 +41,7 @@ runners:
 tracing:
   type: zipkin
   sample_rate: 0.0
+  excluded_urls: Null
   zipkin:
     url: Null
   jaeger:

--- a/bentoml/_internal/server/runner_app.py
+++ b/bentoml/_internal/server/runner_app.py
@@ -134,7 +134,7 @@ class RunnerAppFactory(BaseAppFactory):
         middlewares.append(
             Middleware(
                 otel_asgi.OpenTelemetryMiddleware,
-                excluded_urls=None,
+                excluded_urls=BentoMLContainer.tracing_excluded_urls.get(),
                 default_span_details=None,
                 server_request_hook=None,
                 client_request_hook=client_request_hook,

--- a/bentoml/_internal/server/service_app.py
+++ b/bentoml/_internal/server/service_app.py
@@ -218,7 +218,7 @@ class ServiceAppFactory(BaseAppFactory):
         middlewares.append(
             Middleware(
                 otel_asgi.OpenTelemetryMiddleware,
-                excluded_urls=None,
+                excluded_urls=BentoMLContainer.tracing_excluded_urls.get(),
                 default_span_details=None,
                 server_request_hook=None,
                 client_request_hook=client_request_hook,


### PR DESCRIPTION
## What does this PR address?

Fixes #2829 

## Before submitting:
- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
  those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
No: requires external dependency (Jaeger)

## Who can help review?

Feel free to tag members/contributors who can help review your PR.

Tested manually by

1. Take an existing working Bento (e.g. from using the basic iris-clf example)
2. Package the new bentoml wheel file into the Bento
3. Use docker-compose to set up the Bento and a Jaeger
```
version: '3.9'
services:
  iris_clf:
    build:
      context: <Bento folder>
      dockerfile: env/docker/Dockerfile
    ports:
      - "3000:3000"
    environment:
      - OTEL_SERVICE_NAME=iris-clf
      - BENTOML_CONFIG=bentoml_config.yaml
    volumes:
      - ./bentoml_config.yaml:/home/bentoml/bento/bentoml_config.yaml
  jaeger:
    image: jaegertracing/all-in-one:1.35
    ports:
      - "6831:6831"
      - "16686:16686"
```
4. Use this bentoml_config.yaml - uncomment or comment the `excluded_urls` line to disable / enable the routes
```
tracing:
  type: jaeger
  sample_rate: 1.0
  excluded_urls: readyz,livez,healthz,static_content,docs
  jaeger:
    address: jaeger
    port: 6831
```
5. Visit `http://localhost:3000` (model's API server) on the browser to trigger the tracing. Visit `http://localhost:16686` (Jaeger) to check the traces.

When the `excluded_urls` line is commented out (i.e. trace all routes):

![before-change](https://user-images.githubusercontent.com/12453748/181904278-feadbb8d-0d5c-4801-81c1-041c21be0a7c.png)

When the `excluded_urls` line is left uncommented (i.e. exclude the routes):

![after-change](https://user-images.githubusercontent.com/12453748/181904300-14633d95-7beb-4f9a-ac4f-068d4e2ea403.png)

