### PR TITLE
chore(pyproject): bumping python version typeshed to 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,7 +316,7 @@ skip_glob = [
 ]
 
 [tool.pyright]
-pythonVersion = "3.10"
+pythonVersion = "3.11"
 include = ["src/", "examples/", "tests/"]
 exclude = [
   'src/bentoml/_version.py',


### PR DESCRIPTION
Bumping typeshed for pyright to 3.11 GA

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
