### PR TITLE
fix: Support for a custom docker base image in dockerfile/__init__.py.

### DIFF
--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -34,6 +34,8 @@ from ..container.frontend.dockerfile import SUPPORTED_CUDA_VERSIONS
 from ..container.frontend.dockerfile import ALLOWED_CUDA_VERSION_ARGS
 from ..container.frontend.dockerfile import SUPPORTED_PYTHON_VERSIONS
 from ..container.frontend.dockerfile import CONTAINER_SUPPORTED_DISTROS
+from ..container.frontend.dockerfile import CUSTOM_BASE_IMAGE_DISTRO
+
 
 if TYPE_CHECKING:
     from attr import Attribute
@@ -149,13 +151,13 @@ class DockerOptions:
     # always omit config values in case of default values got changed in future BentoML releases
     __omit_if_default__ = False
 
-    distro: str = attr.field(
+    distro: t.Optional[str] = attr.field(
         default=None,
         validator=attr.validators.optional(
             attr.validators.in_(CONTAINER_SUPPORTED_DISTROS)
         ),
     )
-    python_version: str = attr.field(
+    python_version: t.Optional[str] = attr.field(
         converter=_convert_python_version,
         default=None,
         validator=attr.validators.optional(
@@ -222,6 +224,8 @@ class DockerOptions:
             if self.python_version is None:
                 python_version = f"{version_info.major}.{version_info.minor}"
                 defaults["python_version"] = python_version
+        else:
+            defaults["distro"] = CUSTOM_BASE_IMAGE_DISTRO
 
         return attr.evolve(self, **defaults)
 

--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -31,11 +31,10 @@ from .build_dev_bentoml_whl import build_bentoml_editable_wheel
 from ..container.frontend.dockerfile import DistroSpec
 from ..container.frontend.dockerfile import get_supported_spec
 from ..container.frontend.dockerfile import SUPPORTED_CUDA_VERSIONS
+from ..container.frontend.dockerfile import CUSTOM_BASE_IMAGE_DISTRO
 from ..container.frontend.dockerfile import ALLOWED_CUDA_VERSION_ARGS
 from ..container.frontend.dockerfile import SUPPORTED_PYTHON_VERSIONS
 from ..container.frontend.dockerfile import CONTAINER_SUPPORTED_DISTROS
-from ..container.frontend.dockerfile import CUSTOM_BASE_IMAGE_DISTRO
-
 
 if TYPE_CHECKING:
     from attr import Attribute

--- a/src/bentoml/_internal/container/frontend/dockerfile/__init__.py
+++ b/src/bentoml/_internal/container/frontend/dockerfile/__init__.py
@@ -40,6 +40,8 @@ SUPPORTED_ARCHITECTURES = ["amd64", "arm64", "ppc64le", "s390x"]
 # Supported release types
 SUPPORTED_RELEASE_TYPES = ["python", "miniconda", "cuda"]
 
+CUSTOM_BASE_IMAGE_DISTRO = "custom_base_image"
+
 # BentoML supported distros mapping spec with
 # keys represents distros, and value is a tuple of list for supported python
 # versions and list of supported CUDA versions.
@@ -92,6 +94,13 @@ CONTAINER_METADATA: dict[str, dict[str, t.Any]] = {
             "supported_architectures": ["amd64"],
         },
     },
+    CUSTOM_BASE_IMAGE_DISTRO: {
+        "supported_python_versions": SUPPORTED_PYTHON_VERSIONS,
+        "supported_cuda_versions": SUPPORTED_CUDA_VERSIONS,
+        "custom": {
+            "image": "A custom base image was provided",
+        },
+    }
 }
 
 CONTAINER_SUPPORTED_DISTROS = list(CONTAINER_METADATA.keys())
@@ -143,7 +152,9 @@ class DistroSpec:
                 f"{docker.distro} is not supported. Supported distros are: {', '.join(CONTAINER_METADATA.keys())}."
             )
 
-        if docker.cuda_version is not None:
+        if docker.distro == CUSTOM_BASE_IMAGE_DISTRO:
+            release_type = "custom"
+        elif docker.cuda_version is not None:
             release_type = "cuda"
         elif not conda.is_empty():
             release_type = "miniconda"

--- a/src/bentoml/_internal/container/frontend/dockerfile/__init__.py
+++ b/src/bentoml/_internal/container/frontend/dockerfile/__init__.py
@@ -100,7 +100,7 @@ CONTAINER_METADATA: dict[str, dict[str, t.Any]] = {
         "custom": {
             "image": "A custom base image was provided",
         },
-    }
+    },
 }
 
 CONTAINER_SUPPORTED_DISTROS = list(CONTAINER_METADATA.keys())

--- a/src/bentoml/_internal/server/grpc/servicer/v1/__init__.py
+++ b/src/bentoml/_internal/server/grpc/servicer/v1/__init__.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import anyio
+
 from .....utils import LazyLoader
 from ......exceptions import InvalidArgument
 from ......exceptions import BentoMLException
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
 
     import grpc
     from google.protobuf import struct_pb2
+
     from ......grpc.v1 import service_pb2 as pb
     from ......grpc.v1 import service_pb2_grpc as services
     from ......grpc.types import BentoServicerContext


### PR DESCRIPTION
## What does this PR address?

The 1.0.11 release broke the ability to build bentos that are based on a custom docker base image, as described in https://github.com/bentoml/BentoML/issues/3325. In this PR I'm trying to fix that problem. I went down the path of setting `docker.distro` to a sentinel value ("custom_base_image"). I have no idea if this is a palatable solution, and I won't be offended if you don't think so and prefer something else.

Fixes #3325

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
(`make lint` failed, but I don't think it has anything to do with these changes.)
