### PR TITLE
docs: add spark to docs requirements

### DIFF
--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -16,3 +16,4 @@ pyenchant
 Jinja2>=3.1
 sphinx-autobuild
 sphinx-hoverxref
+pyspark


### PR DESCRIPTION
This should fix the API documentation.