### PR TITLE
fix: extend --cache-from consumption to python tuple

### DIFF
--- a/bentoml/_internal/utils/buildx.py
+++ b/bentoml/_internal/utils/buildx.py
@@ -209,7 +209,7 @@ def build(
     if cache_from is not None:
         if isinstance(cache_from, str):
             cmds.extend(["--cache-from", cache_from])
-        elif isinstance(cache_from, list) or isinstance(cache_from, tuple):
+        elif isinstance(cache_from, t.Iterable):
             for arg in cache_from:
                 cmds.extend(["--cache-from", arg])
         else:

--- a/bentoml/_internal/utils/buildx.py
+++ b/bentoml/_internal/utils/buildx.py
@@ -219,7 +219,7 @@ def build(
     if cache_to is not None:
         if isinstance(cache_to, str):
             cmds.extend(["--cache-to", cache_to])
-        elif isinstance(cache_to, list) or isinstance(cache_to, tuple):
+        elif isinstance(cache_to, t.Iterable):
             for arg in cache_to:
                 cmds.extend(["--cache-to", arg])
         else:

--- a/bentoml/_internal/utils/buildx.py
+++ b/bentoml/_internal/utils/buildx.py
@@ -209,7 +209,7 @@ def build(
     if cache_from is not None:
         if isinstance(cache_from, str):
             cmds.extend(["--cache-from", cache_from])
-        elif isinstance(cache_from, list):
+        elif isinstance(cache_from, list) or isinstance(cache_from, tuple):
             for arg in cache_from:
                 cmds.extend(["--cache-from", arg])
         else:
@@ -219,7 +219,7 @@ def build(
     if cache_to is not None:
         if isinstance(cache_to, str):
             cmds.extend(["--cache-to", cache_to])
-        elif isinstance(cache_to, list):
+        elif isinstance(cache_to, list) or isintance(cache_to, tuple):
             for arg in cache_to:
                 cmds.extend(["--cache-to", arg])
         else:

--- a/bentoml/_internal/utils/buildx.py
+++ b/bentoml/_internal/utils/buildx.py
@@ -219,7 +219,7 @@ def build(
     if cache_to is not None:
         if isinstance(cache_to, str):
             cmds.extend(["--cache-to", cache_to])
-        elif isinstance(cache_to, list) or isintance(cache_to, tuple):
+        elif isinstance(cache_to, list) or isinstance(cache_to, tuple):
             for arg in cache_to:
                 cmds.extend(["--cache-to", arg])
         else:


### PR DESCRIPTION
When invoking 

```
python -m bentoml containerize --cache-from "adsf/asdf:asdf" --cache-from "asdf/asdf:asdf" bento_t5:wyn742ar5g3v2ri3
```
I run into


```
    args = [f"{k}={v}" for k, v in cache_from.items()]
AttributeError: 'tuple' object has no attribute 'items'
```
This PR extends the cli --cache-from consumption code to include the tuple case.
