### PR TITLE
fix(pytest): export plugin lazily via environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ env:
   BENTOML_DO_NOT_TRACK: True
   LINES: 120
   COLUMNS: 120
+  PYTEST_PLUGINS: bentoml.testing.pytest.plugin
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun
 defaults:

--- a/.github/workflows/frameworks.yml
+++ b/.github/workflows/frameworks.yml
@@ -15,6 +15,7 @@ env:
   BENTOML_DO_NOT_TRACK: True
   LINES: 120
   COLUMNS: 120
+  PYTEST_PLUGINS: bentoml.testing.pytest.plugin
 
 jobs:
   diff:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -286,6 +286,12 @@ Make sure to install all test dependencies:
 pip install -r requirements/tests-requirements.txt
 ```
 
+BentoML tests come with a Pytest plugin. Export `PYTEST_PLUGINS`:
+
+```bash
+export PYTEST_PLUGINS=bentoml.testing.pytest.plugin
+```
+
 ### Unit tests
 
 You can run unit tests in two ways:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,9 +74,6 @@ dynamic = ["version"]
 [project.scripts]
 bentoml = "bentoml_cli.cli:cli"
 
-[project.entry-points.pytest11]
-bentoml = "bentoml.testing.pytest.plugin"
-
 [tool.setuptools]
 package-data = { "bentoml" = ["bentoml/*"], "bentoml_cli" = ["bentoml_cli/*"] }
 


### PR DESCRIPTION
Instead of exporting pytest plugins via setuptools, we should do it via PYTEST_PLUGINS
to avoid interfere with users who already using pytest

Using environment variables also unblocks https://bentoml.slack.com/archives/CKRANBHPH/p1665006750560559
