### PR TITLE
fix: remove assertion for dtype

### DIFF
--- a/src/bentoml/_internal/io_descriptors/pandas.py
+++ b/src/bentoml/_internal/io_descriptors/pandas.py
@@ -386,16 +386,48 @@ class PandasDataFrame(
            @svc.api(input=input_spec, output=PandasDataFrame())
            def predict(inputs: pd.DataFrame) -> pd.DataFrame: ...
         """
-        if LazyType["ext.NpNDArray"]("numpy", "ndarray").isinstance(
-            sample
-        ) or isinstance(sample, str):
+        if LazyType["ext.NpNDArray"]("numpy", "ndarray").isinstance(sample):
             logger.warning(
                 "'from_sample' from type '%s' is deprecated. Make sure to only pass pandas DataFrame.",
                 type(sample),
             )
+            sample = pd.DataFrame(sample)
+        elif isinstance(sample, str):
+            logger.warning(
+                "'from_sample' from type '%s' is deprecated. Make sure to only pass pandas DataFrame.",
+                type(sample),
+            )
+            try:
+                if os.path.exists(sample):
+                    try:
+                        ext = os.path.splitext(sample)[-1].strip(".")
+                        sample = getattr(
+                            pd,
+                            {
+                                "json": "read_json",
+                                "csv": "read_csv",
+                                "html": "read_html",
+                                "xls": "read_excel",
+                                "xlsx": "read_excel",
+                                "hdf5": "read_hdf",
+                                "parquet": "read_parquet",
+                                "pickle": "read_pickle",
+                                "sql": "read_sql",
+                            }[ext],
+                        )(sample)
+                    except KeyError:
+                        raise InvalidArgument(f"Unsupported sample '{sample}' format.")
+                else:
+                    # Try to load the string as json.
+                    sample = pd.read_json(sample)
+            except ValueError as e:
+                raise InvalidArgument(
+                    f"Failed to create a 'pd.DataFrame' from sample {sample}: {e}"
+                ) from None
         self._shape = sample.shape
         self._columns = [str(i) for i in list(sample.columns)]
-        self._dtype = True  # infer dtype automatically
+        if self._dtype is None:
+            self._dtype = True  # infer dtype automatically
         return sample
 
     def _convert_dtype(

--- a/src/bentoml/_internal/io_descriptors/pandas.py
+++ b/src/bentoml/_internal/io_descriptors/pandas.py
@@ -517,12 +517,10 @@ class PandasDataFrame(
 
         obj = await request.body()
         if serialization_format is SerializationFormat.JSON:
-            assert not isinstance(self._dtype, bool)
             res = pd.read_json(io.BytesIO(obj), dtype=self._dtype, orient=self._orient)
         elif serialization_format is SerializationFormat.PARQUET:
             res = pd.read_parquet(io.BytesIO(obj), engine=get_parquet_engine())
         elif serialization_format is SerializationFormat.CSV:
-            assert not isinstance(self._dtype, bool)
             res: ext.PdDataFrame = pd.read_csv(io.BytesIO(obj), dtype=self._dtype)
         else:
             raise InvalidArgument(

--- a/src/bentoml/_internal/io_descriptors/pandas.py
+++ b/src/bentoml/_internal/io_descriptors/pandas.py
@@ -411,15 +411,14 @@ class PandasDataFrame(
                         raise InvalidArgument(f"Unsupported sample '{sample}' format.")
                 else:
                     # Try to load the string as json.
-                    sample = pd.read_json(sample)
+                    sample = pd.read_json(sample, dtype=True)
             except ValueError as e:
                 raise InvalidArgument(
                     f"Failed to create a 'pd.DataFrame' from sample {sample}: {e}"
                 ) from None
         self._shape = sample.shape
         self._columns = [str(i) for i in list(sample.columns)]
-        if self._dtype is None:
-            self._dtype = True  # infer dtype automatically
+        self._dtype = True  # infer dtype automatically
         return sample
 
     def _convert_dtype(

--- a/src/bentoml/_internal/io_descriptors/pandas.py
+++ b/src/bentoml/_internal/io_descriptors/pandas.py
@@ -386,36 +386,13 @@ class PandasDataFrame(
            @svc.api(input=input_spec, output=PandasDataFrame())
            def predict(inputs: pd.DataFrame) -> pd.DataFrame: ...
         """
-        if LazyType["ext.NpNDArray"]("numpy", "ndarray").isinstance(sample):
-            sample = pd.DataFrame(sample)
-        elif isinstance(sample, str):
-            try:
-                if os.path.exists(sample):
-                    try:
-                        ext = os.path.splitext(sample)[-1].strip(".")
-                        sample = getattr(
-                            pd,
-                            {
-                                "json": "read_json",
-                                "csv": "read_csv",
-                                "html": "read_html",
-                                "xls": "read_excel",
-                                "xlsx": "read_excel",
-                                "hdf5": "read_hdf",
-                                "parquet": "read_parquet",
-                                "pickle": "read_pickle",
-                                "sql": "read_sql",
-                            }[ext],
-                        )(sample)
-                    except KeyError:
-                        raise InvalidArgument(f"Unsupported sample '{sample}' format.")
-                else:
-                    # Try to load the string as json.
-                    sample = pd.read_json(sample, dtype=True)
-            except ValueError as e:
-                raise InvalidArgument(
-                    f"Failed to create a 'pd.DataFrame' from sample {sample}: {e}"
-                ) from None
+        if LazyType["ext.NpNDArray"]("numpy", "ndarray").isinstance(
+            sample
+        ) or isinstance(sample, str):
+            logger.warning(
+                "'from_sample' from type '%s' is deprecated. Make sure to only pass pandas DataFrame.",
+                type(sample),
+            )
         self._shape = sample.shape
         self._columns = [str(i) for i in list(sample.columns)]
         self._dtype = True  # infer dtype automatically


### PR DESCRIPTION
remove assertion check for `_dtype`, as pd.read_json and read_csv does accept dtype with bool for auto infer types

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
