### PR TITLE
feat: openapi_components method for Multipart

### DIFF
--- a/src/bentoml/_internal/io_descriptors/multipart.py
+++ b/src/bentoml/_internal/io_descriptors/multipart.py
@@ -219,7 +219,14 @@ class Multipart(IODescriptor[t.Dict[str, t.Any]], descriptor_id="bentoml.io.Mult
         )
 
     def openapi_components(self) -> dict[str, t.Any] | None:
-        pass
+        components = {}
+
+        for io in self._inputs.values():
+            child_components = io.openapi_components()
+            if child_components is not None:
+                components.update(child_components)
+
+        return components
 
     def openapi_example(self) -> t.Any:
         return {args: io.openapi_example() for args, io in self._inputs.items()}


### PR DESCRIPTION
Previously the schema components from JSON inputs would not be generated by the MultiPart IO Descriptor. See issue #3436

## What does this PR address?

<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

Copied from corresponding issue:

> When creating an API endpoint with a Multipart Input, where one of the child inputs is JSON with a pydantic model with an Enum field, the resulting OpenAPI spec does not include the schema component for the Enum field.

The approach here is just to call the `openapi_components` for all children of the MultiPart input and then merge all the dictionaries together. I've looked over all of the IO descriptor classes and it appears that the JSON input is the only one that ever returns a dict here, so I believe this won't cause any issues with any of the other input types.

<!-- Remove if not applicable -->

Fixes #3436

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
