### PR TITLE
fix: async bento client methods

### DIFF
--- a/src/bentoml/client.py
+++ b/src/bentoml/client.py
@@ -31,8 +31,14 @@ class Client(ABC):
 
         for name, api in self._svc.apis.items():
             if not hasattr(self, name):
-                setattr(self, name, functools.partial(self._sync_call, _bentoml_api=api))
-                setattr(self, f"async_{name}", functools.partial(self._call, _bentoml_api=api))
+                setattr(
+                    self, name, functools.partial(self._sync_call, _bentoml_api=api)
+                )
+                setattr(
+                    self,
+                    f"async_{name}",
+                    functools.partial(self._call, _bentoml_api=api),
+                )
 
     def call(self, bentoml_api_name: str, inp: t.Any = None, **kwargs: t.Any) -> t.Any:
         return asyncio.run(self.async_call(bentoml_api_name, inp))
@@ -42,7 +48,9 @@ class Client(ABC):
     ) -> t.Any:
         return await self._call(inp, _bentoml_api=self._svc.apis[bentoml_api_name])
 
-    def _sync_call(self, inp: t.Any = None, *, _bentoml_api: InferenceAPI, **kwagrs: t.Any):
+    def _sync_call(
+        self, inp: t.Any = None, *, _bentoml_api: InferenceAPI, **kwagrs: t.Any
+    ):
         return asyncio.run(self._call(inp, _bentoml_api=_bentoml_api))
 
     @abstractmethod

--- a/src/bentoml/client.py
+++ b/src/bentoml/client.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
-import asyncio
 
+import json
 import typing as t
+import asyncio
 import functools
 from abc import ABC
 from abc import abstractmethod
@@ -10,7 +11,6 @@ from urllib.parse import urlparse
 
 import aiohttp
 import starlette.requests
-import json
 import starlette.datastructures
 
 import bentoml

--- a/src/bentoml/client.py
+++ b/src/bentoml/client.py
@@ -34,6 +34,9 @@ class Client(ABC):
                 setattr(
                     self, name, functools.partial(self._sync_call, _bentoml_api=api)
                 )
+
+        for name, api in self._svc.apis.items():
+            if not hasattr(self, f"async_{name}"):
                 setattr(
                     self,
                     f"async_{name}",


### PR DESCRIPTION
Fixes the newly changed async/sync bento client methods, and makes from_url synchronous using the stdlib `HTTPConnection` so that it can be used in both async and non-async contexts.