### PR TITLE
fix: CI breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Install libenchant
         run: |
-          sudo apt-get update && sudo apt-get install -y libenchant-dev
+          sudo apt-get update && sudo apt-get install -y libenchant-2-dev
 
       - name: Run spellcheck script
         run: make spellcheck-docs

--- a/.github/workflows/frameworks.yml
+++ b/.github/workflows/frameworks.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7.10
+          python-version: 3.8
 
       - name: Get pip cache dir
         id: cache-dir

--- a/requirements/tests-requirements.txt
+++ b/requirements/tests-requirements.txt
@@ -16,7 +16,7 @@ pytest-asyncio==0.20.3
 imageio==2.22.4
 pyarrow==10.0.1
 build[virtualenv]==0.9.0
-protobuf
+protobuf<4.0dev
 grpcio
 grpcio-health-checking
 opentelemetry-instrumentation-grpc==0.35b0

--- a/requirements/tests-requirements.txt
+++ b/requirements/tests-requirements.txt
@@ -16,7 +16,7 @@ pytest-asyncio==0.20.3
 imageio==2.22.4
 pyarrow==10.0.1
 build[virtualenv]==0.9.0
-protobuf==3.19.6
-grpcio>=1.41.0, <1.49, !=1.48.2
-grpcio-health-checking>=1.41.0, <1.49, !=1.48.2
+protobuf
+grpcio
+grpcio-health-checking
 opentelemetry-instrumentation-grpc==0.35b0


### PR DESCRIPTION
- bumping base python version for actions/python to 3.8
- unrestrict protobuf requirements for tests

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
