### PR TITLE
fix: make sure to handle relative path for templates

### DIFF
--- a/src/bentoml/_internal/container/generate.py
+++ b/src/bentoml/_internal/container/generate.py
@@ -174,14 +174,14 @@ def generate_containerfile(
 
     user_templates = docker.dockerfile_template
     if user_templates is not None:
-        TEMPLATES_PATH.append(
-            os.path.dirname(resolve_user_filepath(user_templates, build_ctx))
-        )
+        dir_path = os.path.dirname(resolve_user_filepath(user_templates, build_ctx))
+        user_templates = os.path.basename(user_templates)
+        TEMPLATES_PATH.append(dir_path)
         environment = ENVIRONMENT.overlay(
             loader=FileSystemLoader(TEMPLATES_PATH, followlinks=True)
         )
         template = environment.get_template(
-            os.path.basename(user_templates),
+            user_templates,
             globals={"bento_base_template": template, **J2_FUNCTION},
         )
 


### PR DESCRIPTION
revert user templates handling logics to 1.0.10

See https://bentoml.slack.com/archives/CKRANBHPH/p1671009900837059

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
