### PR TITLE
chore: bumping opentelemetry dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,9 +146,9 @@ tracing = [
   "bentoml[tracing-otlp]",
   "bentoml[tracing-zipkin]",
 ]
-tracing-jaeger = ["opentelemetry-exporter-jaeger"]
-tracing-zipkin = ["opentelemetry-exporter-zipkin"]
-tracing-otlp = ["opentelemetry-exporter-otlp"]
+tracing-jaeger = ["opentelemetry-exporter-jaeger==1.13.0"]
+tracing-zipkin = ["opentelemetry-exporter-zipkin==1.13.0"]
+tracing-otlp = ["opentelemetry-exporter-otlp==1.13.0"]
 
 [tool.setuptools_scm]
 write_to = "src/bentoml/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
   "deepmerge",
   "fs",
   "numpy",
+  # OpenTelemetry is the server dependencies, rather than SDK
+  # Since there are discrepancy among API and instrumentation packages,
+  # we should always pin the set version of Opentelemetry suite
   "opentelemetry-api==1.13.0",
   "opentelemetry-instrumentation==0.34b0",
   "opentelemetry-instrumentation-aiohttp-client==0.34b0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "fs",
   "numpy",
   # OpenTelemetry is the server dependencies, rather than SDK
-  # Since there are discrepancy among API and instrumentation packages,
+  # Since there are discrepancies among API and instrumentation packages,
   # we should always pin the set version of Opentelemetry suite
   "opentelemetry-api==1.13.0",
   "opentelemetry-instrumentation==0.34b0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,13 @@ dependencies = [
   "deepmerge",
   "fs",
   "numpy",
-  "opentelemetry-api>=1.9.0",
-  "opentelemetry-instrumentation==0.33b0",
-  "opentelemetry-instrumentation-aiohttp-client==0.33b0",
-  "opentelemetry-instrumentation-asgi==0.33b0",
-  "opentelemetry-sdk>=1.9.0",
-  "opentelemetry-semantic-conventions==0.33b0",
-  "opentelemetry-util-http==0.33b0",
+  "opentelemetry-api==1.13.0",
+  "opentelemetry-instrumentation==0.34b0",
+  "opentelemetry-instrumentation-aiohttp-client==0.34b0",
+  "opentelemetry-instrumentation-asgi==0.34b0",
+  "opentelemetry-sdk==1.13.0",
+  "opentelemetry-semantic-conventions==0.34b0",
+  "opentelemetry-util-http==0.34b0",
   "packaging>=20.0",
   "pathspec",
   "pip-tools>=6.6.2",
@@ -131,7 +131,7 @@ grpc = [
   # We can't use 1.48.2 since it depends on 3.19.5
   "grpcio>=1.41.0, <1.49, !=1.48.2",
   "grpcio-health-checking>=1.41.0, <1.49, !=1.48.2",
-  "opentelemetry-instrumentation-grpc==0.33b0",
+  "opentelemetry-instrumentation-grpc==0.34b0",
 ]
 grpc-reflection = [
   "bentoml[grpc]",
@@ -299,7 +299,7 @@ skip_glob = [
 
 [tool.pyright]
 pythonVersion = "3.10"
-include = ["src/bentoml", "src/bentoml_cli"]
+include = ["src/", "examples/", "tests/"]
 exclude = [
   'src/bentoml/_version.py',
   'src/bentoml/__main__.py',

--- a/requirements/tests-requirements.txt
+++ b/requirements/tests-requirements.txt
@@ -18,4 +18,4 @@ build[virtualenv] >=0.8.0
 yamllint
 protobuf>=3.5.0, <3.20,!=3.19.5
 grpcio-tools>=1.41.0,<1.49.0,!=1.48.2
-opentelemetry-test-utils==0.33b0
+opentelemetry-test-utils==0.34b0

--- a/requirements/tests-requirements.txt
+++ b/requirements/tests-requirements.txt
@@ -18,4 +18,3 @@ build[virtualenv] >=0.8.0
 yamllint
 protobuf>=3.5.0, <3.20,!=3.19.5
 grpcio-tools>=1.41.0,<1.49.0,!=1.48.2
-opentelemetry-test-utils==0.34b0


### PR DESCRIPTION
This PR tries to address locking issue with mismatch opentelemtry due
to inconsistency among opentelemetry release schedule
