### PR TITLE
fix: missing f-string in tag validation error message

### DIFF
--- a/src/bentoml/_internal/tag.py
+++ b/src/bentoml/_internal/tag.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 tag_fmt = "[a-z0-9]([-._a-z0-9]*[a-z0-9])?"
 tag_max_length = 63
 tag_max_length_error_msg = (
-    "a tag's name or version must be at most {tag_max_length} characters in length"
+    f"a tag's name or version must be at most {tag_max_length} characters in length"
 )
 tag_invalid_error_msg = "a tag's name or version must consist of alphanumeric characters, '_', '-', or '.', and must start and end with an alphanumeric character"
 tag_regex = re.compile(f"^{tag_fmt}$")


### PR DESCRIPTION
## What does this PR address?

Thanks for maintaining a nice source project!

I've found the missing 'f' for `tag_max_length_error_msg`, `bentoml._internal.tag`. 
Thanks.


## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
