### PR TITLE
chore(build): add dependabot for pyproject.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,21 @@
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: "weekly"
-    day: "monday"
-    time: "09:00"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+  # maintain required dependencies
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+  # maintain requirements/*.txt files
+  - package-ecosystem: pip
+    directory: "/requirements"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
With recent support for PEP621 from dependabot, we can use it to update our
pyproject.toml

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
