### PR TITLE
fix: relax regex for setting environment variables

### DIFF
--- a/bentoml/_internal/bento/build_config.py
+++ b/bentoml/_internal/bento/build_config.py
@@ -106,7 +106,7 @@ def _convert_env(
     if isinstance(env, list):
         env_dict: dict[str, str | None] = {}
         for envvar in env:
-            match = re.match(r"^(\w+)=(\w+)$", envvar)
+            match = re.match(r"^(\w+)=([\w-]+)$", envvar)
             if not match:
                 raise BentoMLException(
                     "All value in `env` list must follow format ENV=VALUE"


### PR DESCRIPTION


## What does this PR address?

This change allows for environment variables with dashes in them.

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
  those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?

## Who can help review?

@aarnphm