### PR TITLE
fix: don't ignore logging conf

### DIFF
--- a/src/bentoml/serve.py
+++ b/src/bentoml/serve.py
@@ -387,7 +387,6 @@ def serve_http_production(
                             f"$(circus.sockets.{runner.name})",
                             "--working-dir",
                             working_dir,
-                            "--no-access-log",
                             "--worker-id",
                             "$(CIRCUS.WID)",
                             "--worker-env-map",


### PR DESCRIPTION
Previously we disabled always disabled runner logging on Windows. This fixes this.