### PR TITLE
feat(grpc): SSL/TLS support

### DIFF
--- a/bentoml/_internal/configuration/containers.py
+++ b/bentoml/_internal/configuration/containers.py
@@ -408,6 +408,7 @@ class _BentoMLContainerClass:
 
     grpc = api_server_config.grpc
     http = api_server_config.http
+    ssl = api_server_config.ssl
 
     development_mode = providers.Static(True)
 

--- a/bentoml/_internal/server/grpc/server.py
+++ b/bentoml/_internal/server/grpc/server.py
@@ -12,6 +12,7 @@ from simple_di import Provide
 
 from ...utils import LazyLoader
 from ...utils import cached_property
+from ...utils import resolve_user_filepath
 from ...configuration.containers import BentoMLContainer
 
 logger = logging.getLogger(__name__)
@@ -48,6 +49,13 @@ else:
     )
 
 
+def _load_from_file(p: str) -> bytes:
+    rp = resolve_user_filepath(p, ctx=None)
+    with open(rp, "rb") as f:
+        return f.read()
+
+
+# NOTE: we are using the internal aio._server.Server (which is initialized with aio.server)
 class Server(aio._server.Server):
     """An async implementation of a gRPC server."""
 
@@ -64,6 +72,12 @@ class Server(aio._server.Server):
         maximum_concurrent_rpcs: int
         | None = Provide[BentoMLContainer.grpc.maximum_concurrent_rpcs],
         migration_thread_pool_workers: int = 1,
+        ssl_certfile: str
+        | None = Provide[BentoMLContainer.api_server_config.ssl.certfile],
+        ssl_keyfile: str
+        | None = Provide[BentoMLContainer.api_server_config.ssl.keyfile],
+        ssl_ca_certs: str
+        | None = Provide[BentoMLContainer.api_server_config.ssl.ca_certs],
         graceful_shutdown_timeout: float | None = None,
         compression: grpc.Compression | None = None,
     ):
@@ -73,6 +87,9 @@ class Server(aio._server.Server):
         self.bind_address = bind_address
         self.enable_reflection = enable_reflection
         self.graceful_shutdown_timeout = graceful_shutdown_timeout
+        self.ssl_certfile = ssl_certfile
+        self.ssl_keyfile = ssl_keyfile
+        self.ssl_ca_certs = ssl_ca_certs
 
         if not bool(self.servicer):
             self.servicer.load()
@@ -141,8 +158,33 @@ class Server(aio._server.Server):
             except Exception as e:  # pylint: disable=broad-except
                 raise RuntimeError(f"Server failed unexpectedly: {e}") from None
 
+    def configure_port(self, addr: str):
+        if self.ssl_certfile:
+            client_auth = False
+            ca_cert = None
+            assert (
+                self.ssl_keyfile
+            ), "'ssl_keyfile' is required when 'ssl_certfile' is provided."
+            if self.ssl_ca_certs:
+                client_auth = True
+                ca_cert = _load_from_file(self.ssl_ca_certs)
+            server_credentials = grpc.ssl_server_credentials(
+                (
+                    (
+                        _load_from_file(self.ssl_keyfile),
+                        _load_from_file(self.ssl_certfile),
+                    ),
+                ),
+                root_certificates=ca_cert,
+                require_client_auth=client_auth,
+            )
+
+            self.server.add_secure_port(addr, server_credentials)
+        else:
+            self.add_insecure_port(addr)
+
     async def serve(self) -> None:
-        self.add_insecure_port(self.bind_address)
+        self.configure_port(self.bind_address)
         await self.startup()
         await self.wait_for_termination()
 

--- a/bentoml/serve.py
+++ b/bentoml/serve.py
@@ -168,15 +168,13 @@ def serve_http_development(
     host: str = Provide[BentoMLContainer.http.host],
     backlog: int = Provide[BentoMLContainer.api_server_config.backlog],
     bentoml_home: str = Provide[BentoMLContainer.bentoml_home],
-    ssl_certfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.certfile],
-    ssl_keyfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.keyfile],
-    ssl_keyfile_password: str
-    | None = Provide[BentoMLContainer.api_server_config.ssl.keyfile_password],
-    ssl_version: int | None = Provide[BentoMLContainer.api_server_config.ssl.version],
-    ssl_cert_reqs: int
-    | None = Provide[BentoMLContainer.api_server_config.ssl.cert_reqs],
-    ssl_ca_certs: str | None = Provide[BentoMLContainer.api_server_config.ssl.ca_certs],
-    ssl_ciphers: str | None = Provide[BentoMLContainer.api_server_config.ssl.ciphers],
+    ssl_certfile: str | None = Provide[BentoMLContainer.ssl.certfile],
+    ssl_keyfile: str | None = Provide[BentoMLContainer.ssl.keyfile],
+    ssl_keyfile_password: str | None = Provide[BentoMLContainer.ssl.keyfile_password],
+    ssl_version: int | None = Provide[BentoMLContainer.ssl.version],
+    ssl_cert_reqs: int | None = Provide[BentoMLContainer.ssl.cert_reqs],
+    ssl_ca_certs: str | None = Provide[BentoMLContainer.ssl.ca_certs],
+    ssl_ciphers: str | None = Provide[BentoMLContainer.ssl.ciphers],
     reload: bool = False,
 ) -> None:
     from circus.sockets import CircusSocket
@@ -290,15 +288,13 @@ def serve_http_production(
     host: str = Provide[BentoMLContainer.http.host],
     backlog: int = Provide[BentoMLContainer.api_server_config.backlog],
     api_workers: int = Provide[BentoMLContainer.api_server_workers],
-    ssl_certfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.certfile],
-    ssl_keyfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.keyfile],
-    ssl_keyfile_password: str
-    | None = Provide[BentoMLContainer.api_server_config.ssl.keyfile_password],
-    ssl_version: int | None = Provide[BentoMLContainer.api_server_config.ssl.version],
-    ssl_cert_reqs: int
-    | None = Provide[BentoMLContainer.api_server_config.ssl.cert_reqs],
-    ssl_ca_certs: str | None = Provide[BentoMLContainer.api_server_config.ssl.ca_certs],
-    ssl_ciphers: str | None = Provide[BentoMLContainer.api_server_config.ssl.ciphers],
+    ssl_certfile: str | None = Provide[BentoMLContainer.ssl.certfile],
+    ssl_keyfile: str | None = Provide[BentoMLContainer.ssl.keyfile],
+    ssl_keyfile_password: str | None = Provide[BentoMLContainer.ssl.keyfile_password],
+    ssl_version: int | None = Provide[BentoMLContainer.ssl.version],
+    ssl_cert_reqs: int | None = Provide[BentoMLContainer.ssl.cert_reqs],
+    ssl_ca_certs: str | None = Provide[BentoMLContainer.ssl.ca_certs],
+    ssl_ciphers: str | None = Provide[BentoMLContainer.ssl.ciphers],
 ) -> None:
     from circus.sockets import CircusSocket
 
@@ -485,9 +481,9 @@ def serve_grpc_development(
     port: int = Provide[BentoMLContainer.grpc.port],
     host: str = Provide[BentoMLContainer.grpc.host],
     bentoml_home: str = Provide[BentoMLContainer.bentoml_home],
-    ssl_certfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.certfile],
-    ssl_keyfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.keyfile],
-    ssl_ca_certs: str | None = Provide[BentoMLContainer.api_server_config.ssl.ca_certs],
+    ssl_certfile: str | None = Provide[BentoMLContainer.ssl.certfile],
+    ssl_keyfile: str | None = Provide[BentoMLContainer.ssl.keyfile],
+    ssl_ca_certs: str | None = Provide[BentoMLContainer.ssl.ca_certs],
     max_concurrent_streams: int
     | None = Provide[BentoMLContainer.grpc.max_concurrent_streams],
     backlog: int = Provide[BentoMLContainer.api_server_config.backlog],
@@ -661,9 +657,9 @@ def serve_grpc_production(
     host: str = Provide[BentoMLContainer.grpc.host],
     backlog: int = Provide[BentoMLContainer.api_server_config.backlog],
     api_workers: int = Provide[BentoMLContainer.api_server_workers],
-    ssl_certfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.certfile],
-    ssl_keyfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.keyfile],
-    ssl_ca_certs: str | None = Provide[BentoMLContainer.api_server_config.ssl.ca_certs],
+    ssl_certfile: str | None = Provide[BentoMLContainer.ssl.certfile],
+    ssl_keyfile: str | None = Provide[BentoMLContainer.ssl.keyfile],
+    ssl_ca_certs: str | None = Provide[BentoMLContainer.ssl.ca_certs],
     max_concurrent_streams: int
     | None = Provide[BentoMLContainer.grpc.max_concurrent_streams],
     reflection: bool = False,

--- a/bentoml/start.py
+++ b/bentoml/start.py
@@ -240,6 +240,9 @@ def start_grpc_server(
     reflection: bool = Provide[BentoMLContainer.grpc.reflection.enabled],
     max_concurrent_streams: int
     | None = Provide[BentoMLContainer.grpc.max_concurrent_streams],
+    ssl_certfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.certfile],
+    ssl_keyfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.keyfile],
+    ssl_ca_certs: str | None = Provide[BentoMLContainer.api_server_config.ssl.ca_certs],
 ) -> None:
     from bentoml import load
 
@@ -291,7 +294,6 @@ def start_grpc_server(
         ]
         if reflection:
             args.append("--enable-reflection")
-
         if max_concurrent_streams:
             args.extend(
                 [
@@ -299,6 +301,12 @@ def start_grpc_server(
                     str(max_concurrent_streams),
                 ]
             )
+        if ssl_certfile:
+            args.extend(["--ssl-certfile", str(ssl_certfile)])
+        if ssl_keyfile:
+            args.extend(["--ssl-keyfile", str(ssl_keyfile)])
+        if ssl_ca_certs:
+            args.extend(["--ssl-ca-certs", str(ssl_ca_certs)])
 
         watchers.append(
             create_watcher(

--- a/bentoml/start.py
+++ b/bentoml/start.py
@@ -122,15 +122,13 @@ def start_http_server(
     host: str = Provide[BentoMLContainer.api_server_config.host],
     backlog: int = Provide[BentoMLContainer.api_server_config.backlog],
     api_workers: int = Provide[BentoMLContainer.api_server_workers],
-    ssl_certfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.certfile],
-    ssl_keyfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.keyfile],
-    ssl_keyfile_password: str
-    | None = Provide[BentoMLContainer.api_server_config.ssl.keyfile_password],
-    ssl_version: int | None = Provide[BentoMLContainer.api_server_config.ssl.version],
-    ssl_cert_reqs: int
-    | None = Provide[BentoMLContainer.api_server_config.ssl.cert_reqs],
-    ssl_ca_certs: str | None = Provide[BentoMLContainer.api_server_config.ssl.ca_certs],
-    ssl_ciphers: str | None = Provide[BentoMLContainer.api_server_config.ssl.ciphers],
+    ssl_certfile: str | None = Provide[BentoMLContainer.ssl.certfile],
+    ssl_keyfile: str | None = Provide[BentoMLContainer.ssl.keyfile],
+    ssl_keyfile_password: str | None = Provide[BentoMLContainer.ssl.keyfile_password],
+    ssl_version: int | None = Provide[BentoMLContainer.ssl.version],
+    ssl_cert_reqs: int | None = Provide[BentoMLContainer.ssl.cert_reqs],
+    ssl_ca_certs: str | None = Provide[BentoMLContainer.ssl.ca_certs],
+    ssl_ciphers: str | None = Provide[BentoMLContainer.ssl.ciphers],
 ) -> None:
     from circus.sockets import CircusSocket
     from circus.watcher import Watcher
@@ -236,9 +234,9 @@ def start_grpc_server(
     reflection: bool = Provide[BentoMLContainer.grpc.reflection.enabled],
     max_concurrent_streams: int
     | None = Provide[BentoMLContainer.grpc.max_concurrent_streams],
-    ssl_certfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.certfile],
-    ssl_keyfile: str | None = Provide[BentoMLContainer.api_server_config.ssl.keyfile],
-    ssl_ca_certs: str | None = Provide[BentoMLContainer.api_server_config.ssl.ca_certs],
+    ssl_certfile: str | None = Provide[BentoMLContainer.ssl.certfile],
+    ssl_keyfile: str | None = Provide[BentoMLContainer.ssl.keyfile],
+    ssl_ca_certs: str | None = Provide[BentoMLContainer.ssl.ca_certs],
 ) -> None:
     from circus.sockets import CircusSocket
     from circus.watcher import Watcher

--- a/bentoml_cli/serve.py
+++ b/bentoml_cli/serve.py
@@ -291,6 +291,27 @@ def add_serve_command(cli: click.Group) -> None:
         help="Maximum number of concurrent incoming streams to allow on a http2 connection.",
         show_default=True,
     )
+    @click.option(
+        "--ssl-certfile",
+        type=str,
+        default=None,
+        help="SSL certificate file",
+        show_default=True,
+    )
+    @click.option(
+        "--ssl-keyfile",
+        type=str,
+        default=None,
+        help="SSL key file",
+        show_default=True,
+    )
+    @click.option(
+        "--ssl-ca-certs",
+        type=str,
+        default=None,
+        help="CA certificates file",
+        show_default=True,
+    )
     @add_experimental_docstring
     def serve_grpc(  # type: ignore (unused warning)
         bento: str,
@@ -301,6 +322,9 @@ def add_serve_command(cli: click.Group) -> None:
         backlog: int,
         reload: bool,
         working_dir: str,
+        ssl_certfile: str | None,
+        ssl_keyfile: str | None,
+        ssl_ca_certs: str | None,
         enable_reflection: bool,
         max_concurrent_streams: int | None,
     ):
@@ -352,6 +376,9 @@ def add_serve_command(cli: click.Group) -> None:
                 host=host,
                 backlog=backlog,
                 api_workers=api_workers,
+                ssl_keyfile=ssl_keyfile,
+                ssl_certfile=ssl_certfile,
+                ssl_ca_certs=ssl_ca_certs,
                 max_concurrent_streams=max_concurrent_streams,
                 reflection=enable_reflection,
             )
@@ -365,6 +392,9 @@ def add_serve_command(cli: click.Group) -> None:
                 backlog=backlog,
                 reload=reload,
                 host=DEFAULT_DEV_SERVER_HOST if not host else host,
+                ssl_keyfile=ssl_keyfile,
+                ssl_certfile=ssl_certfile,
+                ssl_ca_certs=ssl_ca_certs,
                 max_concurrent_streams=max_concurrent_streams,
                 reflection=enable_reflection,
             )

--- a/bentoml_cli/start.py
+++ b/bentoml_cli/start.py
@@ -312,6 +312,24 @@ def add_start_command(cli: click.Group) -> None:
         type=click.INT,
         help="Maximum number of concurrent incoming streams to allow on a http2 connection.",
     )
+    @click.option(
+        "--ssl-certfile",
+        type=str,
+        default=None,
+        help="SSL certificate file",
+    )
+    @click.option(
+        "--ssl-keyfile",
+        type=str,
+        default=None,
+        help="SSL key file",
+    )
+    @click.option(
+        "--ssl-ca-certs",
+        type=str,
+        default=None,
+        help="CA certificates file",
+    )
     @add_experimental_docstring
     def start_grpc_server(  # type: ignore (unused warning)
         bento: str,
@@ -321,7 +339,10 @@ def add_start_command(cli: click.Group) -> None:
         backlog: int,
         api_workers: int | None,
         working_dir: str,
+        ssl_certfile: str | None,
+        ssl_keyfile: str | None,
         enable_reflection: bool,
+        ssl_ca_certs: str | None,
         max_concurrent_streams: int | None,
     ) -> None:
         """
@@ -343,5 +364,8 @@ def add_start_command(cli: click.Group) -> None:
             backlog=backlog,
             api_workers=api_workers,
             reflection=enable_reflection,
+            ssl_keyfile=ssl_keyfile,
+            ssl_certfile=ssl_certfile,
+            ssl_ca_certs=ssl_ca_certs,
             max_concurrent_streams=max_concurrent_streams,
         )

--- a/bentoml_cli/worker/grpc_api_server.py
+++ b/bentoml_cli/worker/grpc_api_server.py
@@ -45,6 +45,24 @@ import click
     help="Maximum number of concurrent incoming streams to allow on a HTTP2 connection.",
     default=None,
 )
+@click.option(
+    "--ssl-certfile",
+    type=str,
+    default=None,
+    help="SSL certificate file",
+)
+@click.option(
+    "--ssl-keyfile",
+    type=str,
+    default=None,
+    help="SSL key file",
+)
+@click.option(
+    "--ssl-ca-certs",
+    type=str,
+    default=None,
+    help="CA certificates file",
+)
 def main(
     bento_identifier: str,
     host: str,
@@ -55,6 +73,9 @@ def main(
     worker_id: int | None,
     enable_reflection: bool,
     max_concurrent_streams: int | None,
+    ssl_certfile: str | None,
+    ssl_keyfile: str | None,
+    ssl_ca_certs: str | None,
 ):
     """
     Start BentoML API server.
@@ -100,6 +121,12 @@ def main(
     }
     if max_concurrent_streams:
         grpc_options["max_concurrent_streams"] = int(max_concurrent_streams)
+    if ssl_certfile:
+        grpc_options["ssl_certfile"] = ssl_certfile
+    if ssl_keyfile:
+        grpc_options["ssl_keyfile"] = ssl_keyfile
+    if ssl_ca_certs:
+        grpc_options["ssl_ca_certs"] = ssl_ca_certs
 
     grpc.Server(svc.grpc_servicer, **grpc_options).run()
 

--- a/bentoml_cli/worker/grpc_dev_api_server.py
+++ b/bentoml_cli/worker/grpc_dev_api_server.py
@@ -27,6 +27,24 @@ import click
     help="Maximum number of concurrent incoming streams to allow on a http2 connection.",
     default=None,
 )
+@click.option(
+    "--ssl-certfile",
+    type=str,
+    default=None,
+    help="SSL certificate file",
+)
+@click.option(
+    "--ssl-keyfile",
+    type=str,
+    default=None,
+    help="SSL key file",
+)
+@click.option(
+    "--ssl-ca-certs",
+    type=str,
+    default=None,
+    help="CA certificates file",
+)
 def main(
     bento_identifier: str,
     host: str,
@@ -35,7 +53,11 @@ def main(
     working_dir: str | None,
     enable_reflection: bool,
     max_concurrent_streams: int | None,
+    ssl_certfile: str | None,
+    ssl_keyfile: str | None,
+    ssl_ca_certs: str | None,
 ):
+    import grpc
     import psutil
 
     from bentoml import load
@@ -75,6 +97,12 @@ def main(
     }
     if max_concurrent_streams is not None:
         grpc_options["max_concurrent_streams"] = int(max_concurrent_streams)
+    if ssl_certfile:
+        grpc_options["ssl_certfile"] = ssl_certfile
+    if ssl_keyfile:
+        grpc_options["ssl_keyfile"] = ssl_keyfile
+    if ssl_ca_certs:
+        grpc_options["ssl_ca_certs"] = ssl_ca_certs
 
     grpc.Server(svc.grpc_servicer, **grpc_options).run()
 


### PR DESCRIPTION
Initial SSL support for gRPC.

```bash
b serve-grpc --ssl-certfile credentials/cert.pem --ssl-keyfile credentials/key.pem --production --enable-reflection
```

To run on Docker:
```bash
docker run -it --rm -p 3000:3000 -p 3001:3001 --mount=type=bind,target=/credentials,source=$(pwd)/credentials iris_classifier:soc6p2ce62jvxgxi serve-grpc --ssl-certfile /credentials/cert.pem --ssl-keyfile /credentials/key.pem --production --enable-reflection
```
