### PR TITLE
fix: `JSON(IODescriptor[JSONType]).to_http_response` returns empty body when the response is `None`.

### DIFF
--- a/bentoml/_internal/io_descriptors/json.py
+++ b/bentoml/_internal/io_descriptors/json.py
@@ -197,13 +197,17 @@ class JSON(IODescriptor[JSONType]):
         if isinstance(obj, pydantic.BaseModel):
             obj = obj.dict()
 
-        json_str = json.dumps(
-            obj,
-            cls=self._json_encoder,
-            ensure_ascii=False,
-            allow_nan=False,
-            indent=None,
-            separators=(",", ":"),
+        json_str = (
+            json.dumps(
+                obj,
+                cls=self._json_encoder,
+                ensure_ascii=False,
+                allow_nan=False,
+                indent=None,
+                separators=(",", ":"),
+            )
+            if obj is not None
+            else None
         )
 
         if ctx is not None:

--- a/tests/unit/_internal/io/test_json.py
+++ b/tests/unit/_internal/io/test_json.py
@@ -1,12 +1,13 @@
 import json
 import typing as t
-from dataclasses import dataclass
 import asyncio
+from dataclasses import dataclass
 
 import numpy as np
-from bentoml._internal.io_descriptors.json import JSON
 import pytest
 import pydantic
+
+from bentoml._internal.io_descriptors.json import JSON
 
 
 @pytest.fixture

--- a/tests/unit/_internal/io/test_json.py
+++ b/tests/unit/_internal/io/test_json.py
@@ -1,10 +1,19 @@
 import json
 import typing as t
 from dataclasses import dataclass
+import asyncio
 
 import numpy as np
+from bentoml._internal.io_descriptors.json import JSON
 import pytest
 import pydantic
+
+
+@pytest.fixture
+def loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
 
 
 @dataclass
@@ -33,7 +42,6 @@ test_arr = t.cast("np.ndarray[t.Any, np.dtype[np.int32]]", np.array([[1]]))
             '{"name":"test","endpoints":["predict","health"]}',
         ),
         (test_arr, "[[1]]"),
-        (None, None),
     ],
 )
 def test_json_encoder(
@@ -53,3 +61,12 @@ def test_json_encoder(
         separators=(",", ":"),
     )
     assert expected == dumped
+
+
+def test_json_description_to_http_response(loop: asyncio.AbstractEventLoop):
+
+    json_description = JSON()
+
+    response = loop.run_until_complete(json_description.to_http_response(None))
+
+    assert b"" == response.body

--- a/tests/unit/_internal/io/test_json.py
+++ b/tests/unit/_internal/io/test_json.py
@@ -22,17 +22,24 @@ test_arr = t.cast("np.ndarray[t.Any, np.dtype[np.int32]]", np.array([[1]]))
 
 
 @pytest.mark.parametrize(
-    "obj",
+    "obj,expected",
     [
-        _ExampleSchema(name="test", endpoints=["predict", "health"]),
-        _Schema(name="test", endpoints=["predict", "health"]),
-        test_arr,
+        (
+            _ExampleSchema(name="test", endpoints=["predict", "health"]),
+            '{"name":"test","endpoints":["predict","health"]}',
+        ),
+        (
+            _Schema(name="test", endpoints=["predict", "health"]),
+            '{"name":"test","endpoints":["predict","health"]}',
+        ),
+        (test_arr, "[[1]]"),
     ],
 )
 def test_json_encoder(
     obj: t.Union[
         _ExampleSchema, pydantic.BaseModel, "np.ndarray[t.Any, np.dtype[t.Any]]"
-    ]
+    ],
+    expected: str,
 ) -> None:
     from bentoml._internal.io_descriptors.json import DefaultJsonEncoder
 
@@ -44,7 +51,4 @@ def test_json_encoder(
         indent=None,
         separators=(",", ":"),
     )
-    assert (
-        dumped == '{"name":"test","endpoints":["predict","health"]}'
-        or dumped == "[[1]]"
-    )
+    assert expected == dumped

--- a/tests/unit/_internal/io/test_json.py
+++ b/tests/unit/_internal/io/test_json.py
@@ -33,13 +33,14 @@ test_arr = t.cast("np.ndarray[t.Any, np.dtype[np.int32]]", np.array([[1]]))
             '{"name":"test","endpoints":["predict","health"]}',
         ),
         (test_arr, "[[1]]"),
+        (None, None),
     ],
 )
 def test_json_encoder(
     obj: t.Union[
-        _ExampleSchema, pydantic.BaseModel, "np.ndarray[t.Any, np.dtype[t.Any]]"
+        _ExampleSchema, pydantic.BaseModel, "np.ndarray[t.Any, np.dtype[t.Any]]", None
     ],
-    expected: str,
+    expected: t.Union[str, None],
 ) -> None:
     from bentoml._internal.io_descriptors.json import DefaultJsonEncoder
 

--- a/tests/unit/_internal/io/test_json.py
+++ b/tests/unit/_internal/io/test_json.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 import pydantic
 
-from bentoml._internal.io_descriptors.json import JSON
+from bentoml.io import JSON
 
 
 @pytest.fixture


### PR DESCRIPTION
## What does this PR address?
The default behavior of `json.dumps` is to transform the return `None` to a string `null`.
But let's say we want to set a status_code 204 (NO_CONTENT), in this case it is expected an empty body.
Then, even if the function returns `None`, an error like  `h11._util.LocalProtocolError: Too much data for declared Content-Length` is thrown because the response has a body (a string `null`).

I described this scenario in this [slack thread](https://bentoml.slack.com/archives/CKRANBHPH/p1659623872508249?thread_ts=1659476156.379999&cid=CKRANBHPH) too.

:bulb: Extra:
 -  I've noticed that the tests `test_json_encoder` had an `or` in the assert expression. To make it more assertive, I refactored it to pass the expected result as a parameter. I'm use to doing this in this kind of test, to keep the assertiveness (but feel free to undo this change if it doesn't comply with the project pattern).
 - To test the async code, I added a `loop` fixture in the `tests/unit/_internal/io/test_json.py`. But if you guys plan to increase the coverage of async code, this fixture could be in another point. Actually, I did it because I didn't find another example of how is async code tested in the project. If there is an example, please let me know to improve this test.
 
 :thinking:  This PR is updating only the JSON(IODescriptor) behavior. If it makes sense to handle the `None` returned this way, it could be replicated in other `IODescriptor` where the `json.dumps` is called 

## Before submitting:
- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
  those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [x] Did you write tests to cover your changes?

## Who can help review?

Feel free to tag members/contributors who can help review your PR.
- @yubozhao 
- @ssheng 

