### PR TITLE
chore: remove typing-extensions dependency

### DIFF
--- a/bentoml/_internal/runner/runnable.py
+++ b/bentoml/_internal/runner/runnable.py
@@ -12,9 +12,9 @@ from ...exceptions import BentoMLException
 
 if TYPE_CHECKING:
     from ..types import AnyType
-    from ..types import ParamSpec
 
-    P = ParamSpec("P")
+    # only use ParamSpec in type checking, as it's only in 3.10
+    P = t.ParamSpec("P")
 else:
     P = t.TypeVar("P")
 

--- a/bentoml/_internal/runner/runnable.py
+++ b/bentoml/_internal/runner/runnable.py
@@ -8,14 +8,17 @@ from typing import TYPE_CHECKING
 import attr
 
 from ..types import LazyType
-from ..types import ParamSpec
 from ...exceptions import BentoMLException
 
 if TYPE_CHECKING:
     from ..types import AnyType
+    from ..types import ParamSpec
+
+    P = ParamSpec("P")
+else:
+    P = t.TypeVar("P")
 
 T = t.TypeVar("T", bound="Runnable")
-P = ParamSpec("P")
 R = t.TypeVar("R")
 
 logger = logging.getLogger(__name__)

--- a/bentoml/_internal/runner/runner.py
+++ b/bentoml/_internal/runner/runner.py
@@ -18,10 +18,10 @@ from .runner_handle import DummyRunnerHandle
 from ..configuration.containers import BentoMLContainer
 
 if TYPE_CHECKING:
-    from ..types import ParamSpec
     from .runnable import RunnableMethodConfig
 
-    P = ParamSpec("P")
+    # only use ParamSpec in type checking, as it's only in 3.10
+    P = t.ParamSpec("P")
 else:
     P = t.TypeVar("P")
 

--- a/bentoml/_internal/runner/runner.py
+++ b/bentoml/_internal/runner/runner.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 import attr
 
 from ..tag import validate_tag_str
-from ..types import ParamSpec
 from ..utils import first_not_none
 from .runnable import Runnable
 from .strategy import Strategy
@@ -19,11 +18,16 @@ from .runner_handle import DummyRunnerHandle
 from ..configuration.containers import BentoMLContainer
 
 if TYPE_CHECKING:
+    from ..types import ParamSpec
     from .runnable import RunnableMethodConfig
 
+    P = ParamSpec("P")
+else:
+    P = t.TypeVar("P")
+
 T = t.TypeVar("T", bound=Runnable)
-P = ParamSpec("P")
 R = t.TypeVar("R")
+
 
 logger = logging.getLogger(__name__)
 

--- a/bentoml/_internal/types.py
+++ b/bentoml/_internal/types.py
@@ -73,22 +73,6 @@ __all__ = [
     "FileLike",
 ]
 
-if TYPE_CHECKING:
-    if sys.version_info < (3, 10):
-        from typing_extensions import ParamSpec
-    else:
-        from typing import ParamSpec
-
-    __all__ = [
-        "ParamSpec",
-        "MetadataType",
-        "MetadataDict",
-        "JSONSerializable",
-        "LazyType",
-        "is_compatible_type",
-        "FileLike",
-    ]
-
 logger = logging.getLogger(__name__)
 
 BATCH_HEADER = "Bentoml-Is-Batch-Request"

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,6 @@ install_requires =
     schema
     simple-di>=0.1.4
     starlette
-    typing-extensions>=4.0
     backports.cached-property;python_version<"3.8"
     importlib-metadata;python_version<"3.8"
     uvicorn


### PR DESCRIPTION
Remove dependency on `typing-extensions`.

Currently uses code from @bojiang's `typing_utils` for `get_args` and `get_origin` specifically for Python 3.7.