### PR TITLE
chore(triton): remove default set allow-metrics

### DIFF
--- a/src/bentoml/triton.py
+++ b/src/bentoml/triton.py
@@ -455,8 +455,6 @@ class TritonServerHandle:
 
         resolved: dict[str, t.Any] = bentoml_cattr.unstructure(self)
 
-        resolved["allow_metrics"] = str(False)
-
         cli: list[str] = []
         for arg, value in resolved.items():
             if _LazyType["list[str]"](list).isinstance(value) or _LazyType[


### PR DESCRIPTION
We have already raise an exception if users pass in allow-metrics

Signed-off-by: aarnphm-ec2-dev <29749331+aarnphm@users.noreply.github.com>
