### PR TITLE
docs: update env manager docs to grid index

### DIFF
--- a/docs/source/guides/index.rst
+++ b/docs/source/guides/index.rst
@@ -68,6 +68,10 @@ into this part of the documentation.
         :link: /guides/tracing
         :link-type: doc
 
+    .. grid-item-card:: :doc:`/guides/envmanager`
+        :link: /guides/envmanager
+        :link-type: doc
+
     .. grid-item-card:: :doc:`/guides/migration`
         :link: /guides/migration
         :link-type: doc


### PR DESCRIPTION
Add the env manager docs to docs index

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
