### PR TITLE
feat: added port config for prometheus metrics

### DIFF
--- a/bentoml/_internal/configuration/containers.py
+++ b/bentoml/_internal/configuration/containers.py
@@ -89,7 +89,11 @@ SCHEMA = Schema(
             "workers": Or(And(int, _larger_than_zero), None),
             "timeout": And(int, _larger_than_zero),
             "max_request_size": And(int, _larger_than_zero),
-            "metrics": {"enabled": bool, "namespace": str},
+            "metrics": {
+                "enabled": bool,
+                "namespace": str,
+                "port": And(int, _larger_than_zero),
+            },
             "logging": {
                 # TODO add logging level configuration
                 "access": {

--- a/bentoml/_internal/configuration/containers.py
+++ b/bentoml/_internal/configuration/containers.py
@@ -89,11 +89,7 @@ SCHEMA = Schema(
             "workers": Or(And(int, _larger_than_zero), None),
             "timeout": And(int, _larger_than_zero),
             "max_request_size": And(int, _larger_than_zero),
-            "metrics": {
-                "enabled": bool,
-                "namespace": str,
-                "port": And(int, _larger_than_zero),
-            },
+            "metrics": {"enabled": bool, "namespace": str},
             "logging": {
                 # TODO add logging level configuration
                 "access": {
@@ -115,6 +111,8 @@ SCHEMA = Schema(
             },
             "grpc": {
                 "max_concurrent_streams": Or(int, None),
+                "metrics_port": And(int, _larger_than_zero),
+                "metrics_host": And(str, _is_ip_address),
                 "max_message_length": Or(int, None),
                 "maximum_concurrent_rpcs": Or(int, None),
             },

--- a/bentoml/_internal/configuration/default_configuration.yaml
+++ b/bentoml/_internal/configuration/default_configuration.yaml
@@ -8,7 +8,6 @@ api_server:
   metrics:
     enabled: True
     namespace: BENTOML
-    port: 9090
   logging:
     access:
       enabled: True
@@ -29,6 +28,8 @@ api_server:
     max_concurrent_streams: ~
     max_message_length: ~
     maximum_concurrent_rpcs: ~
+    metrics_port: 9090
+    metrics_host: 0.0.0.0
 
 runners:
   batching:

--- a/bentoml/_internal/configuration/default_configuration.yaml
+++ b/bentoml/_internal/configuration/default_configuration.yaml
@@ -8,6 +8,7 @@ api_server:
   metrics:
     enabled: True
     namespace: BENTOML
+    port: 9090
   logging:
     access:
       enabled: True

--- a/bentoml/_internal/server/grpc_app.py
+++ b/bentoml/_internal/server/grpc_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import socket
 import typing as t
 import logging
 import functools
@@ -47,10 +48,12 @@ class GRPCAppFactory:
         enable_metrics: bool = Provide[
             BentoMLContainer.api_server_config.metrics.enabled
         ],
+        metrics_port: int = Provide[BentoMLContainer.api_server_config.metrics.port],
         metrics_client: PrometheusClient = Provide[BentoMLContainer.metrics_client],
     ) -> None:
         self.bento_service = bento_service
         self.enable_metrics = enable_metrics
+        self._metrics_port = metrics_port
         self._maximum_concurrent_rpcs = maximum_concurrent_rpcs
         self._thread_pool_size = _thread_pool_size
         self._metrics_client = metrics_client
@@ -94,17 +97,18 @@ class GRPCAppFactory:
             )
         from .grpc.servicer import create_bento_servicer
 
-        # NOTE: disable metrics server for production
-        # The reason being to create a CircusWatcher for this
-        # and refactor this outside of GrpcAppFactory
-        # from ..utils import reserve_free_port
-        # if self.enable_metrics:
-        #     with reserve_free_port() as port:
-        #         logger.info(
-        #             f"Prometheus metrics for grpc server can be viewed at http://127.0.0.1:{port}/"
-        #         )
-        #     self._metrics_client.start_http_server(port)
-        # TODO: add support for compression when it is fully supported from gRPC.
+        if self.enable_metrics:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                if sock.connect_ex(("localhost", self._metrics_port)) != 0:
+                    self._metrics_client.start_http_server(self._metrics_port)
+                    logger.info(
+                        f"Prometheus metrics for grpc server can be accessed at http://127.0.0.1:{self._metrics_port}"
+                    )
+                else:
+                    logger.warning(
+                        f"Port {self._metrics_port} is already in use. Try using a different port."
+                    )
+
         server = aio.server(
             migration_thread_pool=ThreadPoolExecutor(self._thread_pool_size),
             handlers=self.handlers,

--- a/bentoml/_internal/server/instruments.py
+++ b/bentoml/_internal/server/instruments.py
@@ -1,4 +1,3 @@
-import socket
 import logging
 import contextvars
 from timeit import default_timer
@@ -34,20 +33,8 @@ class MetricsMiddleware:
     def _setup(
         self,
         metrics_client: "PrometheusClient" = Provide[BentoMLContainer.metrics_client],
-        metrics_port: int = Provide[BentoMLContainer.api_server_config.metrics.port],
     ):
         self.metrics_client = metrics_client
-
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            if sock.connect_ex(("localhost", metrics_port)) != 0:
-                self.metrics_client.start_http_server(metrics_port)
-                logger.info(
-                    f"Prometheus metrics can be accessed at http://127.0.0.1:{metrics_port}"
-                )
-            else:
-                logger.warning(
-                    f"Port {metrics_port} is already in use. Metrics can still be accessed at `/metrics` endpoint."
-                )
 
         service_name = self.bento_service.name
         # a valid tag name may includes invalid characters, so we need to escape them

--- a/bentoml/_internal/server/instruments.py
+++ b/bentoml/_internal/server/instruments.py
@@ -1,3 +1,4 @@
+import socket
 import logging
 import contextvars
 from timeit import default_timer
@@ -33,8 +34,21 @@ class MetricsMiddleware:
     def _setup(
         self,
         metrics_client: "PrometheusClient" = Provide[BentoMLContainer.metrics_client],
+        metrics_port: int = Provide[BentoMLContainer.api_server_config.metrics.port],
     ):
         self.metrics_client = metrics_client
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            if sock.connect_ex(("localhost", metrics_port)) != 0:
+                self.metrics_client.start_http_server(metrics_port)
+                logger.info(
+                    f"Prometheus metrics can be accessed at http://127.0.0.1:{metrics_port}"
+                )
+            else:
+                logger.warning(
+                    f"Port {metrics_port} is already in use. Metrics can still be accessed at `/metrics` endpoint."
+                )
+
         service_name = self.bento_service.name
         # a valid tag name may includes invalid characters, so we need to escape them
         # ref: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels


### PR DESCRIPTION
## What does this PR address?
<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

Users can configure a port for prometheus metrics using `config.yml`. Works for both grpc and uvicorn server. For uvicorn server, if the specified port is busy, users can still access the metrics using `/metrics` endpoint.
 
## Before submitting:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [X] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [X] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [X] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
  those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?

## Who can help review?
@aarnphm @ssheng @sauyon  Any feedback is appreciated as always!
<!--
Feel free to ping any of the BentoML members for help on your issue, but don't ping more than three people 😊.
If you know how to use git blame, that is probably the easiest way.

Team members that you can ping:
- @parano
- @yubozhao
- @bojiang
- @ssheng
- @aarnphm
- @sauyon
- @larme
- @yetone
- @jjmachan
-->
