### PR TITLE
fix(templates): ensure dependencies are met for CUDA templates

### DIFF
--- a/src/bentoml/_internal/bento/docker/templates/base_debian.j2
+++ b/src/bentoml/_internal/bento/docker/templates/base_debian.j2
@@ -10,5 +10,5 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloa
 RUN {{ common.mount_cache(__lib_apt__) }} \
     {{ common.mount_cache(__cache_apt__) }} \
     apt-get update -y \
-    && apt-get install -q -y --no-install-recommends --allow-remove-essential ca-certificates gnupg2 bash build-essential software-properties-common {% if __options__system_packages is not none %}{{ __options__system_packages | join(' ') }}{% endif -%}
+    && apt-get install -q -y --no-install-recommends --allow-remove-essential ca-certificates gnupg2 bash build-essential {% if __options__system_packages is not none %}{{ __options__system_packages | join(' ') }}{% endif -%}
 {% endblock %}

--- a/src/bentoml/_internal/bento/docker/templates/base_debian.j2
+++ b/src/bentoml/_internal/bento/docker/templates/base_debian.j2
@@ -10,5 +10,5 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloa
 RUN {{ common.mount_cache(__lib_apt__) }} \
     {{ common.mount_cache(__cache_apt__) }} \
     apt-get update -y \
-    && apt-get install -q -y --no-install-recommends --allow-remove-essential ca-certificates gnupg2 bash build-essential {% if __options__system_packages is not none %}{{ __options__system_packages | join(' ') }}{% endif -%}
+    && apt-get install -q -y --no-install-recommends --allow-remove-essential ca-certificates gnupg2 bash build-essential software-properties-common {% if __options__system_packages is not none %}{{ __options__system_packages | join(' ') }}{% endif -%}
 {% endblock %}

--- a/src/bentoml/_internal/bento/docker/templates/cuda_debian.j2
+++ b/src/bentoml/_internal/bento/docker/templates/cuda_debian.j2
@@ -8,7 +8,7 @@ RUN {{ common.mount_cache(__lib_apt__) }} \
     # add deadsnakes ppa to install python
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends --allow-remove-essential software-properties-common curl {% if "ubuntu22.04" in __base_image__ and __options__python_version == "3.10" %}python{{ __options__python_version }}-jammy{% else %}python{{ __options__python_version }}{% endif %} python{{ __options__python_version }}-dev python{{ __options__python_version }}-distutils
+    apt-get install -y --no-install-recommends --allow-remove-essential curl {% if "ubuntu22.04" in __base_image__ and __options__python_version == "3.10" %}python{{ __options__python_version }}-jammy{% else %}python{{ __options__python_version }}{% endif %} python{{ __options__python_version }}-dev python{{ __options__python_version }}-distutils
 
 RUN ln -sf /usr/bin/python{{ __options__python_version }} /usr/bin/python3 && \
     ln -sf /usr/bin/pip{{ __options__python_version }} /usr/bin/pip3

--- a/src/bentoml/_internal/bento/docker/templates/cuda_debian.j2
+++ b/src/bentoml/_internal/bento/docker/templates/cuda_debian.j2
@@ -4,7 +4,8 @@
 
 RUN {{ common.mount_cache(__lib_apt__) }} \
     {{ common.mount_cache(__cache_apt__) }} \
-    set -eux pipefail && \
+    set -eux && \
+    apt-get install -y --no-install-recommends --allow-remove-essential software-properties-common && \
     # add deadsnakes ppa to install python
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \

--- a/src/bentoml/_internal/bento/docker/templates/cuda_debian.j2
+++ b/src/bentoml/_internal/bento/docker/templates/cuda_debian.j2
@@ -4,6 +4,7 @@
 
 RUN {{ common.mount_cache(__lib_apt__) }} \
     {{ common.mount_cache(__cache_apt__) }} \
+    set -eux pipefail && \
     # add deadsnakes ppa to install python
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \

--- a/src/bentoml/_internal/bento/docker/templates/cuda_debian.j2
+++ b/src/bentoml/_internal/bento/docker/templates/cuda_debian.j2
@@ -4,7 +4,6 @@
 
 RUN {{ common.mount_cache(__lib_apt__) }} \
     {{ common.mount_cache(__cache_apt__) }} \
-    set -euxo pipefail && \
     # add deadsnakes ppa to install python
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \


### PR DESCRIPTION
## What does this PR address?

The new image build Kaniko Dockerfile is broken. When using the CUDA Debian-based  template.
1. software-properties-common - must be run before the add-apt-repository command is called on the next command.
2. pipefail command - Kaniko is also not perceived

Use latest bentoml 1.0.7 (26 oktober 2022) (installed from pip install git+https://github.com/bentoml/BentoML.git)
Yatai v1.0.0-d7-6c68b8e