### PR TITLE
fix(grpc): ensure prometheus dir is created

### DIFF
--- a/bentoml/serve.py
+++ b/bentoml/serve.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import sys
 import json
-import math
 import shutil
 import typing as t
 import logging
@@ -530,6 +529,8 @@ def serve_grpc_development(
             str(api_port),
             "--working-dir",
             working_dir,
+            "--prometheus-dir",
+            prometheus_dir,
         ]
 
         if reflection:
@@ -786,6 +787,8 @@ def serve_grpc_production(
             json.dumps(runner_bind_map),
             "--working-dir",
             working_dir,
+            "--prometheus-dir",
+            prometheus_dir,
             "--worker-id",
             "$(CIRCUS.WID)",
         ]

--- a/bentoml_cli/worker/grpc_api_server.py
+++ b/bentoml_cli/worker/grpc_api_server.py
@@ -22,6 +22,11 @@ import click
     help="Working directory for the API server",
 )
 @click.option(
+    "--prometheus-dir",
+    type=click.Path(exists=True),
+    help="Required by prometheus to pass the metrics in multi-process mode",
+)
+@click.option(
     "--worker-id",
     required=False,
     type=click.INT,
@@ -45,6 +50,7 @@ def main(
     bento_identifier: str,
     host: str,
     port: int,
+    prometheus_dir: str | None,
     runner_map: str | None,
     working_dir: str | None,
     worker_id: int | None,
@@ -67,6 +73,8 @@ def main(
     configure_server_logging()
 
     BentoMLContainer.development_mode.set(False)
+    if prometheus_dir is not None:
+        BentoMLContainer.prometheus_multiproc_dir.set(prometheus_dir)
     if runner_map is not None:
         BentoMLContainer.remote_runner_mapping.set(json.loads(runner_map))
 

--- a/bentoml_cli/worker/grpc_dev_api_server.py
+++ b/bentoml_cli/worker/grpc_dev_api_server.py
@@ -11,6 +11,11 @@ import click
 @click.option("--port", type=click.INT, required=False, default=None)
 @click.option("--working-dir", required=False, type=click.Path(), default=None)
 @click.option(
+    "--prometheus-dir",
+    type=click.Path(exists=True),
+    help="Required by prometheus to pass the metrics in multi-process mode",
+)
+@click.option(
     "--enable-reflection",
     type=click.BOOL,
     is_flag=True,
@@ -27,6 +32,7 @@ def main(
     bento_identifier: str,
     host: str,
     port: int,
+    prometheus_dir: str | None,
     working_dir: str | None,
     enable_reflection: bool,
     max_concurrent_streams: int | None,
@@ -40,6 +46,8 @@ def main(
 
     component_context.component_type = "grpc_dev_api_server"
     configure_server_logging()
+    if prometheus_dir is not None:
+        BentoMLContainer.prometheus_multiproc_dir.set(prometheus_dir)
 
     svc = load(bento_identifier, working_dir=working_dir, standalone_load=True)
     if not port:


### PR DESCRIPTION
This PR ensures that prometheus dir is created when users use `bentoml.metrics`

This is to update gRPC changes introduced from #3053
