### PR TITLE
test: minor pytest fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,13 +226,7 @@ exclude = '''
 [tool.pytest.ini_options]
 addopts = [
   "-rfEX",
-  "-x",
-  "--capture=tee-sys",
-  "--tb=long",
-  "--import-mode=importlib",
-  "--cov=bentoml",
-  "--cov-report=term-missing:skip-covered",
-  "--cov-append",
+  "-pbentoml.testing.pytest.plugin"
 ]
 python_files = ["test_*.py", "*_test.py"]
 testpaths = ["tests"]

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,4 +1,5 @@
 # Dev dependencies
+-e .[all]
 -r tests-requirements.txt
 twine
 wheel

--- a/requirements/frameworks-requirements.txt
+++ b/requirements/frameworks-requirements.txt
@@ -1,6 +1,5 @@
--r tests-requirements.txt
 catboost
-lightgbm
+lightgbm;platform_machine!="arm64"
 mlflow
 fastai
 xgboost

--- a/requirements/tests-requirements.txt
+++ b/requirements/tests-requirements.txt
@@ -1,4 +1,5 @@
 # Tests dependencies
+-r frameworks-requirements.txt
 black[jupyter]==22.8.0
 codecov
 coverage>=4.4

--- a/tests/integration/frameworks/conftest.py
+++ b/tests/integration/frameworks/conftest.py
@@ -3,19 +3,22 @@ from __future__ import annotations
 import os
 import typing as t
 import pkgutil
+import logging
 from types import ModuleType
 from typing import TYPE_CHECKING
 from importlib import import_module
 
 import pytest
 
-from .models import FrameworkTestModel
-
 if TYPE_CHECKING:
+    from .models import FrameworkTestModel
+
     from _pytest.nodes import Item
     from _pytest.config import Config
     from _pytest.config.argparsing import Parser
 
+
+logger = logging.getLogger("bentoml.tests")
 
 def pytest_addoption(parser: Parser):
     parser.addoption("--framework", action="store", default=None)
@@ -81,9 +84,7 @@ def test_inputs(framework: str | None) -> list[tuple[ModuleType, FrameworkTestMo
                 )
             )
         except ModuleNotFoundError as e:
-            raise ModuleNotFoundError(
-                f"Failed to find test module for framework {framework_name} (tests.integration.frameworks.models.{framework_name})"
-            ) from e
+            logger.warning(f"Failed to find test module for framework {framework_name} (tests.integration.frameworks.models.{framework_name})")
 
     return [
         (module.framework, _model)


### PR DESCRIPTION
Adds all frameworks to dev-dependencies as well. Skips LightGBM on arm64 because it's not supported.

Removes most of the pytest flags to make pytest output a little more sane and fix some issues caused by the `importlib` import method.

Also, warns instead of failing if a framework is not installed. Worth noting that pytest ignores the warning completely, but I couldn't find a neat way of printing the warning.