### PR TITLE
style: remove `# type: ignore`

### DIFF
--- a/src/bentoml/_internal/frameworks/fastai.py
+++ b/src/bentoml/_internal/frameworks/fastai.py
@@ -16,7 +16,7 @@ from ...exceptions import MissingDependencyException
 from ..models.model import ModelContext
 
 # register PyTorchTensorContainer as import side effect.
-from .common.pytorch import PyTorchTensorContainer  # type: ignore # noqa
+from .common.pytorch import PyTorchTensorContainer
 
 MODULE_NAME = "bentoml.fastai"
 MODEL_FILENAME = "saved_model.pkl"
@@ -52,7 +52,7 @@ except ImportError:  # pragma: no cover
     raise MissingDependencyException("BentoML only supports fastai v2 onwards.")
 
 
-__all__ = ["load_model", "save_model", "get_runnable", "get"]
+__all__ = ["load_model", "save_model", "get_runnable", "get", "PyTorchTensorContainer"]
 
 
 def get(tag_like: str | Tag) -> bentoml.Model:

--- a/src/bentoml/_internal/frameworks/mlflow.py
+++ b/src/bentoml/_internal/frameworks/mlflow.py
@@ -198,7 +198,7 @@ def import_model(
             local_path = download_artifacts(
                 artifact_uri=model_uri, dst_path=download_dir
             )
-        except ImportError:
+        except (ModuleNotFoundError, ImportError):
             # For MLflow < 1.25
             from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 
@@ -244,7 +244,7 @@ def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
         # because most custom python_function models are likely numpy code or model
         # inference with pre/post-processing code.
         SUPPORTED_RESOURCES = ("cpu",)
-        SUPPORTS_CPU_MULTI_THREADING = True  # type: ignore
+        SUPPORTS_CPU_MULTI_THREADING = True
 
         def __init__(self):
             super().__init__()


### PR DESCRIPTION
This PR cleanup type ignore to and catch module not found error for mlflow.

Some cases it hits ModuleNotFoundError instead of ImportError when mlflow is not available.

Signed-off-by: Aaron Pham (EC2) <29749331+aarnphm@users.noreply.github.com>
