### PR TITLE
fix(runner): set uvicorn keep-alive

### DIFF
--- a/src/bentoml_cli/worker/runner.py
+++ b/src/bentoml_cli/worker/runner.py
@@ -127,6 +127,7 @@ def main(
     uvicorn_options: dict[str, int | None | str] = {
         "log_config": None,
         "workers": 1,
+        "timeout_keep_alive": 1800,
     }
 
     if psutil.WINDOWS:


### PR DESCRIPTION
This mirrors the keep-alive we have set in our runner clients, which uvicorn does not appear to honor.