### PR TITLE
fix: pandas openAPI handle nulltype

### DIFF
--- a/src/bentoml/_internal/io_descriptors/pandas.py
+++ b/src/bentoml/_internal/io_descriptors/pandas.py
@@ -356,6 +356,8 @@ class PandasDataFrame(
             return str(value)
         elif isinstance(value, dict):
             return {str(k): self._convert_dtype(v) for k, v in value.items()}
+        elif value is None:
+            return "null"
         else:
             logger.warning(f"{type(value)} is not yet supported.")
             return None
@@ -822,6 +824,8 @@ class PandasSeries(
             return str(value)
         elif isinstance(value, dict):
             return {str(k): self._convert_dtype(v) for k, v in value.items()}
+        elif value is None:
+            return "null"
         else:
             logger.warning(f"{type(value)} is not yet supported.")
             return None


### PR DESCRIPTION
Handles null type for Pandas for OpenAPI conversion

![Screenshot 2022-10-31 at 13 01 08](https://user-images.githubusercontent.com/29749331/199099660-af2ca10a-4ebd-4284-a6d7-3d107ca02ea5.png)


Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
