### PR TITLE
fix: lazy check for stubs via path when install local wheels

### DIFF
--- a/src/bentoml/_internal/bento/build_dev_bentoml_whl.py
+++ b/src/bentoml/_internal/bento/build_dev_bentoml_whl.py
@@ -43,11 +43,7 @@ def build_bentoml_editable_wheel(target_path: str) -> None:
         raise BentoMLException("Could not find bentoml module location.")
     bentoml_path = Path(module_location)
 
-    try:
-        from importlib import import_module
-
-        _ = import_module("bentoml.grpc.v1alpha1.service_pb2")
-    except ModuleNotFoundError:
+    if not Path(module_location, "grpc", "v1alpha1", "service_pb2.py").exists():
         raise ModuleNotFoundError(
             f"Generated stubs are not found. Make sure to run '{bentoml_path.as_posix()}/scripts/generate_grpc_stubs.sh' beforehand to generate gRPC stubs."
         ) from None


### PR DESCRIPTION
Fix checking grpc availability when BENTOML_LOCAL_BUNDLE_BUILD is specified

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
