### PR TITLE
revert(3017): filter write-only mime type for Image IO

### DIFF
--- a/bentoml/_internal/io_descriptors/image.py
+++ b/bentoml/_internal/io_descriptors/image.py
@@ -57,6 +57,10 @@ ImageType = t.Union["PIL.Image.Image", "ext.NpNDArray"]
 DEFAULT_PIL_MODE = "RGB"
 
 
+PIL_WRITE_ONLY_FORMATS = {
+    "PALM",
+    "PDF",
+}
 MIME_EXT_MAPPING: dict[str, str] = None  # type: ignore (lazy constant)
 
 
@@ -72,7 +76,7 @@ def initialize_pillow():
         )
 
     PIL.Image.init()
-    MIME_EXT_MAPPING = {v: k for k, v in PIL.Image.MIME.items()}  # type: ignore (lazy constant)
+    MIME_EXT_MAPPING = {v: k for k, v in PIL.Image.MIME.items() if k not in PIL_WRITE_ONLY_FORMATS}  # type: ignore (lazy constant)
 
 
 class Image(IODescriptor[ImageType]):

--- a/tests/e2e/bento_server_general_features/tests/test_io.py
+++ b/tests/e2e/bento_server_general_features/tests/test_io.py
@@ -211,7 +211,7 @@ async def test_image(host, img_file):
         "POST",
         f"http://{host}/echo_image",
         data=b,
-        headers={"Content-Type": "application/vnd.bentoml.multiple_outputs"},
+        headers={"Content-Type": "application/pdf"},
         assert_status=400,
     )
 


### PR DESCRIPTION
pdf reading is not supported by PIL