### PR TITLE
fix: ensure conda not use pipefail and unset variables

### DIFF
--- a/src/bentoml/_internal/bento/docker/templates/_macros.j2
+++ b/src/bentoml/_internal/bento/docker/templates/_macros.j2
@@ -9,11 +9,11 @@
 {% set __conda_exec__ = [conda_path, "bin", "conda"] | join("/") %}
 {% set __conda_pkg__ = [conda_path, "pkg"] | join("/") %}
 
-RUN {{ mount_cache(__conda_pkg__) }} set -euxo pipefail && \
-    echo "Installing Python $PYTHON_VERSION with conda..." && \
+RUN {{ mount_cache(__conda_pkg__) }} set -eux && \
+    echo "Installing Python {{ python_version }} with conda..." && \
     {{ __conda_exec__ }} install -y -n base pkgs/main::python={{ python_version }} pip
 
-RUN {{ mount_cache(__conda_pkg__) }} set -euxo pipefail && \
+RUN {{ mount_cache(__conda_pkg__) }} set -eux && \
     if [ -f {{ environment_yml }} ]; then \
       # set pip_interop_enabled to improve conda-pip interoperability. Conda can use
       # pip-installed packages to satisfy dependencies.


### PR DESCRIPTION
This PR fixes a bug where -o pipefail is not available in sh

This PR also remove the unset variable PYTHON_VERSION for conda

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
