### PR TITLE
fix(transformers): check for task aliases

### DIFF
--- a/src/bentoml/_internal/frameworks/transformers.py
+++ b/src/bentoml/_internal/frameworks/transformers.py
@@ -191,6 +191,7 @@ def load_model(
             f"Model {bento_model.tag} was saved with module {bento_model.info.module}, not loading with {MODULE_NAME}."
         )
 
+    from transformers.pipelines import TASK_ALIASES
     from transformers.pipelines import SUPPORTED_TASKS
 
     if TYPE_CHECKING:
@@ -199,7 +200,7 @@ def load_model(
         options = bento_model.info.options
 
     task: str = bento_model.info.options.task  # type: ignore
-    if task not in SUPPORTED_TASKS:
+    if task not in SUPPORTED_TASKS and task not in TASK_ALIASES:
         try:
             import cloudpickle  # type: ignore
         except ImportError:  # pragma: no cover


### PR DESCRIPTION
Bug Fix: add task aliases of transformers pipeline supported tasks

## What does this PR address?

I ran into an issue today trying to load a Huggingface pipeline after it was saved via:

```
nlp = pipeline('ner', model=model, tokenizer=tokenizer)
bentoml.transformers.save_model(name="ner", pipeline=nlp)
runner = bentoml.transformers.get("ner:latest").to_runner()  # fails here
``` 

The "ner" task is one of the `[TASK_ALIASES](https://github.com/huggingface/transformers/blob/main/src/transformers/pipelines/__init__.py#L150)` in transformers pipeline which maps to a SUPPORTED_TASK.  Funny thing is `save_model()` has TASK_ALIASES support but maybe it was forgotten in `load_model()`.

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
