### PR TITLE
fix: add upper bound for packaging version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "opentelemetry-instrumentation-asgi==0.35b0",
   "opentelemetry-semantic-conventions==0.35b0",
   "opentelemetry-util-http==0.35b0",
-  "packaging>=20.0",
+  "packaging>=20.0,<22",
   "pathspec",
   "pip-tools>=6.6.2",
   "pip-requirements-parser>=31.2.0",

--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -16,7 +16,6 @@ import yaml
 import psutil
 import fs.copy
 from pathspec import PathSpec
-from pip_requirements_parser import RequirementsFile
 
 from ..utils import bentoml_cattr
 from ..utils import resolve_user_filepath
@@ -598,6 +597,8 @@ fi
             f.write(install_sh)
 
         if self.requirements_txt is not None:
+            from pip_requirements_parser import RequirementsFile
+
             requirements_txt = RequirementsFile.from_file(
                 resolve_user_filepath(self.requirements_txt, build_ctx),
                 include_nested=True,


### PR DESCRIPTION
packaging 22.0 removes LegacyVersion, which pip-requirements-parser are currently using
