### PR TITLE
perf(cli): speed up

### DIFF
--- a/bentoml/__init__.py
+++ b/bentoml/__init__.py
@@ -23,10 +23,6 @@ from ._internal.configuration import load_global_config
 # Inject dependencies and configurations
 load_global_config()
 
-# Model management APIs
-from . import io
-from . import models
-
 # Bento management APIs
 from .bentos import get
 from .bentos import list  # pylint: disable=W0622
@@ -75,6 +71,10 @@ if TYPE_CHECKING:
     from bentoml import tensorflow_v1
     from bentoml import picklable_model
     from bentoml import pytorch_lightning
+
+    # Model management APIs
+    from . import io
+    from . import models
 else:
     from ._internal.utils import LazyLoader as _LazyLoader
 
@@ -111,6 +111,9 @@ else:
         "bentoml.transformers", globals(), "bentoml.transformers"
     )
     xgboost = _LazyLoader("bentoml.xgboost", globals(), "bentoml.xgboost")
+
+    io = _LazyLoader("io", globals(), "bentoml.io")
+    models = _LazyLoader("models", globals(), "bentoml.models")
 
     del _LazyLoader
 

--- a/tests/test_cli_regression.py
+++ b/tests/test_cli_regression.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import time
+import shlex
+
+from click.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_regression():
+    """
+    This test will determine if our CLI are running in an efficient manner.
+    CLI runtime are ~ 340ms via loading entrypoint.
+    The bulk of the time lies in how Python3 resolves dependencies and imports the package.
+    The core runtime for loading bentoml library is around 170ms, and hence the threshold is set.
+    This upper bound is loosely defined, but provide a good enough upper bound for the regression test.
+    """
+    from bentoml_cli.cli import cli
+
+    # note that this should only be run in a single process.
+    with runner.isolation():
+        prog_name = runner.get_default_prog_name(cli)
+        start = time.perf_counter_ns()
+        try:
+            _ = cli.main(args=shlex.split("--help"), prog_name=prog_name)
+        except SystemExit:
+            finish = time.perf_counter_ns() - start
+
+            threshold = 1.7 * 1e6
+            assert finish <= threshold


### PR DESCRIPTION
This PR speeds up CLI performance by 100ms

Tested with `hyperfine` with 3 rounds of warmup and 1000 runs.

This PR also refactor some of the utilities functions that is only used by `bentoml_cli`
to `bentoml_cli` folder, which also helps with import speeds

This PR also add a regression tests to make sure that in the future, if we accidentally
introduce a heavy imports, we will be able to catch it.
