### PR TITLE
feat: PandasSeries `from_proto` and `to_proto`

### DIFF
--- a/docs/source/guides/grpc.rst
+++ b/docs/source/guides/grpc.rst
@@ -1048,7 +1048,7 @@ It accepts the following fields:
 
   Similar to NumpyNdarray, each of the fields is a `list` of the corresponding data type. The list is a 1-D array, and will be then pass to ``pd.Series``.
 
-  Per request sent, one message should only contain **ONE** of the aforementioned fields.
+  Each request should only contain **ONE** of the aforementioned fields.
 
   The interaction among the above fields and ``dtype`` from ``PandasSeries`` are as follows:
 

--- a/docs/source/guides/grpc.rst
+++ b/docs/source/guides/grpc.rst
@@ -792,6 +792,8 @@ A ``Request`` message takes in:
 +------------------------------------------------------------------+-------------------------------------------------------------------------------------------+
 | :ref:`guides/grpc:Tabular data representation via ``DataFrame``` | :ref:`bentoml.io.PandasDataFrame <reference/api_io_descriptors:Tabular Data with Pandas>` |
 +------------------------------------------------------------------+-------------------------------------------------------------------------------------------+
+| :ref:`guides/grpc:Series representation via ``Series```          | :ref:`bentoml.io.PandasDataFrame <reference/api_io_descriptors:Tabular Data with Pandas>` |
++------------------------------------------------------------------+-------------------------------------------------------------------------------------------+
 | :ref:`guides/grpc:File-like object via ``File```                 | :ref:`bentoml.io.File <reference/api_io_descriptors:Files>`                               |
 +------------------------------------------------------------------+-------------------------------------------------------------------------------------------+
 | |google_protobuf_string_value|_                                  | :ref:`bentoml.io.Text <reference/api_io_descriptors:Texts>`                               |
@@ -1034,6 +1036,54 @@ It accepts the following fields:
          }
 
 :bdg-primary:`API reference:` :meth:`bentoml.io.PandasDataFrame.from_proto`
+
+Series representation via ``Series``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:bdg-info:`Description:` ``Series`` portrays a series of values. This can be used for representing Series types in tabular data.
+
+It accepts the following fields:
+
+* `string_values`, `float_values`, `double_values`, `bool_values`, `int32_values`, `int64_values`
+
+  Similar to NumpyNdarray, each of the fields is a `list` of the corresponding data type. The list is a 1-D array, and will be then pass to ``pd.Series``.
+
+  Per request sent, one message should only contain **ONE** of the aforementioned fields.
+
+  The interaction among the above fields and ``dtype`` from ``PandasSeries`` are as follows:
+
+  - if ``dtype`` is not present in the descriptor:
+      * All of the fields are empty, then we return an empty ``pd.Series``.
+      * We will loop through all of the provided fields, and only allows one field per message.
+
+        If here are more than one field (i.e. ``string_values`` and ``float_values``), then we will raise an error, as we don't know how to deserialize the data.
+
+  - otherwise:
+      * We will use the provided dtype-to-field map to get the data from the given message.
+
+.. grid:: 2
+
+    .. grid-item-card::  ``Python API``
+
+      .. code-block:: python
+
+         PandasSeries.from_sample([5.4, 3.4, 1.5, 0.4])
+
+    .. grid-item-card::  ``pb.Series``
+
+      .. code-block:: none
+
+         series {
+           float_values: 5.4
+           float_values: 3.4
+           float_values: 1.5
+           float_values: 0.4
+         }
+
+
+:bdg-primary:`API reference:` :meth:`bentoml.io.PandasSeries.from_proto`
+
+:raw-html:`<br />`
 
 File-like object via ``File``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/reference/api_io_descriptors.rst
+++ b/docs/source/reference/api_io_descriptors.rst
@@ -98,6 +98,11 @@ To use the IO descriptor, install bentoml with extra ``io-pandas`` dependency:
 .. automethod:: bentoml.io.PandasDataFrame.to_proto
 .. automethod:: bentoml.io.PandasDataFrame.to_http_response
 .. autoclass:: bentoml.io.PandasSeries
+.. automethod:: bentoml.io.PandasSeries.from_sample
+.. automethod:: bentoml.io.PandasSeries.from_proto
+.. automethod:: bentoml.io.PandasSeries.from_http_request
+.. automethod:: bentoml.io.PandasSeries.to_proto
+.. automethod:: bentoml.io.PandasSeries.to_http_response
 
 
 Structured Data with JSON

--- a/src/bentoml/_internal/io_descriptors/pandas.py
+++ b/src/bentoml/_internal/io_descriptors/pandas.py
@@ -779,7 +779,7 @@ class PandasSeries(
 
                   @svc.api(input=PandasSeries(shape=(51,), enforce_shape=True), output=PandasSeries())
                   def infer(input_series: pd.Series) -> pd.Series:
-                  # if input_series have shape (40,), it will throw out errors
+                  # if input_series has shape (40,), it will error
                         ...
         enforce_shape: Whether to enforce a certain shape. If ``enforce_shape=True`` then ``shape`` must be specified.
 

--- a/src/bentoml/_internal/io_descriptors/pandas.py
+++ b/src/bentoml/_internal/io_descriptors/pandas.py
@@ -25,6 +25,7 @@ from ..service.openapi.specification import Schema
 from ..service.openapi.specification import MediaType
 
 if TYPE_CHECKING:
+    import numpy as np
     import pandas as pd
     from typing_extensions import Self
 
@@ -37,6 +38,7 @@ else:
     from bentoml.grpc.utils import import_generated_stubs
 
     pb, _ = import_generated_stubs()
+    np = LazyLoader("np", globals(), "numpy")
     pd = LazyLoader(
         "pd",
         globals(),
@@ -514,6 +516,7 @@ class PandasDataFrame(
                     - :obj:`index` - :code:`dict[str, Any]` ↦ {``idx`` ↠ {``column`` ↠ ``value``}}
                     - :obj:`columns` - :code:`dict[str, Any]` ↦ {``column`` ↠ {``index`` ↠ ``value``}}
                     - :obj:`values` - :code:`dict[str, Any]` ↦ Values arrays
+                    - :obj:`table` - :code:`dict[str, Any]` ↦ {``schema``: { schema }, ``data``: { data }}
             apply_column_names: Update incoming DataFrame columns. ``columns`` must be specified at
                                 function signature. If you don't want to enforce a specific columns
                                 name then change ``apply_column_names=False``.
@@ -564,7 +567,9 @@ class PandasDataFrame(
         self, dataframe: ext.PdDataFrame, exception_cls: t.Type[Exception] = BadInput
     ) -> ext.PdDataFrame:
 
-        if not LazyType["ext.PdDataFrame"]("pd.DataFrame").isinstance(dataframe):
+        if not LazyType["ext.PdDataFrame"]("pandas.core.frame.DataFrame").isinstance(
+            dataframe
+        ):
             raise InvalidArgument(
                 f"return object is not of type 'pd.DataFrame', got type '{type(dataframe)}' instead"
             ) from None
@@ -655,7 +660,7 @@ class PandasDataFrame(
             ``service_pb2.Response``:
                 Protobuf representation of given ``pandas.DataFrame``
         """
-        from bentoml._internal.io_descriptors.numpy import npdtype_to_fieldpb_map
+        from .numpy import npdtype_to_fieldpb_map
 
         # TODO: support different serialization format
         obj = self.validate_dataframe(obj)
@@ -763,21 +768,6 @@ class PandasSeries(
                ``dtype``, then applies those to incoming dataframes. If ``False``, then don't
                infer dtypes at all (only applies to the data). This is not applicable for :code:`orient='table'`.
         enforce_dtype: Whether to enforce a certain data type. if :code:`enforce_dtype=True` then :code:`dtype` must be specified.
-        shape: Optional shape check that users can specify for their incoming HTTP
-               requests. We will only check the number of columns you specified for your
-               given shape:
-
-               .. code-block:: python
-                  :caption: `service.py`
-
-                  import pandas as pd
-                  from bentoml.io import PandasSeries
-
-                  @svc.api(input=PandasSeries(shape=(51,10), enforce_shape=True), output=PandasSeries())
-                  def infer(input_series: pd.Series) -> pd.Series:
-                  # if input_series have shape (40,9), it will throw out errors
-                        ...
-        enforce_shape: Whether to enforce a certain shape. If ``enforce_shape=True`` then ``shape`` must be specified.
 
     Returns:
         :obj:`PandasSeries`: IO Descriptor that represents a :code:`pd.Series`.
@@ -791,15 +781,19 @@ class PandasSeries(
         orient: ext.SeriesOrient = "records",
         dtype: ext.PdDTypeArg | None = None,
         enforce_dtype: bool = False,
-        shape: tuple[int, ...] | None = None,
-        enforce_shape: bool = False,
     ):
         self._orient = orient
         self._dtype = dtype
         self._enforce_dtype = enforce_dtype
-        self._shape = shape
-        self._enforce_shape = enforce_shape
-        # TODO: support parquet for serde pd.Series
+        self._sample_input = None
+
+    @property
+    def sample_input(self) -> ext.PdSeries | None:
+        return self._sample_input
+
+    @sample_input.setter
+    def sample_input(self, value: ext.PdSeries) -> None:
+        self._sample_input = value
 
     def input_type(self) -> LazyType[ext.PdSeries]:
         return LazyType("pandas", "Series")
@@ -899,24 +893,155 @@ class PandasSeries(
         self, series: ext.PdSeries, exception_cls: t.Type[Exception] = BadInput
     ) -> ext.PdSeries:
         # TODO: dtype check
-        if not LazyType["ext.PdSeries"]("pd.Series").isinstance(series):
+        if not LazyType["ext.PdSeries"]("pandas.core.series.Series").isinstance(series):
             raise InvalidArgument(
                 f"return object is not of type 'pd.Series', got type '{type(series)}' instead"
             ) from None
-        # TODO: convert from wide to long format (melt())
-        if self._shape is not None and self._shape != series.shape:
-            msg = f"{self.__class__.__name__}: Expecting Series of shape '{self._shape}', but '{series.shape}' was received."
-            if self._enforce_shape and not all(
-                left == right
-                for left, right in zip(self._shape, series.shape)
-                if left != -1 and right != -1
-            ):
-                raise exception_cls(msg) from None
+        if self._dtype is not None and self._dtype != series.dtype:
+            if np.can_cast(series.dtype, self._dtype, casting="same_kind"):
+                series = series.astype(self._dtype)
+            else:
+                msg = '%s: Expecting series of dtype "%s", but "%s" was received.'
+                if self._enforce_dtype:
+                    raise exception_cls(
+                        msg % (self.__class__.__name__, self._dtype, series.dtype)
+                    ) from None
+                else:
+                    logger.debug(
+                        msg, self.__class__.__name__, self._dtype, series.dtype
+                    )
 
         return series
 
     async def from_proto(self, field: pb.Series | bytes) -> ext.PdSeries:
-        raise NotImplementedError("Currently not yet implemented.")
+        """
+        Process incoming protobuf request and convert it to ``pandas.Series``
+
+        Args:
+            request: Incoming RPC request message.
+            context: grpc.ServicerContext
+
+        Returns:
+            a ``pandas.Series`` object. This can then be used
+             inside users defined logics.
+        """
+        if isinstance(field, bytes):
+            # TODO: handle serialized_bytes for dataframe
+            raise NotImplementedError(
+                'Currently not yet implemented. Use "series" instead.'
+            )
+        else:
+            assert isinstance(field, pb.Series)
+            # The behaviour of `from_proto` will mimic the behaviour of `NumpyNdArray.from_proto`,
+            # where we will respect self._dtype if set.
+            # since self._dtype uses numpy dtype, we will use some of numpy logics here.
+            from .numpy import fieldpb_to_npdtype_map
+            from .numpy import npdtype_to_fieldpb_map
+
+            if self._dtype is not None:
+                dtype = self._dtype
+                data = getattr(field, npdtype_to_fieldpb_map()[self._dtype])
+            else:
+                fieldpb = [
+                    f.name for f, _ in field.ListFields() if f.name.endswith("_values")
+                ]
+                if len(fieldpb) == 0:
+                    # input message doesn't have any fields.
+                    return pd.Series()
+                elif len(fieldpb) > 1:
+                    # when there are more than two values provided in the proto.
+                    raise InvalidArgument(
+                        f"Array contents can only be one of given values key. Use one of '{fieldpb}' instead.",
+                    ) from None
+                dtype = fieldpb_to_npdtype_map()[fieldpb[0]]
+                data = getattr(field, fieldpb[0])
+
+        try:
+            series = pd.Series(data, dtype=dtype)
+        except ValueError:
+            series = pd.Series(data)
+
+        return self.validate_series(series)
 
     async def to_proto(self, obj: ext.PdSeries) -> pb.Series:
-        raise NotImplementedError("Currently not yet implemented.")
+        """
+        Process given objects and convert it to grpc protobuf response.
+
+        Args:
+            obj: ``pandas.Series`` that will be serialized to protobuf
+            context: grpc.aio.ServicerContext from grpc.aio.Server
+        Returns:
+            ``service_pb2.Response``:
+                Protobuf representation of given ``pandas.Series``
+        """
+        from .numpy import npdtype_to_fieldpb_map
+
+        try:
+            obj = self.validate_series(obj, exception_cls=InvalidArgument)
+        except InvalidArgument as e:
+            raise e from None
+
+        # NOTE: Currently, if series has mixed dtype, we will raise an error.
+        # This has to do with no way to represent mixed dtype in protobuf.
+        # User shouldn't use mixed dtype in the first place.
+        if obj.dtype.kind == "O":
+            raise InvalidArgument(
+                f"Series has mixed dtype. Please convert it to a single dtype."
+            ) from None
+        try:
+            fieldpb = npdtype_to_fieldpb_map()[obj.dtype]
+            return pb.Series(**{fieldpb: obj.ravel().tolist()})
+        except KeyError:
+            raise InvalidArgument(
+                f"Unsupported dtype '{obj.dtype}' for response message."
+            ) from None
+
+    @classmethod
+    def from_sample(
+        cls,
+        sample_input: ext.PdSeries,
+        orient: ext.SeriesOrient = "records",
+        enforce_dtype: bool = True,
+    ) -> PandasSeries:
+        """
+        Create a :obj:`PandasSeries` IO Descriptor from given inputs.
+
+        Args:
+            sample_input: Given sample ``pd.DataFrame`` data
+            orient: Indication of expected JSON string format. Compatible JSON strings can be
+                    produced by :func:`pandas.io.json.to_json()` with a corresponding orient value.
+                    Possible orients are:
+
+                    - :obj:`split` - :code:`dict[str, Any]` ↦ {``idx`` ↠ ``[idx]``, ``columns`` ↠ ``[columns]``, ``data`` ↠ ``[values]``}
+                    - :obj:`records` - :code:`list[Any]` ↦ [{``column`` ↠ ``value``}, ..., {``column`` ↠ ``value``}]
+                    - :obj:`index` - :code:`dict[str, Any]` ↦ {``idx`` ↠ {``column`` ↠ ``value``}}
+                    - :obj:`table` - :code:`dict[str, Any]` ↦ {``schema``: { schema }, ``data``: { data }}
+            enforce_dtype: Enforce a certain data type. `dtype` must be specified at function
+                           signature. If you don't want to enforce a specific dtype then change
+                           ``enforce_dtype=False``.
+
+        Returns:
+            :obj:`PandasSeries`: :code:`PandasSeries` IODescriptor from given users inputs.
+
+        Example:
+
+        .. code-block:: python
+           :caption: `service.py`
+
+           import pandas as pd
+           from bentoml.io import PandasSeries
+
+           arr = [1,2,3]
+           input_spec = PandasSeries.from_sample(pd.DataFrame(arr))
+
+           @svc.api(input=input_spec, output=PandasSeries())
+           def predict(inputs: pd.Series) -> pd.Series: ...
+        """
+        inst = cls(
+            orient=orient,
+            dtype=sample_input.dtype,
+            enforce_dtype=enforce_dtype,
+        )
+        inst.sample_input = sample_input
+
+        return inst

--- a/tests/e2e/bento_server_grpc/service.py
+++ b/tests/e2e/bento_server_grpc/service.py
@@ -13,6 +13,7 @@ from bentoml.io import Text
 from bentoml.io import Image
 from bentoml.io import Multipart
 from bentoml.io import NumpyNdarray
+from bentoml.io import PandasSeries
 from bentoml.io import PandasDataFrame
 from bentoml.testing.grpc import TestServiceServicer
 from bentoml._internal.utils import LazyLoader
@@ -147,6 +148,12 @@ async def echo_dataframe(df: pd.DataFrame) -> pd.DataFrame:
 async def echo_dataframe_from_sample(df: pd.DataFrame) -> pd.DataFrame:
     assert isinstance(df, pd.DataFrame)
     return df
+
+
+@svc.api(input=PandasSeries.from_sample(pd.Series([1, 2, 3])), output=PandasSeries())
+async def echo_series_from_sample(series: pd.Series) -> pd.Series:
+    assert isinstance(series, pd.Series)
+    return series
 
 
 @svc.api(

--- a/tests/e2e/bento_server_grpc/tests/test_descriptors.py
+++ b/tests/e2e/bento_server_grpc/tests/test_descriptors.py
@@ -357,6 +357,16 @@ async def test_pandas(host: str):
         )
 
 
+@pytest.mark.asyncio
+async def test_pandas_series(host: str):
+    async with create_channel(host) as channel:
+        await async_client_call(
+            "echo_series_from_sample",
+            channel=channel,
+            data={"series": pb.Series(float_values=[1.0, 2.0, 3.0])},
+        )
+
+
 def assert_multi_images(resp: pb.Response, method: str, im_file: str) -> bool:
     assert method == "pred_multi_images"
     img = PILImage.open(im_file)

--- a/tests/e2e/bento_server_grpc/tests/test_descriptors.py
+++ b/tests/e2e/bento_server_grpc/tests/test_descriptors.py
@@ -364,6 +364,8 @@ async def test_pandas_series(host: str):
             "echo_series_from_sample",
             channel=channel,
             data={"series": pb.Series(float_values=[1.0, 2.0, 3.0])},
+            assert_data=lambda resp: resp.series
+            == pb.Series(float_values=[1.0, 2.0, 3.0]),
         )
 
 


### PR DESCRIPTION
Address #2994 

This PR brings `from_proto` and `to_proto` to PandasSeries, as well as polishing some of
the validation process for series

This PR will also add a functionality `from_sample` for creation of descriptor


Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
