### PR TITLE
docs: Wrong path on disabling access logs

### DIFF
--- a/docs/source/guides/logging.rst
+++ b/docs/source/guides/logging.rst
@@ -59,13 +59,14 @@ logs are logged under the ``"bentoml"`` namespace.
 Web Service Request Logging
 """""""""""""""""""""""""""
 
-For web requests, logging can be enabled and disabled using the `logging.access` parameter at the
+For web requests, logging can be enabled and disabled using the `api_server.logging.access` parameter at the
 top level of the ``bentoml_configuration.yml``.
 
 .. code-block:: yaml
 
-    logging:
-      access:
+    api_server:
+      logging:
+        access:
           enabled: False
           # whether to log the size of the request body
           request_content_length: True


### PR DESCRIPTION
## What does this PR address?

In the docs on logging (https://docs.bentoml.org/en/latest/guides/logging.html#web-service-request-logging) it is incorrectly stated that the `logging` key should be at the root path - it should be within the `api_server` key instead.
## Before submitting:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->
- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
  those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?

## Who can help review?

@bojiang
