### PR TITLE
fix: use `InferenceAPI.multi_input` for parsing multipart

### DIFF
--- a/src/bentoml/_internal/server/grpc/servicer.py
+++ b/src/bentoml/_internal/server/grpc/servicer.py
@@ -116,7 +116,6 @@ def create_bento_servicer(service: Service) -> services.BentoServiceServicer:
     This is the actual implementation of BentoServicer.
     Main inference entrypoint will be invoked via /bentoml.grpc.<version>.BentoService/Call
     """
-    from ...io_descriptors.multipart import Multipart
 
     class BentoServiceImpl(services.BentoServiceServicer):
         """An asyncio implementation of BentoService servicer."""
@@ -145,12 +144,12 @@ def create_bento_servicer(service: Service) -> services.BentoServiceServicer:
                 )
                 input_data = await api.input.from_proto(input_proto)
                 if asyncio.iscoroutinefunction(api.func):
-                    if isinstance(api.input, Multipart):
+                    if api.multi_input:
                         output = await api.func(**input_data)
                     else:
                         output = await api.func(input_data)
                 else:
-                    if isinstance(api.input, Multipart):
+                    if api.multi_input:
                         output = await anyio.to_thread.run_sync(api.func, **input_data)
                     else:
                         output = await anyio.to_thread.run_sync(api.func, input_data)

--- a/src/bentoml/_internal/server/http_app.py
+++ b/src/bentoml/_internal/server/http_app.py
@@ -19,7 +19,6 @@ from ...exceptions import BentoMLException
 from ..server.base_app import BaseAppFactory
 from ..service.service import Service
 from ..configuration.containers import BentoMLContainer
-from ..io_descriptors.multipart import Multipart
 
 if TYPE_CHECKING:
     from starlette.routing import BaseRoute
@@ -312,7 +311,7 @@ class HTTPAppFactory(BaseAppFactory):
                 input_data = await api.input.from_http_request(request)
                 ctx = None
                 if asyncio.iscoroutinefunction(api.func):
-                    if isinstance(api.input, Multipart):
+                    if api.multi_input:
                         if api.needs_ctx:
                             ctx = Context.from_http(request)
                             input_data[api.ctx_param] = ctx
@@ -324,7 +323,7 @@ class HTTPAppFactory(BaseAppFactory):
                         else:
                             output = await api.func(input_data)
                 else:
-                    if isinstance(api.input, Multipart):
+                    if api.multi_input:
                         if api.needs_ctx:
                             ctx = Context.from_http(request)
                             input_data[api.ctx_param] = ctx


### PR DESCRIPTION
This makes multi-input descriptors more generic and allows users to define their own
