### PR TITLE
fix(import): namespace collision

### DIFF
--- a/bentoml/__init__.py
+++ b/bentoml/__init__.py
@@ -112,8 +112,8 @@ else:
     )
     xgboost = _LazyLoader("bentoml.xgboost", globals(), "bentoml.xgboost")
 
-    io = _LazyLoader("io", globals(), "bentoml.io")
-    models = _LazyLoader("models", globals(), "bentoml.models")
+    io = _LazyLoader("bentoml.io", globals(), "bentoml.io")
+    models = _LazyLoader("bentoml.models", globals(), "bentoml.models")
 
     del _LazyLoader
 


### PR DESCRIPTION
Fix namespace collision with default builtin modules in sys.modules

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
