### PR TITLE
fix(containerize): remove autoconfig for buildctl

### DIFF
--- a/src/bentoml/_internal/container/buildctl.py
+++ b/src/bentoml/_internal/container/buildctl.py
@@ -153,22 +153,4 @@ def construct_build_args(
         else:
             raise ValueError(f"Unsupported type for {k}: {type(v)}")
 
-    if tag is not None:
-        # NOTE: We will always use the docker image spec if docker is available.
-        # Otherwise fallback to the OCI image spec.
-        if shutil.which("docker") is not None:
-            cmds.construct_args(
-                tuple(map(lambda tg: f"type=docker,name=docker.io/{tg}", tag)),
-                opt="output",
-            )
-        else:
-            cmds.construct_args(
-                tuple(map(lambda tg: f"type=oci,name={tg}", tag)),
-                opt="output",
-            )
-    else:
-        logger.info(
-            "'tag' is not specified. Result image will only be saved in build cache."
-        )
-
     return cmds

--- a/src/bentoml/_internal/container/buildctl.py
+++ b/src/bentoml/_internal/container/buildctl.py
@@ -153,4 +153,14 @@ def construct_build_args(
         else:
             raise ValueError(f"Unsupported type for {k}: {type(v)}")
 
+    if tag is not None:
+        if output is None:
+            logger.warning(
+                "Autoconfig for output type is deprecated. See message below."
+            )
+    else:
+        logger.info(
+            "'tag' is not specified. Result image will only be saved in build cache."
+        )
+
     return cmds

--- a/src/bentoml/_internal/container/buildctl.py
+++ b/src/bentoml/_internal/container/buildctl.py
@@ -156,8 +156,20 @@ def construct_build_args(
     if tag is not None:
         if output is None:
             logger.warning(
-                "Autoconfig for output type is deprecated. See message below."
+                "Autoconfig for output type is deprecated and will be removed in 2.0."
             )
+            # NOTE: We will always use the docker image spec if docker is available.
+            # Otherwise fallback to the OCI image spec.
+            if shutil.which("docker") is not None:
+                cmds.construct_args(
+                    tuple(map(lambda tg: f"type=docker,name=docker.io/{tg}", tag)),
+                    opt="output",
+                )
+            else:
+                cmds.construct_args(
+                    tuple(map(lambda tg: f"type=oci,name={tg}", tag)),
+                    opt="output",
+                )
     else:
         logger.info(
             "'tag' is not specified. Result image will only be saved in build cache."

--- a/src/bentoml/_internal/container/buildctl.py
+++ b/src/bentoml/_internal/container/buildctl.py
@@ -156,7 +156,7 @@ def construct_build_args(
     if tag is not None:
         if output is None:
             logger.warning(
-                "Autoconfig for output type is deprecated and will be removed in the next major release."
+                "Autoconfig for output type is deprecated and will be removed in the next major release. See message below."
             )
             # NOTE: We will always use the docker image spec if docker is available.
             # Otherwise fallback to the OCI image spec.

--- a/src/bentoml/_internal/container/buildctl.py
+++ b/src/bentoml/_internal/container/buildctl.py
@@ -156,7 +156,7 @@ def construct_build_args(
     if tag is not None:
         if output is None:
             logger.warning(
-                "Autoconfig for output type is deprecated and will be removed in 2.0."
+                "Autoconfig for output type is deprecated and will be removed in the next major release."
             )
             # NOTE: We will always use the docker image spec if docker is available.
             # Otherwise fallback to the OCI image spec.

--- a/src/bentoml_cli/containerize.py
+++ b/src/bentoml_cli/containerize.py
@@ -573,7 +573,8 @@ def add_containerize_command(cli: Group) -> None:
                     o = subprocess.check_output(
                         [container_runtime, "load"], input=result
                     )
-                    click.echo(o.decode("utf-8").strip())
+                    if get_debug_mode():
+                        click.echo(o.decode("utf-8").strip())
                     sys.exit(0)
                 return result
 

--- a/src/bentoml_cli/containerize.py
+++ b/src/bentoml_cli/containerize.py
@@ -4,6 +4,7 @@ import sys
 import shutil
 import typing as t
 import logging
+import subprocess
 import tempfile
 import itertools
 from typing import TYPE_CHECKING
@@ -536,24 +537,44 @@ def add_containerize_command(cli: Group) -> None:
                 elif shutil.which("nerdctl") is not None:
                     container_runtime = "nerdctl"
                 else:
-                    logger.warning(
-                        "To load image built with 'buildctl' requires one of docker, podman, nerdctl (Neither are found in PATH) and try again."
+                    click.echo(
+                        click.style(
+                            "To load image built with 'buildctl' requires one of "
+                            "docker, podman, nerdctl (None are found in PATH). "
+                            "Make sure they are visible to PATH and try again.",
+                            fg="yellow",
+                        ),
+                        color=True,
                     )
                     sys.exit(0)
-                # NOTE: We will always use the docker image spec if docker is available.
-                # Otherwise fallback to the OCI image spec.
                 if "output" not in _memoized:
                     tmp_path = tempfile.gettempdir()
                     type_prefix = "type=oci,name="
                     if container_runtime == "docker":
                         type_prefix = "type=docker,name=docker.io/"
                     click.echo(
-                        "If you wish to load the image locally, set the destination to a tar file. For example:"
+                        click.style(
+                            "Autoconfig is now deprecated and will be removed "
+                            "in the next future release. We recommend setting "
+                            "output to a tarfile should you wish to load the "
+                            "image locally. For example:",
+                            fg="yellow",
+                        ),
+                        color=True,
                     )
                     click.echo(
-                        f"    bentoml containerize {bento_tag} --backend buildctl --opt output={type_prefix}{tags[0]},dest={tmp_path}/{tags[0].replace(':', '_')}.tar\n"
-                        + f"    {container_runtime} load -i {tmp_path}/{tags[0].replace(':', '_')}.tar"
+                        click.style(
+                            f"    bentoml containerize {bento_tag} --backend buildctl --opt output={type_prefix}{tags[0]},dest={tmp_path}/{tags[0].replace(':', '_')}.tar\n"
+                            f"    {container_runtime} load -i {tmp_path}/{tags[0].replace(':', '_')}.tar",
+                            fg="yellow",
+                        ),
+                        color=True,
                     )
+                    o = subprocess.check_output(
+                        [container_runtime, "load"], input=result
+                    )
+                    click.echo(o.decode("utf-8").strip())
+                    sys.exit(0)
                 return result
 
             click.echo(

--- a/src/bentoml_cli/containerize.py
+++ b/src/bentoml_cli/containerize.py
@@ -4,9 +4,9 @@ import sys
 import shutil
 import typing as t
 import logging
-import subprocess
 import tempfile
 import itertools
+import subprocess
 from typing import TYPE_CHECKING
 from functools import partial
 

--- a/src/bentoml_cli/containerize.py
+++ b/src/bentoml_cli/containerize.py
@@ -4,8 +4,8 @@ import sys
 import shutil
 import typing as t
 import logging
-import itertools
 import tempfile
+import itertools
 from typing import TYPE_CHECKING
 from functools import partial
 


### PR DESCRIPTION
People who use buildctl should probably know how to use it.

Remove an auto --output from tag

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
