### PR TITLE
fix: use relative urls in swagger UI

### DIFF
--- a/src/bentoml/_internal/server/static_content/swagger-initializer.js
+++ b/src/bentoml/_internal/server/static_content/swagger-initializer.js
@@ -1,7 +1,7 @@
 window.onload = function() {
   // SwaggerUI Configurations
   window.ui = SwaggerUIBundle({
-    url: "/docs.json",
+    url: "./docs.json",
     dom_id: '#swagger-ui',
     deepLinking: true,
     validatorUrl: null,

--- a/src/bentoml/_internal/service/openapi/__init__.py
+++ b/src/bentoml/_internal/service/openapi/__init__.py
@@ -107,6 +107,7 @@ def generate_spec(svc: Service, *, openapi_version: str = "3.0.2"):
             version=svc.tag.version if svc.tag and svc.tag.version else "None",
             contact=Contact(name="BentoML Team", email="contact@bentoml.com"),
         ),
+        servers=[{"url": "."}],
         paths={
             # setup infra endpoints
             **make_infra_endpoints(),

--- a/src/bentoml/_internal/service/openapi/specification.py
+++ b/src/bentoml/_internal/service/openapi/specification.py
@@ -271,6 +271,7 @@ class OpenAPISpecification:
     openapi: str
     info: Info
     paths: t.Dict[str, PathItem]
+    servers: t.List[t.Any]
     tags: t.Optional[t.List[Tag]] = None
     components: t.Optional[Components] = None
 


### PR DESCRIPTION
This allows for bento services to be rewritten to under a sub-page (see https://github.com/bentoml/BentoML/issues/3258).