### PR TITLE
fix: unset `NVIDIA_VISIBLE_DEVICES` when cuda image is used

### DIFF
--- a/src/bentoml/_internal/container/frontend/dockerfile/templates/base.j2
+++ b/src/bentoml/_internal/container/frontend/dockerfile/templates/base.j2
@@ -28,6 +28,10 @@ ENV PYTHONIOENCODING=UTF-8
 
 ENV PYTHONUNBUFFERED=1
 
+{% if __is_cuda__ %}
+ENV NVIDIA_VISIBLE_DEVICES=
+{% endif %}
+
 {% endblock %}
 
 # Block SETUP_BENTO_USER

--- a/src/bentoml/_internal/container/generate.py
+++ b/src/bentoml/_internal/container/generate.py
@@ -48,7 +48,12 @@ to_options_field: t.Callable[[str], str] = lambda s: f"__options__{s}"
 
 
 def get_templates_variables(
-    docker: DockerOptions, conda: CondaOptions, bento_fs: FS, **bento_env: str | bool
+    docker: DockerOptions,
+    conda: CondaOptions,
+    bento_fs: FS,
+    *,
+    _is_cuda: bool = False,
+    **bento_env: str | bool,
 ) -> dict[str, t.Any]:
     """
     Returns a dictionary of variables to be used in BentoML base templates.
@@ -90,6 +95,7 @@ def get_templates_variables(
         "__prometheus_port__": BentoMLContainer.grpc.metrics.port.get(),
         "__base_image__": base_image,
         "__conda_python_version__": conda_python_version,
+        "__is_cuda__": _is_cuda,
     }
 
 
@@ -177,5 +183,11 @@ def generate_containerfile(
         )
 
     return template.render(
-        **get_templates_variables(docker, conda, bento_fs, **override_bento_env)
+        **get_templates_variables(
+            docker,
+            conda,
+            bento_fs,
+            _is_cuda=release_type == "cuda",
+            **override_bento_env,
+        )
     )


### PR DESCRIPTION
User know need to setup NVIDIA_VISIBLE_DEVICES now as we unset this be default when using cuda to prevent a known memory leak.

```python
docker run -e NVIDIA_VISIBLE_DEVICES=all ...
```

### BREAKING CHANGE

If user are running container then one might have to provide additional `-e` flag.

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
