### PR TITLE
feat: cascade health checks to runner

### DIFF
--- a/src/bentoml/_internal/configuration/containers.py
+++ b/src/bentoml/_internal/configuration/containers.py
@@ -171,7 +171,7 @@ SCHEMA = Schema(
                 "max_message_length": Or(int, None),
                 "maximum_concurrent_rpcs": Or(int, None),
             },
-            "runner_readiness_probe": {"check_runners": bool},
+            "health_probe": {"check_runners": bool},
         },
         "runners": {
             **RUNNER_CFG_SCHEMA,

--- a/src/bentoml/_internal/configuration/containers.py
+++ b/src/bentoml/_internal/configuration/containers.py
@@ -171,7 +171,11 @@ SCHEMA = Schema(
                 "max_message_length": Or(int, None),
                 "maximum_concurrent_rpcs": Or(int, None),
             },
-            "health_probe": {"check_runners": bool},
+            "runner_probe": {
+                "enabled": bool,
+                "timeout": int,
+                "period": int,
+            },
         },
         "runners": {
             **RUNNER_CFG_SCHEMA,

--- a/src/bentoml/_internal/configuration/containers.py
+++ b/src/bentoml/_internal/configuration/containers.py
@@ -171,6 +171,7 @@ SCHEMA = Schema(
                 "max_message_length": Or(int, None),
                 "maximum_concurrent_rpcs": Or(int, None),
             },
+            "runner_readiness_probe": {"check_runners": bool},
         },
         "runners": {
             **RUNNER_CFG_SCHEMA,

--- a/src/bentoml/_internal/configuration/default_configuration.yaml
+++ b/src/bentoml/_internal/configuration/default_configuration.yaml
@@ -38,6 +38,8 @@ api_server:
     metrics:
       host: 0.0.0.0
       port: 3001
+  runner_readiness_probe:
+    check_runners: True
 
 runners:
   batching:

--- a/src/bentoml/_internal/configuration/default_configuration.yaml
+++ b/src/bentoml/_internal/configuration/default_configuration.yaml
@@ -38,8 +38,10 @@ api_server:
     metrics:
       host: 0.0.0.0
       port: 3001
-  health_probe:
-    check_runners: True
+  runner_probe: # configure whether the API server's health check endpoints (readyz, livez, healthz) also check the runners
+    enabled: true
+    timeout: 1
+    period: 10
 
 runners:
   batching:

--- a/src/bentoml/_internal/configuration/default_configuration.yaml
+++ b/src/bentoml/_internal/configuration/default_configuration.yaml
@@ -38,7 +38,7 @@ api_server:
     metrics:
       host: 0.0.0.0
       port: 3001
-  runner_readiness_probe:
+  health_probe:
     check_runners: True
 
 runners:

--- a/src/bentoml/_internal/runner/runner.py
+++ b/src/bentoml/_internal/runner/runner.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import attr
+from simple_di import inject
 from simple_di import Provide
 
 from ..tag import validate_tag_str
@@ -241,6 +242,7 @@ class Runner:
     def destroy(self):
         object.__setattr__(self, "_runner_handle", DummyRunnerHandle())
 
+    @inject
     async def runner_handle_is_ready(
         self,
         timeout: int = Provide[BentoMLContainer.api_server_config.runner_probe.timeout],

--- a/src/bentoml/_internal/runner/runner.py
+++ b/src/bentoml/_internal/runner/runner.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import attr
+from simple_di import Provide
 
 from ..tag import validate_tag_str
 from ..utils import first_not_none

--- a/src/bentoml/_internal/runner/runner.py
+++ b/src/bentoml/_internal/runner/runner.py
@@ -240,6 +240,9 @@ class Runner:
     def destroy(self):
         object.__setattr__(self, "_runner_handle", DummyRunnerHandle())
 
+    async def runner_handle_is_ready(self) -> bool:
+        return await self._runner_handle.is_ready()
+
     @property
     def scheduled_worker_count(self) -> int:
         return self.scheduling_strategy.get_worker_count(

--- a/src/bentoml/_internal/runner/runner.py
+++ b/src/bentoml/_internal/runner/runner.py
@@ -241,8 +241,11 @@ class Runner:
     def destroy(self):
         object.__setattr__(self, "_runner_handle", DummyRunnerHandle())
 
-    async def runner_handle_is_ready(self) -> bool:
-        return await self._runner_handle.is_ready()
+    async def runner_handle_is_ready(
+        self,
+        timeout: int = Provide[BentoMLContainer.api_server_config.runner_probe.timeout],
+    ) -> bool:
+        return await self._runner_handle.is_ready(timeout)
 
     @property
     def scheduled_worker_count(self) -> int:

--- a/src/bentoml/_internal/runner/runner_handle/__init__.py
+++ b/src/bentoml/_internal/runner/runner_handle/__init__.py
@@ -53,6 +53,9 @@ class DummyRunnerHandle(RunnerHandle):
     ) -> None:
         pass
 
+    async def is_ready(self) -> bool:
+        return True
+
     def run_method(
         self,
         __bentoml_method: RunnerMethod[t.Any, t.Any, t.Any],

--- a/src/bentoml/_internal/runner/runner_handle/__init__.py
+++ b/src/bentoml/_internal/runner/runner_handle/__init__.py
@@ -25,6 +25,10 @@ class RunnerHandle(ABC):
         ...
 
     @abstractmethod
+    def is_ready(self) -> bool:
+        return True
+
+    @abstractmethod
     def run_method(
         self,
         __bentoml_method: RunnerMethod[t.Any, P, R],

--- a/src/bentoml/_internal/runner/runner_handle/__init__.py
+++ b/src/bentoml/_internal/runner/runner_handle/__init__.py
@@ -25,7 +25,7 @@ class RunnerHandle(ABC):
         ...
 
     @abstractmethod
-    async def is_ready(self) -> bool:
+    async def is_ready(self, timeout: int) -> bool:
         return True
 
     @abstractmethod
@@ -53,7 +53,7 @@ class DummyRunnerHandle(RunnerHandle):
     ) -> None:
         pass
 
-    async def is_ready(self) -> bool:
+    async def is_ready(self, timeout: int) -> bool:
         return True
 
     def run_method(

--- a/src/bentoml/_internal/runner/runner_handle/__init__.py
+++ b/src/bentoml/_internal/runner/runner_handle/__init__.py
@@ -25,7 +25,7 @@ class RunnerHandle(ABC):
         ...
 
     @abstractmethod
-    def is_ready(self) -> bool:
+    async def is_ready(self) -> bool:
         return True
 
     @abstractmethod

--- a/src/bentoml/_internal/runner/runner_handle/local.py
+++ b/src/bentoml/_internal/runner/runner_handle/local.py
@@ -25,7 +25,7 @@ class LocalRunnerRef(RunnerHandle):
         self._runnable = runner.runnable_class(**runner.runnable_init_params)  # type: ignore
         self._limiter = None
 
-    def is_ready(self) -> bool:
+    async def is_ready(self) -> bool:
         return True
 
     def run_method(

--- a/src/bentoml/_internal/runner/runner_handle/local.py
+++ b/src/bentoml/_internal/runner/runner_handle/local.py
@@ -25,6 +25,9 @@ class LocalRunnerRef(RunnerHandle):
         self._runnable = runner.runnable_class(**runner.runnable_init_params)  # type: ignore
         self._limiter = None
 
+    def is_ready(self) -> bool:
+        return True
+
     def run_method(
         self,
         __bentoml_method: RunnerMethod[t.Any, P, R],

--- a/src/bentoml/_internal/runner/runner_handle/local.py
+++ b/src/bentoml/_internal/runner/runner_handle/local.py
@@ -25,7 +25,7 @@ class LocalRunnerRef(RunnerHandle):
         self._runnable = runner.runnable_class(**runner.runnable_init_params)  # type: ignore
         self._limiter = None
 
-    async def is_ready(self) -> bool:
+    async def is_ready(self, timeout: int) -> bool:
         return True
 
     def run_method(

--- a/src/bentoml/_internal/runner/runner_handle/remote.py
+++ b/src/bentoml/_internal/runner/runner_handle/remote.py
@@ -219,6 +219,7 @@ class RemoteRunnerClient(RunnerHandle):
     async def is_ready(self) -> bool:
         import aiohttp
 
+        # modeling after k8s' liveness probe frequency of 5s (see `periodSeconds` at https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
         timeout = aiohttp.ClientTimeout(total=5)
         async with self._client.get(f"{self._addr}/readyz", timeout=timeout) as resp:
             return resp.status == 200

--- a/src/bentoml/_internal/runner/runner_handle/remote.py
+++ b/src/bentoml/_internal/runner/runner_handle/remote.py
@@ -222,7 +222,17 @@ class RemoteRunnerClient(RunnerHandle):
         # default kubernetes probe timeout is also 1s; see
         # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
         timeout = aiohttp.ClientTimeout(total=1)
-        async with self._client.get(f"{self._addr}/readyz", timeout=timeout) as resp:
+        async with self._client.get(
+            f"{self._addr}/readyz",
+            headers={
+                "Bento-Name": component_context.bento_name,
+                "Bento-Version": component_context.bento_version,
+                "Runner-Name": self._runner.name,
+                "Yatai-Bento-Deployment-Name": component_context.yatai_bento_deployment_name,
+                "Yatai-Bento-Deployment-Namespace": component_context.yatai_bento_deployment_namespace,
+            },
+            timeout=timeout,
+        ) as resp:
             return resp.status == 200
 
     def __del__(self) -> None:

--- a/src/bentoml/_internal/runner/runner_handle/remote.py
+++ b/src/bentoml/_internal/runner/runner_handle/remote.py
@@ -219,8 +219,9 @@ class RemoteRunnerClient(RunnerHandle):
     async def is_ready(self) -> bool:
         import aiohttp
 
-        # modeling after k8s' liveness probe frequency of 5s (see `periodSeconds` at https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
-        timeout = aiohttp.ClientTimeout(total=5)
+        # default kubernetes probe timeout is also 1s; see
+        # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+        timeout = aiohttp.ClientTimeout(total=1)
         async with self._client.get(f"{self._addr}/readyz", timeout=timeout) as resp:
             return resp.status == 200
 

--- a/src/bentoml/_internal/runner/runner_handle/remote.py
+++ b/src/bentoml/_internal/runner/runner_handle/remote.py
@@ -130,7 +130,7 @@ class RemoteRunnerClient(RunnerHandle):
         __bentoml_method: RunnerMethod[t.Any, P, R],
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> R:
+    ) -> R | tuple[R, ...]:
         from ...runner.container import AutoContainer
 
         inp_batch_dim = __bentoml_method.config.batch_dim[0]

--- a/src/bentoml/_internal/runner/runner_handle/remote.py
+++ b/src/bentoml/_internal/runner/runner_handle/remote.py
@@ -216,12 +216,12 @@ class RemoteRunnerClient(RunnerHandle):
             ),
         )
 
-    async def is_ready(self) -> bool:
+    async def is_ready(self, timeout: int) -> bool:
         import aiohttp
 
         # default kubernetes probe timeout is also 1s; see
         # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
-        timeout = aiohttp.ClientTimeout(total=1)
+        aio_timeout = aiohttp.ClientTimeout(total=timeout)
         async with self._client.get(
             f"{self._addr}/readyz",
             headers={
@@ -231,7 +231,7 @@ class RemoteRunnerClient(RunnerHandle):
                 "Yatai-Bento-Deployment-Name": component_context.yatai_bento_deployment_name,
                 "Yatai-Bento-Deployment-Namespace": component_context.yatai_bento_deployment_namespace,
             },
-            timeout=timeout,
+            timeout=aio_timeout,
         ) as resp:
             return resp.status == 200
 

--- a/src/bentoml/_internal/runner/runner_handle/remote.py
+++ b/src/bentoml/_internal/runner/runner_handle/remote.py
@@ -216,5 +216,9 @@ class RemoteRunnerClient(RunnerHandle):
             ),
         )
 
+    async def is_ready(self) -> bool:
+        async with self._client.get(f"{self._addr}/readyz") as resp:
+            return resp.status == 200
+
     def __del__(self) -> None:
         self._close_conn()

--- a/src/bentoml/_internal/runner/runner_handle/remote.py
+++ b/src/bentoml/_internal/runner/runner_handle/remote.py
@@ -217,7 +217,10 @@ class RemoteRunnerClient(RunnerHandle):
         )
 
     async def is_ready(self) -> bool:
-        async with self._client.get(f"{self._addr}/readyz") as resp:
+        import aiohttp
+
+        timeout = aiohttp.ClientTimeout(total=5)
+        async with self._client.get(f"{self._addr}/readyz", timeout=timeout) as resp:
             return resp.status == 200
 
     def __del__(self) -> None:

--- a/src/bentoml/_internal/server/grpc_app.py
+++ b/src/bentoml/_internal/server/grpc_app.py
@@ -89,11 +89,6 @@ class GRPCAppFactory:
         on_startup.append(self.wait_for_runner_ready)
         return on_startup
 
-        raise Exception(
-            "Runners %s failed to be ready within %s seconds"
-            % (self.bento_service.runners, timeout)
-        )
-
     @property
     def on_shutdown(self) -> list[t.Callable[[], None]]:
         on_shutdown = [self.bento_service.on_grpc_server_shutdown]

--- a/src/bentoml/_internal/server/grpc_app.py
+++ b/src/bentoml/_internal/server/grpc_app.py
@@ -23,11 +23,6 @@ if TYPE_CHECKING:
     from .grpc.servicer import Servicer
 
     OnStartup = list[t.Callable[[], None | t.Coroutine[t.Any, t.Any, None]]]
-    from grpc import aio
-else:
-    from bentoml.grpc.utils import import_grpc
-
-    _, aio = import_grpc()
 
 
 class GRPCAppFactory:
@@ -74,7 +69,7 @@ class GRPCAppFactory:
                     break
                 else:
                     time.sleep(check_interval)
-            except (ConnectionError, socket.timeout, aio.AioRpcError) as e:
+            except (ConnectionError, socket.timeout) as e:
                 logger.debug("[%s] Retrying ..." % e)
                 time.sleep(check_interval)
         raise RuntimeError(

--- a/src/bentoml/_internal/server/grpc_app.py
+++ b/src/bentoml/_internal/server/grpc_app.py
@@ -47,9 +47,11 @@ class GRPCAppFactory:
     async def wait_for_runner_ready(
         self,
         *,
-        check_interval: int = 5,
+        check_interval: int = Provide[
+            BentoMLContainer.api_server_config.runner_probe.period
+        ],
     ):
-        if BentoMLContainer.api_server_config.health_probe.check_runners.get():
+        if BentoMLContainer.api_server_config.runner_probe.enabled.get():
             logger.info(
                 "Waiting for runners %r to be ready...", self.bento_service.runners
             )

--- a/src/bentoml/_internal/server/grpc_app.py
+++ b/src/bentoml/_internal/server/grpc_app.py
@@ -62,7 +62,6 @@ class GRPCAppFactory:
                         runner.runner_handle_is_ready()
                         for runner in self.bento_service.runners
                     )
-
                     runners_ready = all(await asyncio.gather(*runner_statuses))
 
                     if runners_ready:

--- a/src/bentoml/_internal/server/grpc_app.py
+++ b/src/bentoml/_internal/server/grpc_app.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import time
-import socket
 import typing as t
 import asyncio
 import logging
@@ -49,14 +48,14 @@ class GRPCAppFactory:
     async def wait_for_runner_ready(
         self,
         *,
-        runner_timeout: int = Provide[BentoMLContainer.runners_config.timeout],
         check_interval: int = 5,
     ):
-        start_time = time.time()
+
         logger.debug(
             "Waiting for runners {!r} to be ready...".format(self.bento_service.runners)
         )
-        while time.time() - start_time < runner_timeout:
+
+        while True:
             try:
                 if all(
                     await asyncio.gather(
@@ -69,12 +68,9 @@ class GRPCAppFactory:
                     break
                 else:
                     time.sleep(check_interval)
-            except (ConnectionError, socket.timeout) as e:
+            except ConnectionError as e:
                 logger.debug("[%s] Retrying ..." % e)
                 time.sleep(check_interval)
-        raise RuntimeError(
-            f"Timed out waiting {runner_timeout} seconds for runners to be ready."
-        )
 
     @property
     def on_startup(self) -> OnStartup:

--- a/src/bentoml/_internal/server/http_app.py
+++ b/src/bentoml/_internal/server/http_app.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 
 from simple_di import inject
 from simple_di import Provide
-
 from starlette.responses import PlainTextResponse
 from starlette.exceptions import HTTPException
 

--- a/src/bentoml/_internal/server/http_app.py
+++ b/src/bentoml/_internal/server/http_app.py
@@ -272,19 +272,17 @@ class HTTPAppFactory(BaseAppFactory):
 
     async def readyz(self, _: "Request") -> "Response":
 
-        ready_status = all(
+        if all(
             await asyncio.gather(
                 *(
                     runner.runner_handle_is_ready()
                     for runner in self.bento_service.runners
                 )
             )
-        )
-
-        if ready_status:
+        ):
             return PlainTextResponse("\n", status_code=200)
-        else:
-            raise HTTPException(500)
+
+        raise HTTPException(500)
 
     @property
     def on_shutdown(self) -> list[t.Callable[[], None]]:

--- a/src/bentoml/_internal/server/http_app.py
+++ b/src/bentoml/_internal/server/http_app.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import os
 import sys
-import time
-import socket
 import typing as t
 import asyncio
 import logging
@@ -272,33 +270,17 @@ class HTTPAppFactory(BaseAppFactory):
         return on_startup
 
     async def readyz(self, _: "Request") -> "Response":
+        if all(
+            await asyncio.gather(
+                *(
+                    runner.runner_handle_is_ready()
+                    for runner in self.bento_service.runners
+                )
+            )
+        ):
+            return PlainTextResponse("\n", status_code=200)
 
-        runner_timeout = BentoMLContainer.runners_config.timeout.get()
-        check_interval = 5
-        start_time = time.time()
-        logger.debug(
-            "Waiting for runners {!r} to be ready...".format(self.bento_service.runners)
-        )
-        while time.time() - start_time < runner_timeout:
-            try:
-                if all(
-                    await asyncio.gather(
-                        *(
-                            runner.runner_handle_is_ready()
-                            for runner in self.bento_service.runners
-                        )
-                    )
-                ):
-                    return PlainTextResponse("\n", status_code=200)
-                else:
-                    time.sleep(check_interval)
-            except (ConnectionError, socket.timeout, HTTPException) as e:
-                logger.debug("[%s] Retrying ..." % e)
-                time.sleep(check_interval)
-
-        raise RuntimeError(
-            f"Timed out waiting {runner_timeout} seconds for runners to be ready."
-        )
+        raise HTTPException(status_code=500, detail="Runners are not ready.")
 
     @property
     def on_shutdown(self) -> list[t.Callable[[], None]]:

--- a/src/bentoml/_internal/server/http_app.py
+++ b/src/bentoml/_internal/server/http_app.py
@@ -268,7 +268,6 @@ class HTTPAppFactory(BaseAppFactory):
         else:
             for runner in self.bento_service.runners:
                 on_startup.append(runner.init_client)
-
         on_startup.extend(super().on_startup)
         return on_startup
 

--- a/src/bentoml/_internal/server/http_app.py
+++ b/src/bentoml/_internal/server/http_app.py
@@ -269,12 +269,8 @@ class HTTPAppFactory(BaseAppFactory):
         on_startup.extend(super().on_startup)
         return on_startup
 
-    async def readyz(
-        self, _: "Request"
-    ) -> "Response":  # TODO call the config here, if false return 200
-        if (
-            BentoMLContainer.api_server_config.runner_readiness_probe.check_runners.get()
-        ):
+    async def readyz(self, _: "Request") -> "Response":
+        if BentoMLContainer.api_server_config.health_probe.check_runners.get():
             if all(
                 await asyncio.gather(
                     *(

--- a/src/bentoml/_internal/server/http_app.py
+++ b/src/bentoml/_internal/server/http_app.py
@@ -270,11 +270,10 @@ class HTTPAppFactory(BaseAppFactory):
         return on_startup
 
     async def readyz(self, _: "Request") -> "Response":
-        if BentoMLContainer.api_server_config.health_probe.check_runners.get():
+        if BentoMLContainer.api_server_config.runner_probe.enabled.get():
             runner_statuses = (
                 runner.runner_handle_is_ready() for runner in self.bento_service.runners
             )
-
             runners_ready = all(await asyncio.gather(*runner_statuses))
 
             if not runners_ready:

--- a/src/bentoml/_internal/server/http_app.py
+++ b/src/bentoml/_internal/server/http_app.py
@@ -264,6 +264,8 @@ class HTTPAppFactory(BaseAppFactory):
         else:
             for runner in self.bento_service.runners:
                 on_startup.append(runner.init_client)
+        for runner in self.bento_service.runners:
+            asyncio.get_event_loop().run_until_complete(runner.runner_handle_is_ready())
         on_startup.extend(super().on_startup)
         return on_startup
 

--- a/src/bentoml_cli/worker/grpc_api_server.py
+++ b/src/bentoml_cli/worker/grpc_api_server.py
@@ -92,6 +92,11 @@ def main(
     component_context.component_index = worker_id
     configure_server_logging()
 
+    if worker_id is None:
+        # worker ID is not set; this server is running in standalone mode
+        # and should not be concerned with the status of its runners
+        BentoMLContainer.config.runner_probe.enabled.set(False)
+
     BentoMLContainer.development_mode.set(False)
     if prometheus_dir is not None:
         BentoMLContainer.prometheus_multiproc_dir.set(prometheus_dir)

--- a/src/bentoml_cli/worker/http_api_server.py
+++ b/src/bentoml_cli/worker/http_api_server.py
@@ -116,7 +116,7 @@ def main(
     if worker_id is None:
         # worker ID is not set; this server is running in standalone mode
         # and should not be concerned with the status of its runners
-        BentoMLContainer.config.health_probe.check_runners.set(False)
+        BentoMLContainer.config.runner_probe.enabled.set(False)
 
     BentoMLContainer.development_mode.set(False)
     if prometheus_dir is not None:

--- a/src/bentoml_cli/worker/http_api_server.py
+++ b/src/bentoml_cli/worker/http_api_server.py
@@ -113,6 +113,11 @@ def main(
     component_context.component_index = worker_id
     configure_server_logging()
 
+    if worker_id is None:
+        # worker ID is not set; this server is running in standalone mode
+        # and should not be concerned with the status of its runners
+        BentoMLContainer.config.health_probe.check_runners.set(False)
+
     BentoMLContainer.development_mode.set(False)
     if prometheus_dir is not None:
         BentoMLContainer.prometheus_multiproc_dir.set(prometheus_dir)

--- a/tests/e2e/bento_server_http/tests/test_meta.py
+++ b/tests/e2e/bento_server_http/tests/test_meta.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import time
 import asyncio
 from pathlib import Path
-from asyncio.timeouts import timeout
 
 import pytest
 

--- a/tests/e2e/bento_server_http/tests/test_meta.py
+++ b/tests/e2e/bento_server_http/tests/test_meta.py
@@ -32,12 +32,13 @@ async def test_api_server_meta(host: str) -> None:
     status, _, body = await async_request("POST", f"http://{host}//api/v1/with_prefix")
     assert status == 404
 
+
 @pytest.mark.asyncio
 async def test_runner_readiness(host: str) -> None:
-    await async_request("GET", f"http://{host}/readyz", assert_status=500)
-    await asyncio.sleep(10)
     status, _, _ = await async_request("GET", f"http://{host}/readyz")
+    await asyncio.sleep(20)
     assert status == 200
+
 
 @pytest.mark.asyncio
 async def test_cors(host: str, server_config_file: str) -> None:

--- a/tests/e2e/bento_server_http/tests/test_meta.py
+++ b/tests/e2e/bento_server_http/tests/test_meta.py
@@ -36,12 +36,12 @@ async def test_api_server_meta(host: str) -> None:
 
 @pytest.mark.asyncio
 async def test_runner_readiness(host: str) -> None:
-    timeout = 300
+    timeout = 20
     start_time = time.time()
     status = ""
     while (time.time() - start_time) < timeout:
         status, _, _ = await async_request("GET", f"http://{host}/readyz")
-        await asyncio.sleep(20)
+        await asyncio.sleep(5)
         if status == 200:
             break
     assert status == 200

--- a/tests/e2e/bento_server_http/tests/test_meta.py
+++ b/tests/e2e/bento_server_http/tests/test_meta.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -28,6 +29,7 @@ async def test_api_server_meta(host: str) -> None:
     status, _, _ = await async_request("GET", f"http://{host}/readyz")
     assert status == 500
     status, _, body = await async_request("GET", f"http://{host}/metrics")
+    await asyncio.sleep(20)
     assert status == 200
     assert body
     status, _, body = await async_request("POST", f"http://{host}//api/v1/with_prefix")

--- a/tests/e2e/bento_server_http/tests/test_meta.py
+++ b/tests/e2e/bento_server_http/tests/test_meta.py
@@ -26,15 +26,18 @@ async def test_api_server_meta(host: str) -> None:
     assert b'{"Hello":"World"}' == body
     status, _, _ = await async_request("GET", f"http://{host}/docs.json")
     assert status == 200
-    status, _, _ = await async_request("GET", f"http://{host}/readyz")
-    assert status == 500
     status, _, body = await async_request("GET", f"http://{host}/metrics")
-    await asyncio.sleep(20)
     assert status == 200
     assert body
     status, _, body = await async_request("POST", f"http://{host}//api/v1/with_prefix")
     assert status == 404
 
+@pytest.mark.asyncio
+async def test_runner_readiness(host: str) -> None:
+    await async_request("GET", f"http://{host}/readyz", assert_status=500)
+    await asyncio.sleep(10)
+    status, _, _ = await async_request("GET", f"http://{host}/readyz")
+    assert status == 200
 
 @pytest.mark.asyncio
 async def test_cors(host: str, server_config_file: str) -> None:

--- a/tests/e2e/bento_server_http/tests/test_meta.py
+++ b/tests/e2e/bento_server_http/tests/test_meta.py
@@ -26,7 +26,7 @@ async def test_api_server_meta(host: str) -> None:
     status, _, _ = await async_request("GET", f"http://{host}/docs.json")
     assert status == 200
     status, _, _ = await async_request("GET", f"http://{host}/readyz")
-    assert status == 200
+    assert status == 500
     status, _, body = await async_request("GET", f"http://{host}/metrics")
     assert status == 200
     assert body

--- a/tests/e2e/bento_server_http/tests/test_meta.py
+++ b/tests/e2e/bento_server_http/tests/test_meta.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import time
 import asyncio
 from pathlib import Path
+from asyncio.timeouts import timeout
 
 import pytest
 
@@ -35,8 +37,14 @@ async def test_api_server_meta(host: str) -> None:
 
 @pytest.mark.asyncio
 async def test_runner_readiness(host: str) -> None:
-    status, _, _ = await async_request("GET", f"http://{host}/readyz")
-    await asyncio.sleep(20)
+    timeout = 300
+    start_time = time.time()
+    status = ""
+    while (time.time() - start_time) < timeout:
+        status, _, _ = await async_request("GET", f"http://{host}/readyz")
+        await asyncio.sleep(20)
+        if status == 200:
+            break
     assert status == 200
 
 


### PR DESCRIPTION
- Added `is_ready` method to `RunnerHandle`'s `init` file, then implemented it in the local and remote runners
- Added new method to `Runner` to check that `RunnerHandle` is ready
- Added new method to HTTP service app's `on_startup` method to check the Runner in loop until it returns true