### PR TITLE
fix(container): ensure to stream logs when `DOCKER_BUILDKIT=0`

### DIFF
--- a/src/bentoml/_internal/container/base.py
+++ b/src/bentoml/_internal/container/base.py
@@ -181,7 +181,11 @@ class OCIBuilder:
         commands = list(map(str, cmds))
 
         try:
-            if not self.enable_buildkit:
+            # We need to also respect DOCKER_BUILDKIT environment here
+            # to stream logs
+            if not self.enable_buildkit or (
+                "DOCKER_BUILDKIT" in env and env["DOCKER_BUILDKIT"] == "0"
+            ):
                 return self.stream_logs(commands, cwd=context_path, env=env).stdout
             else:
                 return subprocess.check_output(commands, cwd=context_path, env=env)


### PR DESCRIPTION
Make sure to stream logs when DOCKER_BUILDKIT=0 is set.

Before this will go to the below leaf, which uses check_output.

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
