### PR TITLE
chore: add options to install pydantic with `bentoml[io-json]`

### DIFF
--- a/docs/source/concepts/bento.rst
+++ b/docs/source/concepts/bento.rst
@@ -559,6 +559,14 @@ validation, specify the desired variant in the under ``python.packages`` field:
            packages:
            - "bentoml[aws]"
 
+   .. tab-item:: JSON IO
+
+      .. code-block:: yaml
+
+         python:
+           packages:
+           - "bentoml[io-json]"
+
    .. tab-item:: Image IO
 
       .. code-block:: yaml
@@ -599,7 +607,7 @@ validation, specify the desired variant in the under ``python.packages`` field:
            packages:
            - "bentoml[tracing-zipkin]"
 
-   .. tab-item:: OpenTelemetry Protocol
+   .. tab-item:: OTLP
 
       .. code-block:: yaml
 

--- a/docs/source/concepts/bento.rst
+++ b/docs/source/concepts/bento.rst
@@ -575,6 +575,14 @@ validation, specify the desired variant in the under ``python.packages`` field:
            packages:
            - "bentoml[io-pandas]"
 
+   .. tab-item:: JSON IO
+
+      .. code-block:: yaml
+
+         python:
+           packages:
+           - "bentoml[io-json]"
+
    .. tab-item:: Jaeger
 
       .. code-block:: yaml

--- a/docs/source/reference/api_io_descriptors.rst
+++ b/docs/source/reference/api_io_descriptors.rst
@@ -109,7 +109,15 @@ Structured Data with JSON
    `Pydantic <https://pydantic-docs.helpmanual.io/>`_ model, and use it to for data
    validation.
 
-   Make sure to install `Pydantic <https://pydantic-docs.helpmanual.io/>`_ with ``pip install pydantic`` if you want to use ``pydantic``.
+   To use the IO descriptor with pydantic, install bentoml with extra ``io-json`` dependency:
+
+   .. code-block:: bash
+
+      pip install "bentoml[io-json]"
+
+   This will include BentoML with `Pydantic <https://pydantic-docs.helpmanual.io/>`_
+   alongside with BentoML
+
    Then proceed to add it to your :code:`bentofile.yaml`'s under either Python or Conda packages list.
 
    Refer to :ref:`Build Options <concepts/bento:Bento Build Options>`.
@@ -138,7 +146,38 @@ Structured Data with JSON
               dependencies:
                 - pydantic
 
+   Refers to :ref:`Build Options <concepts/bento:Bento Build Options>`.
+
+   .. tab-set::
+
+      .. tab-item:: pip
+
+         .. code-block:: yaml
+            :caption: `bentofile.yaml`
+
+            ...
+            python:
+              packages:
+                - pydantic
+
+      .. tab-item:: conda
+
+         .. code-block:: yaml
+            :caption: `bentofile.yaml`
+
+            ...
+            conda:
+              channels:
+                - conda-forge
+              dependencies:
+                - pydantic
+
 .. autoclass:: bentoml.io.JSON
+.. automethod:: bentoml.io.JSON.from_sample
+.. automethod:: bentoml.io.JSON.from_proto
+.. automethod:: bentoml.io.JSON.from_http_request
+.. automethod:: bentoml.io.JSON.to_proto
+.. automethod:: bentoml.io.JSON.to_http_response
 
 Texts
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ include = [
 [project.optional-dependencies]
 all = [
   "bentoml[aws]",
+  "bentoml[io-json]",
   "bentoml[io-image]",
   "bentoml[io-pandas]",
   "bentoml[grpc]",
@@ -116,6 +117,7 @@ all = [
   "bentoml[tracing]",
 ]
 aws = ["fs-s3fs"]
+io-json = ["pydantic<2"] # currently we don't have support for pydantic 2.0
 io-image = ["Pillow"]
 io-pandas = ["pandas", "pyarrow"]
 grpc = [

--- a/src/bentoml/bentos.py
+++ b/src/bentoml/bentos.py
@@ -447,6 +447,7 @@ FEATURES = [
     "all",
     "io-image",
     "io-pandas",
+    "io-json",
     "tracing-zipkin",
     "tracing-jaeger",
     "tracing-otlp",


### PR DESCRIPTION
Add ability to install optional pydantic with `bentoml[io-json]`

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
