### PR TITLE
fix: include dockerfile_template to Bento for containerize

### DIFF
--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -265,6 +265,16 @@ class DockerOptions:
                 setup_script, bento_fs, docker_folder, "setup_script"
             )
 
+        # If dockerfile_template is provided, then we copy it to the Bento
+        # See https://github.com/bentoml/BentoML/issues/3491
+        if self.dockerfile_template is not None:
+            copy_file_to_fs_folder(
+                resolve_user_filepath(self.dockerfile_template, build_ctx),
+                bento_fs,
+                docker_folder,
+                "Dockerfile.template",
+            )
+
     def to_dict(self) -> dict[str, t.Any]:
         return bentoml_cattr.unstructure(self)
 

--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -142,7 +142,6 @@ def _convert_env(
 
 @attr.frozen
 class DockerOptions:
-
     # For validating user defined bentofile.yaml.
     __forbid_extra_keys__ = True
     # always omit config values in case of default values got changed in future BentoML releases
@@ -266,7 +265,7 @@ class DockerOptions:
             )
 
         # If dockerfile_template is provided, then we copy it to the Bento
-        # See https://github.com/bentoml/BentoML/issues/3491
+        # This template then can be used later to containerize.
         if self.dockerfile_template is not None:
             copy_file_to_fs_folder(
                 resolve_user_filepath(self.dockerfile_template, build_ctx),
@@ -322,7 +321,6 @@ else:
 
 @attr.frozen
 class CondaOptions:
-
     # User shouldn't add new fields under yaml file.
     __forbid_extra_keys__ = True
     # no need to omit since BentoML has already handled the default values.
@@ -448,7 +446,6 @@ class CondaOptions:
 
 @attr.frozen
 class PythonOptions:
-
     # User shouldn't add new fields under yaml file.
     __forbid_extra_keys__ = True
     # no need to omit since BentoML has already handled the default values.
@@ -742,7 +739,6 @@ class BentoBuildConfig:
     )
 
     if TYPE_CHECKING:
-
         # NOTE: This is to ensure that BentoBuildConfig __init__
         # satisfies type checker. docker, python, and conda accepts
         # dict[str, t.Any] since our converter will handle the conversion.

--- a/src/bentoml/_internal/container/__init__.py
+++ b/src/bentoml/_internal/container/__init__.py
@@ -156,7 +156,7 @@ def construct_containerfile(
         # tmpdir is our new build context.
         fs.mirror.mirror(bento._fs, temp_fs, copy_if_newer=True)
 
-        # NOTE: dockefile_template is already included in the
+        # NOTE: dockerfile_template is already included in the
         # Dockerfile inside bento, and it is not relevant to
         # construct_containerfile. Hence it is safe to set it to None here.
         # See https://github.com/bentoml/BentoML/issues/3399.
@@ -168,7 +168,6 @@ def construct_containerfile(
             # NOTE: if users specify a dockerfile_template, we will
             # save it to /env/docker/Dockerfile.template. This is necessary
             # for the reconstruction of the Dockerfile.
-            # See https://github.com/bentoml/BentoML/issues/3491
             docker_attrs["dockerfile_template"] = "env/docker/Dockerfile.template"
 
         dockerfile = generate_containerfile(

--- a/src/bentoml/_internal/container/__init__.py
+++ b/src/bentoml/_internal/container/__init__.py
@@ -161,7 +161,10 @@ def construct_containerfile(
         # construct_containerfile. Hence it is safe to set it to None here.
         # See https://github.com/bentoml/BentoML/issues/3399.
         docker_attrs = bentoml_cattr.unstructure(options.docker)
-        if "dockerfile_template" in docker_attrs:
+        if (
+            "dockerfile_template" in docker_attrs
+            and docker_attrs["dockerfile_template"] is not None
+        ):
             # NOTE: if users specify a dockerfile_template, we will
             # save it to /env/docker/Dockerfile.template. This is necessary
             # for the reconstruction of the Dockerfile.

--- a/src/bentoml/_internal/container/__init__.py
+++ b/src/bentoml/_internal/container/__init__.py
@@ -161,7 +161,12 @@ def construct_containerfile(
         # construct_containerfile. Hence it is safe to set it to None here.
         # See https://github.com/bentoml/BentoML/issues/3399.
         docker_attrs = bentoml_cattr.unstructure(options.docker)
-        docker_attrs["dockerfile_template"] = None
+        if "dockerfile_template" in docker_attrs:
+            # NOTE: if users specify a dockerfile_template, we will
+            # save it to /env/docker/Dockerfile.template. This is necessary
+            # for the reconstruction of the Dockerfile.
+            # See https://github.com/bentoml/BentoML/issues/3491
+            docker_attrs["dockerfile_template"] = "env/docker/Dockerfile.template"
 
         dockerfile = generate_containerfile(
             docker=DockerOptions(**docker_attrs),


### PR DESCRIPTION
We will include Dockerfile.template into the bento if users specify a `dockerfile_template`

This is required for the reconstruction of the Dockerfile during containerize steps.

Address #3491 

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
