### PR TITLE
revert: remove frameworks-requirements.txt from test requirements

### DIFF
--- a/requirements/tests-requirements.txt
+++ b/requirements/tests-requirements.txt
@@ -1,5 +1,4 @@
 # Tests dependencies
--r frameworks-requirements.txt
 black[jupyter]==22.8.0
 codecov
 coverage>=4.4


### PR DESCRIPTION
Remove framework-requirements.txt from tests, which fails the CI
