### PR TITLE
fix(docs): missing `table` tag

### DIFF
--- a/examples/custom_model_runner/README.md
+++ b/examples/custom_model_runner/README.md
@@ -85,6 +85,7 @@ grpcurl -d @ -plaintext 0.0.0.0:3000 bentoml.grpc.v1alpha1.BentoService/Call <<E
 }
 EOM
 ```
+</table>
 
 5. Load testing
 


### PR DESCRIPTION
Add table closing tag on instruction 4
