### PR TITLE
chore: provides shim for bentoctl

### DIFF
--- a/src/bentoml/_internal/bento/gen.py
+++ b/src/bentoml/_internal/bento/gen.py
@@ -1,0 +1,39 @@
+"""
+This module is shim for bentoctl. NOT FOR DIRECT USE.
+"""
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import TYPE_CHECKING
+
+import fs
+
+from ..container.generate import generate_containerfile
+
+if TYPE_CHECKING:
+    from .build_config import DockerOptions
+
+__all__ = ["generate_dockerfile"]
+
+logger = logging.getLogger(__name__)
+
+warnings.warn(
+    "%s is deprecated. Make sure to use 'bentoml.container.build' and 'bentoml.container.health' instead."
+    % __name__,
+    DeprecationWarning,
+    stacklevel=4,
+)
+
+
+def generate_dockerfile(docker: DockerOptions, context_path: str, *, use_conda: bool):
+    from ..bento import Bento
+
+    bento = Bento.from_fs(fs.open_fs(context_path))
+    logger.debug("'use_conda' is deprecated and will not be used.")
+    return generate_containerfile(
+        docker,
+        bento.path,
+        conda=bento.info.conda,
+        bento_fs=bento._fs,
+    )

--- a/src/bentoml/_internal/container/base.py
+++ b/src/bentoml/_internal/container/base.py
@@ -49,6 +49,7 @@ class Arguments(ListStr):
 
     @construct_args.register(type(None))
     @construct_args.register(tuple)
+    @construct_args.register(list)
     def _(self, args: ArgType, opt: str = ""):
         if args is not None:
             self.extend(

--- a/src/bentoml/_internal/container/generate.py
+++ b/src/bentoml/_internal/container/generate.py
@@ -113,7 +113,7 @@ def generate_containerfile(
 
     .. note::
 
-        You should use ``construct_dockerfile`` instead of this function.
+        You should use ``construct_containerfile`` instead of this function.
 
     Returns:
         str: The rendered Dockerfile string.

--- a/src/bentoml/_internal/utils/buildx.py
+++ b/src/bentoml/_internal/utils/buildx.py
@@ -30,5 +30,9 @@ def health():
 def build(**kwargs: t.Any):
     # subprocess_env from bentoctl will be handle by buildx, so it is safe to pop this out.
     kwargs.pop("subprocess_env")
+    kwargs["tag"] = kwargs.pop("tags")
     context_path = kwargs.pop("cwd", None)
+    for key, value in kwargs.items():
+        if not value:
+            kwargs[key] = None
     _buildx_backend.build(context_path=context_path, **kwargs)

--- a/src/bentoml/_internal/utils/buildx.py
+++ b/src/bentoml/_internal/utils/buildx.py
@@ -1,0 +1,34 @@
+"""
+This module is shim for bentoctl. NOT FOR DIRECT USE.
+Make sure to use 'bentoml.container.build' and 'bentoml.container.health' instead.
+"""
+
+from __future__ import annotations
+
+import typing as t
+import warnings
+
+from ..container import health as _internal_container_health
+from ..container import get_backend
+
+__all__ = ["build", "health"]
+
+_buildx_backend = get_backend("buildx")
+
+warnings.warn(
+    "%s is deprecated. Make sure to use 'bentoml.container.build' and 'bentoml.container.health' instead."
+    % __name__,
+    DeprecationWarning,
+    stacklevel=4,
+)
+
+
+def health():
+    return _internal_container_health("buildx")
+
+
+def build(**kwargs: t.Any):
+    # subprocess_env from bentoctl will be handle by buildx, so it is safe to pop this out.
+    kwargs.pop("subprocess_env")
+    context_path = kwargs.pop("cwd", None)
+    _buildx_backend.build(context_path=context_path, **kwargs)

--- a/src/bentoml_cli/utils.py
+++ b/src/bentoml_cli/utils.py
@@ -114,6 +114,16 @@ def validate_container_tag(
         raise BentoMLException(f"Invalid tag type. Got {type(tag)}")
 
 
+# NOTE: shim for bentoctl
+def validate_docker_tag(
+    ctx: Context, param: Parameter, tag: str | tuple[str] | None
+) -> str | tuple[str] | None:
+    logger.warning(
+        "'validate_docker_tag' is now deprecated, use 'validate_container_tag' instead."
+    )
+    return validate_container_tag(ctx, param, tag)
+
+
 class BentoMLCommandGroup(click.Group):
     """
     Click command class customized for BentoML CLI, allow specifying a default


### PR DESCRIPTION
provide backward shim for bentoctl until it migrates to public API
I have tested with sagemaker. with and without conda.

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
