### PR TITLE
chore(deps): ensure grpc resolve dependencies correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,8 @@ grpc = [
   # since grpcio >=1.49.0 uses protbuf >=3.20.0, which breaks compatibility.
   # We can't use 1.48.2 since it depends on 3.19.5
   "grpcio>=1.41.0, <1.49, !=1.48.2",
-  "grpcio-health-checking",
-  "grpcio-reflection",
+  "grpcio-health-checking>=1.41.0, <1.49, !=1.48.2",
+  "grpcio-reflection>=1.41.0, <1.49, !=1.48.2",
   "opentelemetry-instrumentation-grpc==0.33b0",
 ]
 # We kept for compatibility with previous


### PR DESCRIPTION
Dependencies resolution for pip-tools apparently will try to lock to the latest version
instead of depending on previous dependent packages.

The expected behaviour would be:

- grpcio == 1.42 -> (grpcio-health-checking should lock to 1.42)

However, this will lock grpcio-health-checking to latest.

This could be a bug, but imminent fix for this is to specify the boundary.
