### PR TITLE
feat: add support for specifying urls to exclude from tracing as a list

### DIFF
--- a/bentoml/_internal/configuration/containers.py
+++ b/bentoml/_internal/configuration/containers.py
@@ -416,7 +416,8 @@ class _BentoMLContainerClass:
             config.tracing.excluded_urls
         ],
     ):
-        from opentelemetry.util.http import ExcludeList, parse_excluded_urls
+        from opentelemetry.util.http import ExcludeList
+        from opentelemetry.util.http import parse_excluded_urls
 
         if isinstance(excluded_urls, list):
             return ExcludeList(excluded_urls)

--- a/bentoml/_internal/configuration/containers.py
+++ b/bentoml/_internal/configuration/containers.py
@@ -116,7 +116,7 @@ SCHEMA = Schema(
         "tracing": {
             "type": Or(And(str, Use(str.lower), _check_tracing_type), None),
             "sample_rate": Or(And(float, lambda i: i >= 0 and i <= 1), None),
-            "excluded_urls": Or(str, None),
+            "excluded_urls": Or([str], str, None),
             Optional("zipkin"): {"url": Or(str, None)},
             Optional("jaeger"): {"address": Or(str, None), "port": Or(int, None)},
         },
@@ -412,11 +412,16 @@ class _BentoMLContainerClass:
     @providers.SingletonFactory
     @staticmethod
     def tracing_excluded_urls(
-        excluded_urls: t.Optional[str] = Provide[config.tracing.excluded_urls],
+        excluded_urls: t.Optional[t.Union[str, t.List[str]]] = Provide[
+            config.tracing.excluded_urls
+        ],
     ):
-        from opentelemetry.util.http import parse_excluded_urls
+        from opentelemetry.util.http import ExcludeList, parse_excluded_urls
 
-        return parse_excluded_urls(excluded_urls)
+        if isinstance(excluded_urls, list):
+            return ExcludeList(excluded_urls)
+        else:
+            return parse_excluded_urls(excluded_urls)
 
     # Mapping from runner name to RunnerApp file descriptor
     remote_runner_mapping = providers.Static[t.Dict[str, str]]({})

--- a/docs/source/guides/tracing.rst
+++ b/docs/source/guides/tracing.rst
@@ -39,6 +39,19 @@ Here is another example config file for tracing with Jaeger and opentracing:
         address: localhost
         port: 6831
 
+If you would like to exclude some routes from tracing, you can specify them using
+the :code:`excluded_urls` parameter. This parameter can be either a comma-separated 
+string of routes, or a list of strings.
+
+.. code-block:: yaml
+
+    tracing:
+      type: jaeger
+      jaeger:
+        address: localhost
+        port: 6831
+      excluded_urls: readyz,livez,healthz,static_content,docs,metrics
+
 
 When starting a BentoML API model server, provide the path to this config file via the
 CLI argument `--config`:


### PR DESCRIPTION
## What does this PR address?
In https://github.com/bentoml/BentoML/pull/2843, we can specify urls to exclude from tracing as a comma-separated string. It was suggested that this parameter should also support a list of strings. In addition, this PR also adds documentation for excluding routes from tracing.

## Before submitting:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [x] Did your changes require updates to the documentation? Have you updated
  those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?

## Who can help review?

## Testing

This change was also manually tested using docker compose, by setting up the Bento and Jaeger. Test cases are a bit hard to implement; there is currently no infrastructure in place to test any of the tracing features. It could be possible to monkeypatch the opentelemetry exporter to send traces to our own Python class instead of a Jaeger / Zipkin collector and then check the traces that get sent, but I myself am also not too familiar with how the traces get exported, so I have not tried to do this.