### PR TITLE
chore: generate plain dockerfile without buildkit syntax

### DIFF
--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -219,7 +219,7 @@ class DockerOptions:
         dockerfile_path = fs.path.combine(docker_folder, "Dockerfile")
 
         # NOTE that by default the generated Dockerfile won't have BuildKit syntax.
-        # By default, BentoML will use BuildKit. To opt-out specify DOCKER_BUILDKIT=0
+        # By default, BentoML containerization will use BuildKit. To opt-out specify DOCKER_BUILDKIT=0
         bento_fs.writetext(
             dockerfile_path,
             generate_containerfile(

--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -218,9 +218,13 @@ class DockerOptions:
         bento_fs.makedirs(docker_folder, recreate=True)
         dockerfile_path = fs.path.combine(docker_folder, "Dockerfile")
 
+        # NOTE that by default the generated Dockerfile won't have BuildKit syntax.
+        # By default, BentoML will use BuildKit. To opt-out specify DOCKER_BUILDKIT=0
         bento_fs.writetext(
             dockerfile_path,
-            generate_containerfile(self, build_ctx, conda=conda, bento_fs=bento_fs),
+            generate_containerfile(
+                self, build_ctx, conda=conda, bento_fs=bento_fs, enable_buildkit=False
+            ),
         )
         copy_file_to_fs_folder(
             fs.path.join(


### PR DESCRIPTION
The generated Dockerfile inside Bento will now be stripped down without BuildKit syntax.

This is for purpose of serving users who wants to build directly using this Dockerfile.

By default `bentoml containerize` is the recommended way and it uses BuildKit by default.

To opt-out specify `DOCKER_BUILDKIT=0`

Signed-off-by: Ubuntu <29749331+aarnphm@users.noreply.github.com>
