### PR TITLE
fix: tagging docker image by bento

### DIFF
--- a/bentoml/bentos.py
+++ b/bentoml/bentos.py
@@ -498,7 +498,7 @@ def containerize(
 
     bento = _bento_store.get(tag)
     if not docker_image_tag:
-        docker_image_tag = [str(bento.tag)]
+        docker_image_tag = (str(bento.tag),)
 
     logger.info(f"Building docker image for {bento}...")
     if platform and not psutil.LINUX and platform != "linux/amd64":


### PR DESCRIPTION
revert to previous behaviour, where we tag docker image by bento tag.

This is a regression introduced somewhere in previous development cycle
