### PR TITLE
fix(cli): expands working_dir with default path

### DIFF
--- a/src/bentoml_cli/serve.py
+++ b/src/bentoml_cli/serve.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import os
 
 import sys
 import logging
@@ -173,6 +174,13 @@ def add_serve_command(cli: click.Group) -> None:
         """
         configure_server_logging()
 
+        if working_dir is None:
+            if os.path.isdir(os.path.expanduser(bento)):
+                working_dir = os.path.expanduser(bento)
+            else:
+                working_dir = "."
+            print(working_dir)
+
         if sys.path[0] != working_dir:
             sys.path.insert(0, working_dir)
 
@@ -273,7 +281,7 @@ def add_serve_command(cli: click.Group) -> None:
         "--working-dir",
         type=click.Path(),
         help="When loading from source code, specify the directory to find the Service instance",
-        default=".",
+        default=None,
         show_default=True,
     )
     @click.option(

--- a/src/bentoml_cli/serve.py
+++ b/src/bentoml_cli/serve.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-import os
 
+import os
 import sys
 import logging
 
@@ -70,7 +70,7 @@ def add_serve_command(cli: click.Group) -> None:
         "--working-dir",
         type=click.Path(),
         help="When loading from source code, specify the directory to find the Service instance",
-        default=".",
+        default=None,
         show_default=True,
     )
     @click.option(
@@ -173,14 +173,11 @@ def add_serve_command(cli: click.Group) -> None:
         - all model store changes will also trigger a restart (new model saved or existing model removed)
         """
         configure_server_logging()
-
         if working_dir is None:
             if os.path.isdir(os.path.expanduser(bento)):
                 working_dir = os.path.expanduser(bento)
             else:
                 working_dir = "."
-            print(working_dir)
-
         if sys.path[0] != working_dir:
             sys.path.insert(0, working_dir)
 
@@ -377,6 +374,11 @@ def add_serve_command(cli: click.Group) -> None:
         - all model store changes will also trigger a restart (new model saved or existing model removed)
         """
         configure_server_logging()
+        if working_dir is None:
+            if os.path.isdir(os.path.expanduser(bento)):
+                working_dir = os.path.expanduser(bento)
+            else:
+                working_dir = "."
         if production:
             if reload:
                 logger.warning(

--- a/src/bentoml_cli/start.py
+++ b/src/bentoml_cli/start.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import json
 import logging
@@ -71,7 +72,7 @@ def add_start_command(cli: click.Group) -> None:
         "--working-dir",
         type=click.Path(),
         help="When loading from source code, specify the directory to find the Service instance",
-        default=".",
+        default=None,
         show_default=True,
     )
     @click.option(
@@ -138,6 +139,11 @@ def add_start_command(cli: click.Group) -> None:
         """
         Start a HTTP API server standalone. This will be used inside Yatai.
         """
+        if working_dir is None:
+            if os.path.isdir(os.path.expanduser(bento)):
+                working_dir = os.path.expanduser(bento)
+            else:
+                working_dir = "."
         if sys.path[0] != working_dir:
             sys.path.insert(0, working_dir)
 
@@ -218,7 +224,7 @@ def add_start_command(cli: click.Group) -> None:
         "--working-dir",
         type=click.Path(),
         help="When loading from source code, specify the directory to find the Service instance",
-        default=".",
+        default=None,
         show_default=True,
     )
     @add_experimental_docstring
@@ -234,6 +240,11 @@ def add_start_command(cli: click.Group) -> None:
         """
         Start Runner server standalone. This will be used inside Yatai.
         """
+        if working_dir is None:
+            if os.path.isdir(os.path.expanduser(bento)):
+                working_dir = os.path.expanduser(bento)
+            else:
+                working_dir = "."
         if sys.path[0] != working_dir:
             sys.path.insert(0, working_dir)
 
@@ -289,7 +300,7 @@ def add_start_command(cli: click.Group) -> None:
         "--working-dir",
         type=click.Path(),
         help="When loading from source code, specify the directory to find the Service instance",
-        default=".",
+        default=None,
         show_default=True,
     )
     @click.option(
@@ -356,6 +367,11 @@ def add_start_command(cli: click.Group) -> None:
         """
         Start a gRPC API server standalone. This will be used inside Yatai.
         """
+        if working_dir is None:
+            if os.path.isdir(os.path.expanduser(bento)):
+                working_dir = os.path.expanduser(bento)
+            else:
+                working_dir = "."
         if sys.path[0] != working_dir:
             sys.path.insert(0, working_dir)
 


### PR DESCRIPTION
We should be able to run the command `bentoml serve` outside of the directory containing bentofile.yaml, for example, by running `bentoml serve ..` in a subdirectory. This does not work today. These are WIP changes made during my pairing with @sauyon today.