### PR TITLE
fix(io): Pandas OpenAPI schema

### DIFF
--- a/bentoml/_internal/io_descriptors/pandas.py
+++ b/bentoml/_internal/io_descriptors/pandas.py
@@ -729,7 +729,7 @@ class PandasSeries(IODescriptor["ext.PdSeries"]):
     def __init__(
         self,
         orient: ext.SeriesOrient = "records",
-        dtype: ext.PdDTypeArg | str | None = None,
+        dtype: ext.PdDTypeArg | None = None,
         enforce_dtype: bool = False,
         shape: tuple[int, ...] | None = None,
         enforce_shape: bool = False,

--- a/bentoml/_internal/io_descriptors/pandas.py
+++ b/bentoml/_internal/io_descriptors/pandas.py
@@ -132,8 +132,7 @@ def _series_openapi_schema(dtype: bool | ext.PdDTypeArg | None, orient: ext.Seri
             return Schema(type="object", additionalProperties=Schema(type=_openapi_types(dtype)))
         if orient in ["records", "columns"]:
             return Schema(type="array", items=Schema(type=_openapi_types(dtype)))
-    else:
-        return Schema(type="object")
+    return Schema(type="object")
 
 class SerializationFormat(Enum):
     JSON = "application/json"

--- a/bentoml/_internal/io_descriptors/pandas.py
+++ b/bentoml/_internal/io_descriptors/pandas.py
@@ -126,7 +126,7 @@ def _dataframe_openapi_schema(dtype: bool | ext.PdDTypeArg | None, orient: ext.D
         return Schema(type="object")
 
 
-def _series_openapi_schema(dtype: bool | ext.PdDTypeArg | str | None, orient: ext.SeriesOrient = None) -> Schema:  # pragma: no cover
+def _series_openapi_schema(dtype: bool | ext.PdDTypeArg | None, orient: ext.SeriesOrient = None) -> Schema:  # pragma: no cover
     if isinstance(dtype, str):
         if orient in ["index", "values"]:
             return Schema(type="object", additionalProperties=Schema(type=_openapi_types(dtype)))

--- a/bentoml/_internal/io_descriptors/pandas.py
+++ b/bentoml/_internal/io_descriptors/pandas.py
@@ -78,7 +78,9 @@ def _openapi_types(item: str) -> str:  # pragma: no cover
         return "object"
 
 
-def _dataframe_openapi_schema(dtype: bool | ext.PdDTypeArg | None, orient: ext.DataFrameOrient = None) -> Schema:  # pragma: no cover
+def _dataframe_openapi_schema(
+    dtype: bool | ext.PdDTypeArg | None, orient: ext.DataFrameOrient = None
+) -> Schema:  # pragma: no cover
     if isinstance(dtype, dict):
         if orient == "records":
             return Schema(
@@ -86,10 +88,9 @@ def _dataframe_openapi_schema(dtype: bool | ext.PdDTypeArg | None, orient: ext.D
                 items=Schema(
                     type="object",
                     properties={
-                        k: Schema(type=_openapi_types(v))
-                        for k, v in dtype.items()
-                    }
-                )
+                        k: Schema(type=_openapi_types(v)) for k, v in dtype.items()
+                    },
+                ),
             )
         if orient == "index":
             return Schema(
@@ -97,10 +98,9 @@ def _dataframe_openapi_schema(dtype: bool | ext.PdDTypeArg | None, orient: ext.D
                 additionalProperties=Schema(
                     type="object",
                     properties={
-                        k: Schema(type=_openapi_types(v))
-                        for k, v in dtype.items()
-                    }
-                )
+                        k: Schema(type=_openapi_types(v)) for k, v in dtype.items()
+                    },
+                ),
             )
         if orient == "columns":
             return Schema(
@@ -108,11 +108,10 @@ def _dataframe_openapi_schema(dtype: bool | ext.PdDTypeArg | None, orient: ext.D
                 properties={
                     k: Schema(
                         type="object",
-                        additionalProperties=Schema(
-                            type=_openapi_types(v)
-                        ))
+                        additionalProperties=Schema(type=_openapi_types(v)),
+                    )
                     for k, v in dtype.items()
-                }
+                },
             )
 
         return Schema(
@@ -126,13 +125,18 @@ def _dataframe_openapi_schema(dtype: bool | ext.PdDTypeArg | None, orient: ext.D
         return Schema(type="object")
 
 
-def _series_openapi_schema(dtype: bool | ext.PdDTypeArg | None, orient: ext.SeriesOrient = None) -> Schema:  # pragma: no cover
+def _series_openapi_schema(
+    dtype: bool | ext.PdDTypeArg | None, orient: ext.SeriesOrient = None
+) -> Schema:  # pragma: no cover
     if isinstance(dtype, str):
         if orient in ["index", "values"]:
-            return Schema(type="object", additionalProperties=Schema(type=_openapi_types(dtype)))
+            return Schema(
+                type="object", additionalProperties=Schema(type=_openapi_types(dtype))
+            )
         if orient in ["records", "columns"]:
             return Schema(type="array", items=Schema(type=_openapi_types(dtype)))
     return Schema(type="object")
+
 
 class SerializationFormat(Enum):
     JSON = "application/json"


### PR DESCRIPTION
Bug Fix: PandasDataFrame orient does not change open api schema generation to expected format. 
Bug Fix: PandasSeries orient does not change open api schema generation to expected format. 
Separated openapi schema generation for each.
PandasSeries from_http_request() seem to be missing io.BytesIO.  Added it.

## What does this PR address?

When specifying the pandas PandasDataFrame and PandasSeries input spec the generated open api schemas do not match the expected schema with the provided orient parameter.  This shows in the bento serve index webpage in the request body and successful response output sections.  This PR seeks to address this by adding orient to the schema generation in addition to the existing the dtype dict parameter (Dataframe) or dtype str parameter (Series) to return the correct Schema.

Fixes #(issue)

## Before submitting:

- [X] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [X] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
