### PR TITLE
fix(serve): return self within context manager

### DIFF
--- a/src/bentoml/_internal/server/server.py
+++ b/src/bentoml/_internal/server/server.py
@@ -39,7 +39,7 @@ class ServerHandle:
         return f"{self.host}:{self.port}"
 
     def __enter__(self):
-        yield self
+        return self
 
     def __exit__(
         self,


### PR DESCRIPTION
**enter** should return self instead of yielding it

Signed-off-by: aarnphm-ec2-dev <29749331+aarnphm@users.noreply.github.com>
