### PR TITLE
EXPERIMENTAL[grpc]: synonymous configuration fields

### DIFF
--- a/bentoml/_internal/configuration/containers.py
+++ b/bentoml/_internal/configuration/containers.py
@@ -378,6 +378,13 @@ class BentoMLConfiguration:
                 raise BentoMLConfigException(
                     f"Failed to parse config options from the env var: {e}. \n *** Note: You can use '\"' to quote the key if it contains special characters. ***"
                 ) from None
+            # v1 -> v2 changes follow:
+            # - api_server.[max_request_size|cors|port|host] -> api_server.http.$^
+            # - tracing.jaeger.* -> tracing.jaeger.http.*
+            # - add tracing.jaeger.grpc.* with default values
+            # TODO: follow up versioning and deprecation generation.
+            v1_to_v2_migration(config_merger, override_config)
+
             config_merger.merge(self.config, override_config)
 
         if override_config_file is not None or override_config_values is not None:

--- a/bentoml/_internal/configuration/default_configuration.yaml
+++ b/bentoml/_internal/configuration/default_configuration.yaml
@@ -61,11 +61,26 @@ tracing:
   type: zipkin
   sample_rate: ~
   excluded_urls: ~
+  timeout: ~
+  max_tag_value_length: ~
   zipkin:
-    url: ~
+    endpoint: ~
   jaeger:
-    address: ~
-    port: ~
+    protocol: thrift
+    collector_endpoint: ~
+    thrift:
+      agent_host_name: ~
+      agent_port: ~
+      udp_split_oversized_batches: ~
+    grpc:
+      insecure: ~
   otlp:
     protocol: ~
-    url: ~
+    endpoint: ~
+    compression: ~
+    http:
+      certificate_file: ~
+      headers: ~
+    grpc:
+      headers: ~
+      insecure: ~

--- a/tests/unit/_internal/test_configuration.py
+++ b/tests/unit/_internal/test_configuration.py
@@ -44,6 +44,10 @@ api_server:
     assert "cors" not in bentoml_cfg["api_server"]
     assert bentoml_cfg["api_server"]["http"]["host"] == "0.0.0.0"
     assert bentoml_cfg["api_server"]["http"]["port"] == 5000
+    assert (
+        "Field 'api_server.max_request_size' is deprecated and has become obsolete."
+        in caplog.text
+    )
 
 
 @pytest.mark.usefixtures("config_cls")
@@ -68,7 +72,7 @@ api_server:
 """
     with caplog.at_level(logging.WARNING):
         config_cls(OLD_HOST)
-    assert "field 'api_server.host' is deprecated" in caplog.text
+    assert "Field 'api_server.host' is deprecated" in caplog.text
     caplog.clear()
 
     OLD_PORT = """\
@@ -77,7 +81,7 @@ api_server:
 """
     with caplog.at_level(logging.WARNING):
         config_cls(OLD_PORT)
-    assert "field 'api_server.port' is deprecated" in caplog.text
+    assert "Field 'api_server.port' is deprecated" in caplog.text
     caplog.clear()
 
     OLD_MAX_REQUEST_SIZE = """\
@@ -87,7 +91,7 @@ api_server:
     with caplog.at_level(logging.WARNING):
         config_cls(OLD_MAX_REQUEST_SIZE)
     assert (
-        "'api_server.max_request_size' is deprecated and has become obsolete."
+        "Field 'api_server.max_request_size' is deprecated and has become obsolete."
         in caplog.text
     )
     caplog.clear()
@@ -99,7 +103,57 @@ api_server:
 """
     with caplog.at_level(logging.WARNING):
         config_cls(OLD_CORS)
-    assert "field 'api_server.cors' is deprecated" in caplog.text
+    assert "Field 'api_server.cors' is deprecated" in caplog.text
+    caplog.clear()
+
+    OLD_JAEGER_ADDRESS = """\
+tracing:
+    type: jaeger
+    jaeger:
+        address: localhost
+"""
+    with caplog.at_level(logging.WARNING):
+        config_cls(OLD_JAEGER_ADDRESS)
+    assert "Field 'tracing.jaeger.address' is deprecated" in caplog.text
+    caplog.clear()
+
+    OLD_JAEGER_PORT = """\
+tracing:
+    type: jaeger
+    jaeger:
+        port: 6881
+"""
+    with caplog.at_level(logging.WARNING):
+        config_cls(OLD_JAEGER_PORT)
+    assert "Field 'tracing.jaeger.port' is deprecated" in caplog.text
+    caplog.clear()
+
+    OLD_ZIPKIN_URL = """\
+tracing:
+    type: zipkin
+    zipkin:
+        url: localhost:6881
+"""
+    with caplog.at_level(logging.WARNING):
+        config_cls(OLD_ZIPKIN_URL)
+    assert (
+        "Field 'tracing.zipkin.url' is deprecated and has been renamed to 'tracing.zipkin.endpoint'."
+        in caplog.text
+    )
+    caplog.clear()
+
+    OLD_OTLP_URL = """\
+tracing:
+    type: otlp
+    otlp:
+        url: localhost:6881
+"""
+    with caplog.at_level(logging.WARNING):
+        config_cls(OLD_OTLP_URL)
+    assert (
+        "Field 'tracing.otlp.url' is deprecated and has been renamed to 'tracing.otlp.endpoint'."
+        in caplog.text
+    )
     caplog.clear()
 
 

--- a/tests/unit/grpc/interceptors/test_opentelemetry.py
+++ b/tests/unit/grpc/interceptors/test_opentelemetry.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import typing as t
+from typing import TYPE_CHECKING
+
+import grpc
+import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.semconv.trace import SpanAttributes
+
+from bentoml.testing.grpc import create_channel
+from bentoml.grpc.v1alpha1 import service_test_pb2 as pb_test
+from bentoml.grpc.v1alpha1 import service_test_pb2_grpc as services_test
+from bentoml._internal.utils import LazyLoader
+
+if TYPE_CHECKING:
+    import opentelemetry.instrumentation.grpc as otel_grpc
+    from opentelemetry.sdk.trace import Span
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+else:
+    otel_grpc = LazyLoader("otel_grpc", globals(), "opentelemetry.instrumentation.grpc")
+
+
+def assert_span_has_attributes(span: Span, attributes: dict[str, t.Any]):
+    assert span.attributes
+    for key, value in attributes.items():
+        assert key in span.attributes
+        assert span.attributes[key] == value
+
+
+def sanity_check(span: Span, name: str):
+    # check if span name is the same as rpc_call
+    assert span.name == name
+    assert span.kind == trace_api.SpanKind.SERVER
+
+    # sanity check
+    assert span.instrumentation_info.name == otel_grpc.__name__
+    assert span.instrumentation_info.version == otel_grpc.__version__
+
+
+@pytest.mark.skip("Currently broken test, will revisit after experimental release.")
+@pytest.mark.otel
+@pytest.mark.asyncio
+async def test_otel_interceptor(memory_exporter: InMemorySpanExporter, host: str):
+    async with create_channel(host) as channel:
+        stub = services_test.TestServiceStub(channel)  # type: ignore (no async types)
+        await stub.Execute(pb_test.ExecuteRequest(input="BentoML"))
+
+        spans_list = t.cast("list[Span]", memory_exporter.get_finished_spans())
+        assert len(spans_list) == 1
+        # We only care about the second span, which is the rpc_call
+        span = spans_list[0]
+        service_name = "bentoml.testing.v1alpha1.TestService"
+
+        sanity_check(span, f"/{service_name}/Execute")
+        assert_span_has_attributes(
+            span,
+            {
+                SpanAttributes.NET_PEER_IP: "[::1]",
+                SpanAttributes.NET_PEER_NAME: "localhost",
+                SpanAttributes.RPC_METHOD: "Execute",
+                SpanAttributes.RPC_SERVICE: service_name,
+                SpanAttributes.RPC_SYSTEM: "grpc",
+                SpanAttributes.RPC_GRPC_STATUS_CODE: grpc.StatusCode.OK.value[0],
+            },
+        )


### PR DESCRIPTION
Address #2986 

This PR address some tests followup as well as some configuration refactor to be consistent with correct exporter field

This PR will also introduce tests related to gRPC tracing interceptor

Depends on #2808 and will rebase to main once #2808 is merged.