### PR TITLE
docs(metrics): remove API reference

### DIFF
--- a/docs/source/reference/metrics.rst
+++ b/docs/source/reference/metrics.rst
@@ -73,11 +73,3 @@ The following section will go over the most commonly used metrics API in
 .. autofunction:: bentoml.metrics.generate_latest
 
 .. autofunction:: bentoml.metrics.text_string_to_metric_families
-
-.. autofunction:: bentoml.metrics.Histogram
-
-.. autofunction:: bentoml.metrics.Counter
-
-.. autofunction:: bentoml.metrics.Summary
-
-.. autofunction:: bentoml.metrics.Gauge


### PR DESCRIPTION
To silent sphinx warning. Documentation for metrics will still work with `help()`

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
