### PR TITLE
fix(cli): helper message default values

### DIFF
--- a/bentoml_cli/serve.py
+++ b/bentoml_cli/serve.py
@@ -28,7 +28,7 @@ def add_serve_command(cli: click.Group) -> None:
     @click.option(
         "--port",
         type=click.INT,
-        default=BentoMLContainer.service_port.get,
+        default=BentoMLContainer.service_port.get(),
         help="The port to listen on for the REST api server",
         envvar="BENTOML_PORT",
         show_default=True,
@@ -36,7 +36,7 @@ def add_serve_command(cli: click.Group) -> None:
     @click.option(
         "--host",
         type=click.STRING,
-        default=BentoMLContainer.service_host.get,
+        default=BentoMLContainer.service_host.get(),
         help="The host to bind for the REST api server [defaults: 127.0.0.1(dev), 0.0.0.0(production)]",
         envvar="BENTOML_HOST",
     )
@@ -50,7 +50,7 @@ def add_serve_command(cli: click.Group) -> None:
     @click.option(
         "--backlog",
         type=click.INT,
-        default=BentoMLContainer.api_server_config.backlog.get,
+        default=BentoMLContainer.api_server_config.backlog.get(),
         help="The maximum number of pending connections.",
         show_default=True,
     )

--- a/bentoml_cli/start.py
+++ b/bentoml_cli/start.py
@@ -25,7 +25,7 @@ def add_start_command(cli: click.Group) -> None:
     @click.option(
         "--port",
         type=click.INT,
-        default=BentoMLContainer.service_port.get,
+        default=BentoMLContainer.service_port.get(),
         help="The port to listen on for the REST api server",
         envvar="BENTOML_PORT",
         show_default=True,
@@ -33,14 +33,14 @@ def add_start_command(cli: click.Group) -> None:
     @click.option(
         "--host",
         type=click.STRING,
-        default=BentoMLContainer.service_host.get,
+        default=BentoMLContainer.service_host.get(),
         help="The host to bind for the REST api server [defaults: 127.0.0.1(dev), 0.0.0.0(production)]",
         envvar="BENTOML_HOST",
     )
     @click.option(
         "--backlog",
         type=click.INT,
-        default=BentoMLContainer.api_server_config.backlog.get,
+        default=BentoMLContainer.api_server_config.backlog.get(),
         help="The maximum number of pending connections.",
         show_default=True,
     )
@@ -144,7 +144,7 @@ def add_start_command(cli: click.Group) -> None:
     @click.option(
         "--port",
         type=click.INT,
-        default=BentoMLContainer.service_port.get,
+        default=BentoMLContainer.service_port.get(),
         help="The port to listen on for the REST api server",
         envvar="BENTOML_PORT",
         show_default=True,
@@ -152,14 +152,14 @@ def add_start_command(cli: click.Group) -> None:
     @click.option(
         "--host",
         type=click.STRING,
-        default=BentoMLContainer.service_host.get,
+        default=BentoMLContainer.service_host.get(),
         help="The host to bind for the REST api server [defaults: 127.0.0.1(dev), 0.0.0.0(production)]",
         envvar="BENTOML_HOST",
     )
     @click.option(
         "--backlog",
         type=click.INT,
-        default=BentoMLContainer.api_server_config.backlog.get,
+        default=BentoMLContainer.api_server_config.backlog.get(),
         help="The maximum number of pending connections.",
         show_default=True,
     )


### PR DESCRIPTION
## What does this PR address?
<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

Default value in help text is outputting incorrect value from config.


Before:
```
Options:
  --production                 Run the BentoServer in production mode
  --port INTEGER               The port to listen on for the REST api server  [default: <bound method
                               _ConfigurationItem.get of _ConfigurationItem(_config={'api_server': {'port': 3000,
                               'host': '0.0.0.0', 'backlog': 2048, 'workers': 1, 'timeout': 60, 'max_request_size':
                               20971520, 'metrics': {'enabled': True, 'namespace': 'BENTOML'}, 'logging': {'access':
                               {'enabled': True, 'request_content_length': True, 'request_content_type': True,
                               'response_content_length': True, 'response_content_type': True}}, 'cors': {'enabled':
                               False, 'access_control_allow_origin': None, 'access_control_allow_credentials': None,
                               'access_control_allow_methods': None, 'access_control_allow_headers': None,
                               'access_control_max_age': None, 'access_control_expose_headers': None}}, 'runners':
                               {'batching': {'enabled': True, 'max_batch_size': 100, 'max_latency_ms': 10000},
                               'resources': None, 'logging': {'access': {'enabled': True, 'request_content_length':
                               True, 'request_content_type': True, 'response_content_length': True,
                               'response_content_type': True}}, 'timeout': 300}, 'tracing': {'type': 'zipkin',
                               'sample_rate': None, 'excluded_urls': None, 'zipkin': {'url': None}, 'jaeger':
                               {'address': None, 'port': None}, 'otlp': {'protocol': None, 'url': None}}},
                               _path=('api_server', 'port'))>]
  --host TEXT                  The host to bind for the REST api server [defaults: 127.0.0.1(dev),
                               0.0.0.0(production)]
  --api-workers INTEGER        Specify the number of API server workers to start. Default to number of available CPU
                               cores in production mode
  --backlog INTEGER            The maximum number of pending connections.  [default: <bound method
                               _ConfigurationItem.get of _ConfigurationItem(_config={'api_server': {'port': 3000,
                               'host': '0.0.0.0', 'backlog': 2048, 'workers': 1, 'timeout': 60, 'max_request_size':
                               20971520, 'metrics': {'enabled': True, 'namespace': 'BENTOML'}, 'logging': {'access':
                               {'enabled': True, 'request_content_length': True, 'request_content_type': True,
                               'response_content_length': True, 'response_content_type': True}}, 'cors': {'enabled':
                               False, 'access_control_allow_origin': None, 'access_control_allow_credentials': None,
                               'access_control_allow_methods': None, 'access_control_allow_headers': None,
                               'access_control_max_age': None, 'access_control_expose_headers': None}}, 'runners':
                               {'batching': {'enabled': True, 'max_batch_size': 100, 'max_latency_ms': 10000},
                               'resources': None, 'logging': {'access': {'enabled': True, 'request_content_length':
                               True, 'request_content_type': True, 'response_content_length': True,
                               'response_content_type': True}}, 'timeout': 300}, 'tracing': {'type': 'zipkin',
                               'sample_rate': None, 'excluded_urls': None, 'zipkin': {'url': None}, 'jaeger':
                               {'address': None, 'port': None}, 'otlp': {'protocol': None, 'url': None}}},
                               _path=('api_server', 'backlog'))>]
  --reload                     Reload Service when code changes detected, this is only available in development mode
  --working-dir PATH           When loading from source code, specify the directory to find the Service instance
                               [default: .]
  --ssl-certfile TEXT          SSL certificate file
  --ssl-keyfile TEXT           SSL key file
  --ssl-keyfile-password TEXT  SSL keyfile password
  --ssl-version INTEGER        SSL version to use (see stdlib 'ssl' module)
  --ssl-cert-reqs INTEGER      Whether client certificate is required (see stdlib 'ssl' module)
  --ssl-ca-certs TEXT          CA certificates file
  --ssl-ciphers TEXT           Ciphers to use (see stdlib 'ssl' module)
  -q, --quiet                  Suppress all warnings and info logs
  --verbose, --debug           Generate debug information
  --do-not-track               Do not send usage info
  -h, --help                   Show this message and exit.
```

After:
```
Options:
  --production                 Run the BentoServer in production mode
  --port INTEGER               The port to listen on for the REST api server  [default: 3000]
  --host TEXT                  The host to bind for the REST api server [defaults: 127.0.0.1(dev),
                               0.0.0.0(production)]
  --api-workers INTEGER        Specify the number of API server workers to start. Default to number of available CPU
                               cores in production mode
  --backlog INTEGER            The maximum number of pending connections.  [default: 2048]
  --reload                     Reload Service when code changes detected, this is only available in development mode
  --working-dir PATH           When loading from source code, specify the directory to find the Service instance
                               [default: .]
  --ssl-certfile TEXT          SSL certificate file
  --ssl-keyfile TEXT           SSL key file
  --ssl-keyfile-password TEXT  SSL keyfile password
  --ssl-version INTEGER        SSL version to use (see stdlib 'ssl' module)
  --ssl-cert-reqs INTEGER      Whether client certificate is required (see stdlib 'ssl' module)
  --ssl-ca-certs TEXT          CA certificates file
  --ssl-ciphers TEXT           Ciphers to use (see stdlib 'ssl' module)
  -q, --quiet                  Suppress all warnings and info logs
  --verbose, --debug           Generate debug information
  --do-not-track               Do not send usage info
  -h, --help                   Show this message and exit.
```


## Before submitting:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
  those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?

## Who can help review?

Feel free to tag members/contributors who can help review your PR.
<!--
Feel free to ping any of the BentoML members for help on your issue, but don't ping more than three people 😊.
If you know how to use git blame, that is probably the easiest way.

Team members that you can ping:
- @parano
- @yubozhao
- @bojiang
- @ssheng
- @aarnphm
- @sauyon
- @larme
- @yetone
- @jjmachan
-->
