### PR TITLE
fix(docs): indentation in migration.rst

### DIFF
--- a/docs/source/guides/migration.rst
+++ b/docs/source/guides/migration.rst
@@ -138,7 +138,7 @@ defined in the :code:`bentofile.yaml` file in the project directory. The content
         owner: bentoml-team
         project: gallery
     include:
-    - "*.py"
+        - "*.py"
     python:
         packages:
         - scikit-learn


### PR DESCRIPTION
Fix indentation in migration.rst

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
