### PR TITLE
fix: debugger breaks on circus process

### DIFF
--- a/bentoml/_internal/server/__init__.py
+++ b/bentoml/_internal/server/__init__.py
@@ -128,8 +128,7 @@ def serve_development(
             # if debug mode is enabled, we don't want to close stdin for
             # child process in case user use debugger.
             # See https://circus.readthedocs.io/en/latest/for-ops/configuration/
-            close_child_stdin=not get_debug_mode()
-            or not BentoMLContainer.development_mode.get(),
+            close_child_stdin=not get_debug_mode(),
         )
     )
 

--- a/bentoml/_internal/server/__init__.py
+++ b/bentoml/_internal/server/__init__.py
@@ -22,7 +22,6 @@ from ..utils import reserve_free_port
 from ..resource import CpuResource
 from ..utils.uri import path_to_uri
 from ..utils.circus import create_standalone_arbiter
-from ..configuration import get_debug_mode
 from ..utils.analytics import track_serve
 from ..configuration.containers import BentoMLContainer
 
@@ -128,7 +127,7 @@ def serve_development(
             # if debug mode is enabled, we don't want to close stdin for
             # child process in case user use debugger.
             # See https://circus.readthedocs.io/en/latest/for-ops/configuration/
-            close_child_stdin=not get_debug_mode(),
+            close_child_stdin=False,
         )
     )
 

--- a/bentoml/_internal/server/__init__.py
+++ b/bentoml/_internal/server/__init__.py
@@ -124,8 +124,7 @@ def serve_development(
             stop_children=True,
             use_sockets=True,
             working_dir=working_dir,
-            # if debug mode is enabled, we don't want to close stdin for
-            # child process in case user use debugger.
+            # we don't want to close stdin for child process in case user use debugger.
             # See https://circus.readthedocs.io/en/latest/for-ops/configuration/
             close_child_stdin=False,
         )

--- a/bentoml/_internal/server/__init__.py
+++ b/bentoml/_internal/server/__init__.py
@@ -22,6 +22,7 @@ from ..utils import reserve_free_port
 from ..resource import CpuResource
 from ..utils.uri import path_to_uri
 from ..utils.circus import create_standalone_arbiter
+from ..configuration import get_debug_mode
 from ..utils.analytics import track_serve
 from ..configuration.containers import BentoMLContainer
 
@@ -124,6 +125,10 @@ def serve_development(
             stop_children=True,
             use_sockets=True,
             working_dir=working_dir,
+            # if debug mode is enabled, we don't want to close stdin for
+            # child process in case user use debugger.
+            # See https://circus.readthedocs.io/en/latest/for-ops/configuration/
+            close_child_stdin=not get_debug_mode(),
         )
     )
 

--- a/bentoml/_internal/server/__init__.py
+++ b/bentoml/_internal/server/__init__.py
@@ -128,7 +128,8 @@ def serve_development(
             # if debug mode is enabled, we don't want to close stdin for
             # child process in case user use debugger.
             # See https://circus.readthedocs.io/en/latest/for-ops/configuration/
-            close_child_stdin=not get_debug_mode(),
+            close_child_stdin=not get_debug_mode()
+            or not BentoMLContainer.development_mode.get(),
         )
     )
 

--- a/bentoml/_internal/service/loader.py
+++ b/bentoml/_internal/service/loader.py
@@ -21,6 +21,7 @@ from ...exceptions import ImportServiceError
 from ..bento.bento import BENTO_YAML_FILENAME
 from ..bento.bento import BENTO_PROJECT_DIR_NAME
 from ..bento.bento import DEFAULT_BENTO_BUILD_FILE
+from ..configuration import get_debug_mode
 from ..configuration import BENTOML_VERSION
 from ..bento.build_config import BentoBuildConfig
 from ..configuration.containers import BentoMLContainer
@@ -135,6 +136,11 @@ def import_service(
         # Import the service using the Bento's own model store
         try:
             module = importlib.import_module(module_name, package=working_dir)
+            # check if import pdb is present inside service.py
+            if "pdb" in dir(module) and not get_debug_mode():
+                raise ImportError(
+                    "Debug mode is disabled, 'import pdb' is not allowed. Either pass '--debug', 'BENTOML_DEBUG=True' to use pdb with your service code, or remove 'import pdb' completely."
+                )
         except ImportError as e:
             raise ImportServiceError(f'Failed to import module "{module_name}": {e}')
         if not standalone_load:

--- a/bentoml/_internal/service/loader.py
+++ b/bentoml/_internal/service/loader.py
@@ -152,16 +152,6 @@ def import_service(
                         raise BentoMLException(
                             exception_message.format(mode="Debug mode", clause=clause)
                         )
-                    elif not BentoMLContainer.development_mode.get():
-                        raise BentoMLException(
-                            exception_message.format(
-                                mode="Development mode", clause=clause
-                            )
-                        )
-                    else:
-                        logger.warning(
-                            f"'{clause}' is detected inside '{module_name}'. This could means you are importing '{clause}' lazily. Make sure to remove it when finish debugging."
-                        )
         except ImportError as e:
             raise ImportServiceError(f'Failed to import module "{module_name}": {e}')
         if not standalone_load:

--- a/bentoml/_internal/service/loader.py
+++ b/bentoml/_internal/service/loader.py
@@ -142,8 +142,8 @@ def import_service(
             # eager check if import pdb is present inside service definition.
             # For breakpoint see https://peps.python.org/pep-0553/
             checks = {
-                "breakpoint()": re.compile(r"^(?:\s+)|(breakpoint\(\))"),
-                "pdb": re.compile(r"^(?:\s+)|(import|from)+\s(pdb)+"),
+                "breakpoint()": re.compile(r"^(?:\s+)?(breakpoint\(\))"),
+                "pdb": re.compile(r"^(?:\s+)?(import|from)+\s(pdb)+"),
             }
             for clause, rgx in checks.items():
                 if any(rgx.match(line) for line in source):


### PR DESCRIPTION
## What does this PR address?

<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->

Before this PR, if users use debugger inside `service.py` lazily or eagerly:

lazy case:

```python
@svc.api(input=NumpyNdarray(), output=NumpyNdarray())
async def predict(input_series: NDArray[np.float16]) -> NDArray[np.int16]:
    import pdb

    pdb.set_trace()
    return await iris_clf_runner.async_run(input_series)

```

eager case:

```python
import pdb
pdb.set_trace()

@svc.api(input=NumpyNdarray(), output=NumpyNdarray())
async def predict(input_series: NDArray[np.float16]) -> NDArray[np.int16]:
    return await iris_clf_runner.async_run(input_series)
```

This would break when users use `serve`. This has to do with how circus manages
child process and how debugger like `pdb` requires process' stdin. By default
circus omit child stdin, via [`close_child_stdin`](https://circus.readthedocs.io/en/latest/for-ops/configuration/).

This PR address this by disable this behaviour from circus when users pass in
`--debug`. This means that debugger are only meant to use during development.

If users want to use debugger or pdb, one must pass `--debug` or set `BENTOML_DEBUG=True`:

```bash
bentoml serve [--reload] --debug
```

If user are using [breakpoint()](https://peps.python.org/pep-0553/), the above also applies.

This PR will also introduce a eager check for `import pdb` inside service
definition. `pdb` shouldn't be used in production settings (since it is
a debugger)

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
