### PR TITLE
chore(docs): earlier check for buildx

### DIFF
--- a/bentoml/_internal/utils/buildx.py
+++ b/bentoml/_internal/utils/buildx.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import typing as t
 import logging
-import functools
 import subprocess
 from typing import TYPE_CHECKING
 
@@ -28,20 +27,18 @@ UNAME_M_TO_PLATFORM_MAPPING = {
 }
 
 
-@functools.lru_cache(maxsize=1)
 def health() -> None:
     """
     Check whether buildx is available in given system.
     """
     cmds = DOCKER_BUILDX_CMD + ["--help"]
     try:
-        output = subprocess.check_output(cmds, stderr=subprocess.STDOUT)
-        assert "--builder string" in output.decode("utf-8")
+        output = subprocess.check_output(cmds)
+        print(output)
+        assert "buildx" in output.decode("utf-8")
     except (subprocess.CalledProcessError, AssertionError):
         raise BentoMLException(
-            "BentoML requires Docker Buildx to be installed to support multi-arch builds. "
-            "Buildx comes with Docker Desktop, but one can also install it manually by following "
-            "instructions via https://docs.docker.com/buildx/working-with-buildx/#install."
+            "BentoML requires BuildKit (via Docker Buildx) to be installed to support multi-arch builds. Buildx comes with Docker Desktop, but one can also install it manually by following instructions via https://docs.docker.com/buildx/working-with-buildx/#install."
         )
 
 

--- a/bentoml/_internal/utils/buildx.py
+++ b/bentoml/_internal/utils/buildx.py
@@ -34,7 +34,6 @@ def health() -> None:
     cmds = DOCKER_BUILDX_CMD + ["--help"]
     try:
         output = subprocess.check_output(cmds)
-        print(output)
         assert "buildx" in output.decode("utf-8")
     except (subprocess.CalledProcessError, AssertionError):
         raise BentoMLException(

--- a/bentoml/bentos.py
+++ b/bentoml/bentos.py
@@ -416,9 +416,6 @@ def containerize(
 
     env = {"DOCKER_BUILDKIT": "1", "DOCKER_SCAN_SUGGEST": "false"}
 
-    # run health check whether buildx is install locally
-    buildx.health()
-
     bento = _bento_store.get(tag)
     if not docker_image_tag:
         docker_image_tag = str(bento.tag)

--- a/bentoml_cli/containerize.py
+++ b/bentoml_cli/containerize.py
@@ -220,6 +220,11 @@ def add_containerize_command(cli: click.Group) -> None:
 
         We also pass all given args for `docker buildx` through `bentoml containerize` with ease.
         """
+        from bentoml._internal.utils import buildx
+
+        # run health check whether buildx is install locally
+        buildx.health()
+
         add_hosts = {}
         if add_host:
             for host in add_host:


### PR DESCRIPTION
This PR address to check for buildx earlier

This PR also remove cache stored for buildx to ensure we run that check everytime before
`bentoml containerize`
