### PR TITLE
fix(monitoring): wrong format key for formatter

### DIFF
--- a/src/bentoml/_internal/monitoring/default.py
+++ b/src/bentoml/_internal/monitoring/default.py
@@ -44,8 +44,8 @@ handlers:
     filename: "{schema_filename}"
 formatters:
   bentoml_json:
-    class: pythonjsonlogger.jsonlogger.JsonFormatter
-    format: " "
+    class: pythonjsonlogger.tsonlogger.JsonFormatter
+    format: ""
 """
 
 

--- a/src/bentoml/_internal/monitoring/default.py
+++ b/src/bentoml/_internal/monitoring/default.py
@@ -44,7 +44,7 @@ handlers:
     filename: "{schema_filename}"
 formatters:
   bentoml_json:
-    class: pythonjsonlogger.tsonlogger.JsonFormatter
+    class: pythonjsonlogger.jsonlogger.JsonFormatter
     format: ""
 """
 


### PR DESCRIPTION
format should be an empty string instead of an empty space, otherwise it will fail the regex search for logging format


Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
