### PR TITLE
fix(ssl): provide default values in configuration

### DIFF
--- a/src/bentoml/_internal/configuration/default_configuration.yaml
+++ b/src/bentoml/_internal/configuration/default_configuration.yaml
@@ -16,7 +16,6 @@ api_server:
         trace_id: 032x
         span_id: 016x
   ssl:
-    enabled: false
     certfile: ~
     keyfile: ~
     keyfile_password: ~

--- a/src/bentoml/_internal/configuration/default_configuration.yaml
+++ b/src/bentoml/_internal/configuration/default_configuration.yaml
@@ -15,7 +15,15 @@ api_server:
       format:
         trace_id: 032x
         span_id: 016x
-
+  ssl:
+    enabled: false
+    certfile: ~
+    keyfile: ~
+    keyfile_password: ~
+    ca_certs: ~
+    version: 17 # ssl.PROTOCOL_TLS_SERVER
+    cert_reqs: 0 # ssl.CERT_NONE
+    ciphers: TLSv1 # default ciphers
   http:
     host: 0.0.0.0
     port: 3000


### PR DESCRIPTION
This has to do with when using API from `bentoml.serve` directly, the value for SSL

is not set, whereas on CLI, all fields are default to None.

Since the configuration value is not set under our default configuration files, using `serve_[http|grpc]_*`
directly will result in simple_di error

```prolog
Traceback (most recent call last):
  File "/Users/aarnphm/.pyenv/versions/3.10.4/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/aarnphm/.pyenv/versions/3.10.4/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/aarnphm/workspace/playground/scripts/run.py", line 18, in <module>
    serve_http_development(
  File "/Users/aarnphm/.pyenv/versions/3.10.4/lib/python3.10/site-packages/simple_di/__init__.py", line 139, in _
    return func(*_inject_args(bind.args), **_inject_kwargs(bind.kwargs))
  File "/Users/aarnphm/.pyenv/versions/3.10.4/lib/python3.10/site-packages/simple_di/__init__.py", line 104, in _inject_args
    return tuple(a.get() if isinstance(a, Provider) else a for a in args)
  File "/Users/aarnphm/.pyenv/versions/3.10.4/lib/python3.10/site-packages/simple_di/__init__.py", line 104, in <genexpr>
    return tuple(a.get() if isinstance(a, Provider) else a for a in args)
  File "/Users/aarnphm/.pyenv/versions/3.10.4/lib/python3.10/site-packages/simple_di/providers.py", line 218, in get
    _cursor = _cursor[i]
KeyError: 'ssl'
```

Simple reproducible way on main:

```python
serve_http_development(str(bento.tag), working_dir=".")
```

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
