### PR TITLE
ci: disable 3.10 e2e for gRPC on Mac X86

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,9 @@ jobs:
         exclude:
           - os: windows-latest
             server_type: "grpc"
+          - os: macos-latest
+            server_type: "grpc"
+            python-version: "3.10"
 
     if: ${{ (github.event_name == 'pull_request' && needs.diff.outputs.bentoml == 'true') || github.event_name == 'push' }}
     name: python${{ matrix.python-version }}_${{ matrix.server_type }}_e2e_tests (${{ matrix.os }})


### PR DESCRIPTION
ci: disable 3.10 tests on x86 mac

The tests pass locally with M1 mac. I don't realy have a x86 mac to test ;(
