### PR TITLE
fix: log error when runnable instantiation fails

### DIFF
--- a/src/bentoml/_internal/runner/runner.py
+++ b/src/bentoml/_internal/runner/runner.py
@@ -223,7 +223,18 @@ class Runner:
     def _init_local(self) -> None:
         from .runner_handle.local import LocalRunnerRef
 
-        self._init(LocalRunnerRef)
+        try:
+            self._init(LocalRunnerRef)
+        except Exception as e:
+            import traceback
+
+            logger.error(
+                "An exception occurred while instantiating runner '%s', see details below:",
+                self.name,
+            )
+            logger.error(traceback.format_exc())
+
+            raise e
 
     def init_local(self, quiet: bool = False) -> None:
         """


### PR DESCRIPTION
This works around an issue where Starlette handles exceptions in startup, hiding the actual issue from the user.

In production mode, this will double print the exception, but that doesn't seem like a particularly important problem, since this is an exception and the application fails to start anyway.

We should probably do a little more digging on the implementation of the ASGI lifespan protocol, but for now this should do.