### PR TITLE
docs: add instruction for external package on Alpine

### DIFF
--- a/bentoml/_internal/bento/docker/templates/base_alpine.j2
+++ b/bentoml/_internal/bento/docker/templates/base_alpine.j2
@@ -4,8 +4,7 @@
 
 # Install helpers
 RUN {{ common.mount_cache("/var/cache/apk") }} \
-    apk add --update bash gcc libc-dev shadow musl-dev build-base \
-		linux-headers g++
+    apk add --update bash gcc libc-dev shadow musl-dev build-base linux-headers g++
 
 ENV ENV /root/.bashrc
 

--- a/docs/source/concepts/bento.rst
+++ b/docs/source/concepts/bento.rst
@@ -694,6 +694,24 @@ Here's a basic Docker options configuration:
    However, if you are using a standalone version of Docker, you can install
    BuildKit by following the instructions `here <https://github.com/docker/buildx#installing>`_.
 
+.. note::
+
+   If you are building your Bento container using Alpine image, make sure to add the
+   following to ``system_packages``:
+
+   .. code:: yaml
+
+      docker:
+          distro: alpine
+          system_packages:
+              - gcc
+              - gfortran
+              - build-base
+              - wget
+              - freetype-dev
+              - libpng-dev
+              - openblas-dev
+
 OS Distros
 """"""""""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 requires = [
   # sync with setup.py until we discard non-pep-517/518
   "wheel",
-  "setuptools>=59.0",
-  "setuptools-scm[toml]>=6.2.3",
+  "setuptools<60",
+  "setuptools-scm[toml]>=6.3.1",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
This PR adds a docs section telling users to install additional packages if using Alpine
This has to do with the lack of compiled binary wheels from numpy on Alpine
