### PR TITLE
fix(templates): ensure to use python3 and pip3

### DIFF
--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -527,28 +527,28 @@ BENTOML_VERSION=${BENTOML_VERSION:-"""
 # Install python packages, prefer installing the requirements.lock.txt file if it exist
 if [ -f "$REQUIREMENTS_LOCK" ]; then
     echo "Installing pip packages from 'requirements.lock.txt'.."
-    pip install -r "$REQUIREMENTS_LOCK" "${PIP_ARGS[@]}"
+    pip3 install -r "$REQUIREMENTS_LOCK" "${PIP_ARGS[@]}"
 else
     if [ -f "$REQUIREMENTS_TXT" ]; then
         echo "Installing pip packages from 'requirements.txt'.."
-        pip install -r "$REQUIREMENTS_TXT" "${PIP_ARGS[@]}"
+        pip3 install -r "$REQUIREMENTS_TXT" "${PIP_ARGS[@]}"
     fi
 fi
 
 # Install user-provided wheels
 if [ -d "$WHEELS_DIR" ]; then
     echo "Installing wheels packaged in Bento.."
-    pip install "$WHEELS_DIR"/*.whl "${PIP_ARGS[@]}"
+    pip3 install "$WHEELS_DIR"/*.whl "${PIP_ARGS[@]}"
 fi
 
 # Install the BentoML from PyPI if it's not already installed
-if python -c "import bentoml" &> /dev/null; then
-    existing_bentoml_version=$(python -c "import bentoml; print(bentoml.__version__)")
+if python3 -c "import bentoml" &> /dev/null; then
+    existing_bentoml_version=$(python3 -c "import bentoml; print(bentoml.__version__)")
     if [ "$existing_bentoml_version" != "$BENTOML_VERSION" ]; then
         echo "WARNING: using BentoML version ${existing_bentoml_version}"
     fi
 else
-    pip install bentoml=="$BENTOML_VERSION"
+    pip3 install bentoml=="$BENTOML_VERSION"
 fi
 """
             )


### PR DESCRIPTION
Ensure our install.sh uses pip3 and python3

For distro such as amazonlinux, the docker container includes both python2 and python3.
python is often aliased with python2, hence this PR explicitly state the distinction.

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
