### PR TITLE
fix: log runner errors explicitly

### DIFF
--- a/bentoml/_internal/server/runner_app.py
+++ b/bentoml/_internal/server/runner_app.py
@@ -217,7 +217,10 @@ class RunnerAppFactory(BaseAppFactory):
             try:
                 ret = await runner_method.async_run(*params.args, **params.kwargs)
             except BaseException as exc:
-                logger.error(f"Exception on runner '{runner_method.runner.name}' method '{runner_method.name}'", exc_info=exc)
+                logger.error(
+                    f"Exception on runner '{runner_method.runner.name}' method '{runner_method.name}'",
+                    exc_info=exc,
+                )
                 return Response(
                     status_code=500,
                     headers={


### PR DESCRIPTION
## What does this PR address?
<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

Catch and log errors raised inside runners explicitly. If not logged explicitly, Uvicorn will log the error but we will lose the trace context causing the exception log to contain no trace and span IDs.

```
2022-08-30T02:32:24-0700 [ERROR] [runner:iris_clf:1] Exception in ASGI application
Traceback (most recent call last):
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/uvicorn/protocols/http/h11_impl.py", line 404, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/uvicorn/middleware/message_logger.py", line 86, in __call__
    raise exc from None
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/uvicorn/middleware/message_logger.py", line 82, in __call__
    await self.app(scope, inner_receive, inner_send)
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/opentelemetry/instrumentation/asgi/__init__.py", line 482, in __call__
    await self.app(scope, otel_receive, otel_send)
  File "/Users/ssheng/github/BentoML/bentoml/_internal/server/access.py", line 124, in __call__
    await self.app(scope, receive, wrapped_send)
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 75, in __call__
    raise exc
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/starlette/middleware/exceptions.py", line 64, in __call__
    await self.app(scope, receive, sender)
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/starlette/routing.py", line 680, in __call__
    await route.handle(scope, receive, send)
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/starlette/routing.py", line 275, in handle
    await self.app(scope, receive, send)
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/starlette/routing.py", line 65, in app
    response = await func(request)
  File "/Users/ssheng/github/BentoML/bentoml/_internal/server/runner_app.py", line 216, in _run
    ret = await runner_method.async_run(*params.args, **params.kwargs)
  File "/Users/ssheng/github/BentoML/bentoml/_internal/runner/runner.py", line 51, in async_run
    return await self.runner._runner_handle.async_run_method(  # type: ignore
  File "/Users/ssheng/github/BentoML/bentoml/_internal/runner/runner_handle/local.py", line 57, in async_run_method
    return await anyio.to_thread.run_sync(
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/anyio/to_thread.py", line 31, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
    return await future
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "/Users/ssheng/github/BentoML/bentoml/_internal/runner/runnable.py", line 139, in method
    return self.func(obj, *args, **kwargs)
  File "/Users/ssheng/github/BentoML/bentoml/_internal/frameworks/sklearn.py", line 199, in _run
    raise ValueError("Test Error in runner")
```

With this fix, errors will be explicitly logged in `runner_app` and an HTTP 500 response will be explicitly returned. Returning the HTTP 500 error by BentoML is ideal because Uvicorn will otherwise close the underlying connection with `connection: close` header, see https://github.com/encode/uvicorn/blob/master/uvicorn/protocols/http/h11_impl.py#L436. Returning HTTP 500 response ourselves will preserve the connection for re-use. See new error message below.

```
2022-08-30T02:24:47-0700 [ERROR] [runner:iris_clf:1] Exception on runner 'iris_clf' method 'predict' (trace=131995672636859149405386882178741931655,span=5671561614823693742,sampled=0)
Traceback (most recent call last):
  File "/Users/ssheng/github/BentoML/bentoml/_internal/server/runner_app.py", line 220, in _run
    ret = await runner_method.async_run(*params.args, **params.kwargs)
  File "/Users/ssheng/github/BentoML/bentoml/_internal/runner/runner.py", line 51, in async_run
    return await self.runner._runner_handle.async_run_method(  # type: ignore
  File "/Users/ssheng/github/BentoML/bentoml/_internal/runner/runner_handle/local.py", line 57, in async_run_method
    return await anyio.to_thread.run_sync(
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/anyio/to_thread.py", line 31, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
    return await future
  File "/opt/miniconda3/envs/bentoml/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "/Users/ssheng/github/BentoML/bentoml/_internal/runner/runnable.py", line 139, in method
    return self.func(obj, *args, **kwargs)
  File "/Users/ssheng/github/BentoML/bentoml/_internal/frameworks/sklearn.py", line 199, in _run
    raise ValueError("Test error in runner")
ValueError: Test error in runner
```

Thanks for reporting the error, @jiewpeng. 

## Before submitting:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
  those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?

## Who can help review?

Feel free to tag members/contributors who can help review your PR.
<!--
Feel free to ping any of the BentoML members for help on your issue, but don't ping more than three people 😊.
If you know how to use git blame, that is probably the easiest way.

Team members that you can ping:
- @parano
- @yubozhao
- @bojiang
- @ssheng
- @aarnphm
- @sauyon
- @larme
- @yetone
- @jjmachan
-->
