### PR TITLE
refactor: update transformers save and load implementation

### DIFF
--- a/src/bentoml/_internal/frameworks/transformers.py
+++ b/src/bentoml/_internal/frameworks/transformers.py
@@ -3,29 +3,65 @@ from __future__ import annotations
 import os
 import typing as t
 import logging
+import functools
 from types import ModuleType
-from typing import TYPE_CHECKING
 
 import attr
+from cattr.gen import override
+from cattr.gen import make_dict_structure_fn
 
 import bentoml
-from bentoml import Tag
-from bentoml.models import Model
-from bentoml.models import ModelContext
-from bentoml.models import ModelOptions
-from bentoml.exceptions import NotFound
-from bentoml.exceptions import BentoMLException
-from bentoml.exceptions import MissingDependencyException
 
+from ..tag import Tag
 from ..types import LazyType
+from ..utils import LazyLoader
+from ..utils import bentoml_cattr
 from ..utils.pkg import find_spec
 from ..utils.pkg import get_pkg_version
+from ..utils.pkg import pkg_version_info
+from ...exceptions import NotFound
+from ...exceptions import BentoMLException
+from ...exceptions import MissingDependencyException
+from ..models.model import Model
+from ..models.model import ModelContext
+from ..models.model import PartialKwargsModelOptions as ModelOptions
+from ..configuration import DEBUG_ENV_VAR
+from ..configuration import get_debug_mode
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
+    import cloudpickle
+
     from bentoml.types import ModelSignature
 
     from ..models.model import ModelSignaturesType
     from ..external_typing import transformers as ext
+
+    class SimpleDefaultMapping(t.TypedDict, total=False):
+        pt: tuple[str, ...]
+        tf: tuple[str, ...]
+
+    class ModelDefaultMapping(t.TypedDict):
+        model: SimpleDefaultMapping
+
+    DefaultMapping = (
+        ModelDefaultMapping
+        | SimpleDefaultMapping
+        | dict[tuple[str, ...], ModelDefaultMapping]
+    )
+
+    TupleStr = tuple[str, ...]
+    TupleAutoModel = tuple[ext.BaseAutoModelClass, ...]
+else:
+    TupleStr = TupleAutoModel = tuple
+    DefaultMapping = SimpleDefaultMapping = ModelDefaultMapping = dict
+
+    cloudpickle = LazyLoader(
+        "cloudpickle",
+        globals(),
+        "cloudpickle",
+        exc_msg="'cloudpickle' is required to save/load custom pipeline.",
+    )
+
 
 try:
     import transformers
@@ -37,6 +73,7 @@ except ImportError:  # pragma: no cover
 
 __all__ = ["load_model", "save_model", "get_runnable", "get"]
 
+_object_setattr = object.__setattr__
 
 MODULE_NAME = "bentoml.transformers"
 API_VERSION = "v1"
@@ -45,14 +82,19 @@ PIPELINE_PICKLE_NAME = f"pipeline.{API_VERSION}.pkl"
 
 logger = logging.getLogger(__name__)
 
+TRANSFORMERS_VERSION = pkg_version_info("transformers")
 
+HAS_PIPELINE_REGISTRY = TRANSFORMERS_VERSION >= (4, 21, 0)
+
+
+@functools.lru_cache(maxsize=1)
 def _check_flax_supported() -> None:  # pragma: no cover
-    _supported: bool = get_pkg_version("transformers").startswith("4")
+    _supported = TRANSFORMERS_VERSION[0] >= 4
 
     if not _supported:
         logger.warning(
-            "Detected transformers version: %s, which doesn't have supports for Flax. Update 'transformers' to 4.x and above to have Flax supported.",
-            get_pkg_version("transformers"),
+            "Detected transformers version: %s.%s.%s, which doesn't have supports for Flax. Update 'transformers' to 4.x and above to have Flax supported.",
+            *TRANSFORMERS_VERSION,
         )
     else:
         _flax_available = find_spec("jax") is not None and find_spec("flax") is not None
@@ -70,14 +112,22 @@ def _check_flax_supported() -> None:  # pragma: no cover
             )
 
 
-def _deep_convert_to_tuple(dct: dict[str, t.Any]) -> dict[str, tuple[str, str | None]]:
+def _deep_convert_to_tuple(
+    dct: dict[str, str | TupleStr | list[str] | dict[str, t.Any]]
+) -> dict[str, str | TupleStr | list[str] | dict[str, t.Any]]:
     for k, v in dct.items():
+        override = v
         if isinstance(v, list):
-            dct[k] = tuple(v)  # type: ignore
+            override = tuple(v)
+        elif isinstance(v, dict):
+            override = _deep_convert_to_tuple(v)
+        dct[k] = override
     return dct
 
 
-def _validate_type(_: t.Any, attribute: attr.Attribute[t.Any], value: t.Any) -> None:
+def _validate_pipeline_type(
+    _: t.Any, attribute: attr.Attribute[str | list[str]], value: str | list[str]
+) -> None:
     """
     Validate the type of the given pipeline definition. The value is expected to be a `str`.
     `list` type is also allowed here to maintain compatibility with an earlier introduced bug.
@@ -88,40 +138,137 @@ def _validate_type(_: t.Any, attribute: attr.Attribute[t.Any], value: t.Any) -> 
         raise ValueError(f"{attribute.name} must be a string")
 
 
+if t.TYPE_CHECKING:
+
+    class TaskDefinition(t.TypedDict):
+        impl: type[ext.TransformersPipeline]
+        tf: TupleAutoModel | ext.BaseAutoModelClass | None
+        pt: TupleAutoModel | ext.BaseAutoModelClass | None
+        default: t.NotRequired[DefaultMapping]
+        type: t.NotRequired[str]
+
+else:
+    TaskDefinition = dict
+
+
+def _autoclass_converter(
+    value: tuple[ext.BaseAutoModelClass | str, ...] | None
+) -> TupleStr:
+    if value is None:
+        return TupleStr()
+    elif isinstance(value, t.Iterable):
+        value = tuple(value)
+    elif not isinstance(value, tuple):
+        value = (value,)
+    return tuple(it if isinstance(it, str) else it.__qualname__ for it in value)
+
+
 @attr.define
 class TransformersOptions(ModelOptions):
     """Options for the Transformers model."""
 
-    task: str = attr.field(validator=attr.validators.instance_of(str))
-    tf: t.Tuple[str] = attr.field(
-        validator=attr.validators.optional(
-            attr.validators.deep_iterable(
-                member_validator=attr.validators.instance_of(str)
-            )
-        ),  # type: ignore
-        factory=tuple,
-        converter=tuple,
+    task: str = attr.field(factory=str, validator=attr.validators.instance_of(str))
+    tf: TupleStr = attr.field(
+        validator=attr.validators.deep_iterable(
+            attr.validators.instance_of(str), attr.validators.instance_of(TupleStr)
+        ),
+        factory=TupleStr,
+        converter=_autoclass_converter,
     )
-    pt: t.Tuple[str] = attr.field(
-        validator=attr.validators.optional(
-            attr.validators.deep_iterable(
-                member_validator=attr.validators.instance_of(str)
-            )
-        ),  # type: ignore
-        factory=tuple,
-        converter=tuple,
+    pt: TupleStr = attr.field(
+        validator=attr.validators.deep_iterable(
+            attr.validators.instance_of(str), attr.validators.instance_of(TupleStr)
+        ),
+        factory=TupleStr,
+        converter=_autoclass_converter,
     )
-    default: t.Dict[str, t.Any] = attr.field(
-        factory=dict, converter=_deep_convert_to_tuple
-    )
+    default: DefaultMapping = attr.field(factory=dict, converter=_deep_convert_to_tuple)
     type: str = attr.field(
-        validator=attr.validators.optional(_validate_type),
+        validator=attr.validators.optional(_validate_pipeline_type),
         default=None,
     )
     kwargs: t.Dict[str, t.Any] = attr.field(factory=dict)
 
+    @staticmethod
+    def process_task_mapping(
+        impl: type[ext.TransformersPipeline],
+        pt: tuple[ext.BaseAutoModelClass | str, ...]
+        | TupleAutoModel
+        | ext.BaseAutoModelClass
+        | None = None,
+        tf: tuple[ext.BaseAutoModelClass | str, ...]
+        | TupleAutoModel
+        | ext.BaseAutoModelClass
+        | None = None,
+        default: DefaultMapping | None = None,
+        type: str | None = None,
+    ) -> TaskDefinition:
+        if pt is None:
+            pt = TupleAutoModel()
+        elif not isinstance(pt, tuple):
+            pt = (pt,)
+        pt = tuple(convert_to_autoclass(it) if isinstance(it, str) else it for it in pt)
 
-def _convert_to_auto_class(cls_name: str) -> ext.BaseAutoModelClass:
+        if tf is None:
+            tf = TupleAutoModel()
+        elif not isinstance(tf, tuple):
+            tf = (tf,)
+        tf = tuple(convert_to_autoclass(it) if isinstance(it, str) else it for it in tf)
+
+        task_impl = TaskDefinition(impl=impl, pt=pt, tf=tf)
+
+        if default is not None:
+            if "model" not in default and ("pt" in default or "tf" in default):
+                # case for SimpleDefaultMapping, needs then to convert to ModelDefaultMapping
+                default = ModelDefaultMapping(
+                    model=t.cast(SimpleDefaultMapping, default)
+                )
+            task_impl["default"] = default
+        if type is not None:
+            task_impl["type"] = type
+
+        return task_impl
+
+    @classmethod
+    def from_task(cls, task: str, definition: TaskDefinition) -> TransformersOptions:
+        return cls(
+            task=task,
+            tf=definition.get("tf", None),  # type: ignore (handle by cattrs converter)
+            pt=definition.get("pt", None),  # type: ignore (handle by cattrs converter)
+            default=definition.get("default", {}),
+            type=definition.get("type", "text"),
+        )
+
+    def to_dict(self) -> dict[str, t.Any]:
+        res = {
+            "task": self.task,
+            "tf": tuple(self.tf),
+            "pt": tuple(self.pt),
+            "default": {
+                "_".join(k) if isinstance(k, tuple) else k: v
+                for k, v in self.default.items()
+            },
+            "type": self.type,
+            "kwargs": self.kwargs,
+        }
+        if self.partial_kwargs:
+            t.cast("dict[str, t.Any]", res["kwargs"]).update(self.partial_kwargs)
+        return res
+
+
+# provide backward compatibility with previous transformers options.
+bentoml_cattr.register_structure_hook_func(
+    lambda cls: issubclass(cls, TransformersOptions),
+    make_dict_structure_fn(
+        TransformersOptions,
+        bentoml_cattr,
+        _cattrs_forbid_extra_keys=True,
+        partial_kwargs=override(omit=True),
+    ),
+)
+
+
+def convert_to_autoclass(cls_name: str) -> ext.BaseAutoModelClass:
     if not hasattr(transformers, cls_name):
         raise BentoMLException(
             f"Given {cls_name} is not a valid Transformers auto class. For more information, "
@@ -156,23 +303,72 @@ def get(tag_like: str | Tag) -> Model:
     return model
 
 
+def register_pipeline(
+    task: str,
+    impl: type[ext.TransformersPipeline],
+    pt: tuple[ext.BaseAutoModelClass | str, ...]
+    | TupleAutoModel
+    | ext.BaseAutoModelClass
+    | None = None,
+    tf: tuple[ext.BaseAutoModelClass | str, ...]
+    | TupleAutoModel
+    | ext.BaseAutoModelClass
+    | None = None,
+    default: DefaultMapping | None = None,
+    type: str | None = None,
+):
+    task_impl = TransformersOptions.process_task_mapping(impl, pt, tf, default, type)
+
+    if HAS_PIPELINE_REGISTRY:
+        from transformers.pipelines import PIPELINE_REGISTRY
+
+        PIPELINE_REGISTRY.register_pipeline(
+            task,
+            pipeline_class=impl,
+            pt_model=task_impl["pt"],
+            tf_model=task_impl["tf"],
+            default=task_impl.get("default", None),
+            type=task_impl.get("type", None),
+        )
+    else:
+        # For backward compatibility
+        from transformers.pipelines import SUPPORTED_TASKS
+
+        SUPPORTED_TASKS.setdefault(task, task_impl)
+
+        _object_setattr(impl, "_registered_impl", {task: task_impl})
+
+
+def delete_pipeline(task: str) -> None:
+    """
+    Remove pipelines from current registry by task name.
+    """
+    if HAS_PIPELINE_REGISTRY:
+        from transformers.pipelines import PIPELINE_REGISTRY
+
+        del PIPELINE_REGISTRY.supported_tasks[task]
+    else:
+        # For backward compatibility
+        from transformers.pipelines import SUPPORTED_TASKS
+
+        del SUPPORTED_TASKS[task]
+
+
 def load_model(
-    bento_model: str | Tag | Model,
-    **kwargs: t.Any,
+    bento_model: str | Tag | Model, **kwargs: t.Any
 ) -> ext.TransformersPipeline:
     """
     Load the Transformers model from BentoML local modelstore with given name.
 
     Args:
-        bento_model (``str`` ``|`` :obj:`~bentoml.Tag` ``|`` :obj:`~bentoml.Model`):
-            Either the tag of the model to get from the store, or a BentoML `~bentoml.Model`
-            instance to load the model from.
-        kwargs (:code:`Any`):
-            Additional keyword arguments to pass to the model.
+        bento_model: Either the tag of the model to get from the store,
+                     or a BentoML :class:`~bentoml.Model` instance to load the
+                     model from.
+        attrs: Additional keyword arguments to pass into the pipeline.
 
     Returns:
-        ``Pipeline``:
-            The Transformers pipeline loaded from the model store.
+        ``transformers.pipeline.base.Pipeline``: The Transformers pipeline loaded
+        from the model store.
 
     Example:
 
@@ -191,55 +387,124 @@ def load_model(
             f"Model {bento_model.tag} was saved with module {bento_model.info.module}, not loading with {MODULE_NAME}."
         )
 
-    from transformers.pipelines import TASK_ALIASES
-    from transformers.pipelines import SUPPORTED_TASKS
+    from transformers.pipelines import get_supported_tasks
 
-    if TYPE_CHECKING:
-        options = t.cast(TransformersOptions, bento_model.info.options)
-    else:
-        options = bento_model.info.options
+    options = t.cast(TransformersOptions, bento_model.info.options)
 
-    task: str = bento_model.info.options.task  # type: ignore
-    if task not in SUPPORTED_TASKS and task not in TASK_ALIASES:
-        try:
-            import cloudpickle  # type: ignore
-        except ImportError:  # pragma: no cover
-            raise MissingDependencyException(
-                "Module `cloudpickle` is required in order to use to load custom pipelines."
-            )
+    task = options.task
+    pipeline: ext.TransformersPipeline | None = None
+    pipeline_class: type[ext.TransformersPipeline] | None = None
+
+    # Set trust_remote_code to True to allow loading custom pipeline.
+    kwargs.setdefault("trust_remote_code", False)
+
+    if os.path.exists(bento_model.path_of(PIPELINE_PICKLE_NAME)):
+        with open(bento_model.path_of(PIPELINE_PICKLE_NAME), "rb") as f:
+            pipeline_class = cloudpickle.load(f)
+
+    if task not in get_supported_tasks():
+        logger.debug(
+            "'%s' is not a supported task, trying to load custom pipeline.", task
+        )
 
         with open(bento_model.path_of(PIPELINE_PICKLE_NAME), "rb") as f:
-            pipeline = cloudpickle.load(f)
+            pipeline_class = cloudpickle.load(f)
 
-        SUPPORTED_TASKS[task] = {
-            "impl": type(pipeline),
-            "tf": tuple(
-                _convert_to_auto_class(auto_class) for auto_class in options.tf
-            ),
-            "pt": tuple(
-                _convert_to_auto_class(auto_class) for auto_class in options.pt
-            ),
-            "default": options.default,
-            "type": options.type,
-        }
+        register_pipeline(
+            task,
+            pipeline_class,
+            tuple(convert_to_autoclass(auto_class) for auto_class in options.pt),
+            tuple(convert_to_autoclass(auto_class) for auto_class in options.tf),
+            options.default,
+            options.type,
+        )
+        kwargs["trust_remote_code"] = True
 
-    extra_kwargs: dict[str, t.Any] = options.kwargs
-    extra_kwargs.update(kwargs)
-    if len(extra_kwargs) > 0:
-        logger.info(
-            "Loading '%s' pipeline '%s' with kwargs %s.",
+    kwargs.setdefault("pipeline_class", pipeline_class)
+
+    assert (
+        task in get_supported_tasks()
+    ), f"Task '{task}' failed to register into pipeline registry."
+
+    kwargs.update(options.kwargs)
+    if len(kwargs) > 0:
+        logger.debug(
+            "Loading '%s' pipeline (tag='%s') with kwargs %s.",
             task,
             bento_model.tag,
-            extra_kwargs,
+            kwargs,
         )
-    return transformers.pipeline(task=task, model=bento_model.path, **extra_kwargs)
+    try:
+        return transformers.pipeline(task=task, model=bento_model.path, **kwargs)
+    except Exception:
+        # When loading a custom pipeline that is not available on huggingface hub,
+        # the class registered in the pipeline registry will be a path to a Python file path.
+        # Currently, it doesn't handle relative imports correctly, so users will need to use
+        # external_modules when using 'save_model'.
+        logger.debug(
+            "If you are loading a custom pipeline, See https://huggingface.co/docs/transformers/main/en/add_new_pipeline#how-to-create-a-custom-pipeline for more information. We recommend to upload the custom pipeline to HuggingFace Hub to ensure consistency."
+        )
+        if pipeline is not None:
+            logger.info(
+                "Exception caught when trying to load pipeline for task '%s'. set '%s=True' to see the full exception. Return the pipeline pickle.",
+                task,
+                DEBUG_ENV_VAR,
+            )
+            logger.debug(
+                "If the pipeline is a custom pipeline, Make sure to add the following to your saving code: 'import importlib; bentoml.transformers.save_model(..., external_modules=[importlib.import_module(%s.__module__)])'",
+                pipeline,
+            )
+            if get_debug_mode():
+                import traceback
+
+                traceback.print_exc()
+
+            # Only return pipeline if pipeline is not None.
+            return pipeline
+
+        # Otherwise, raise the exception.
+        raise
+
+
+@t.overload
+def save_model(
+    name: str,
+    pipeline: ext.TransformersPipeline,
+    task_name: t.LiteralString = ...,
+    task_definition: dict[str, t.Any] = ...,
+    *,
+    signatures: ModelSignaturesType | None = ...,
+    labels: dict[str, str] | None = ...,
+    custom_objects: dict[str, t.Any] | None = ...,
+    external_modules: t.List[ModuleType] | None = ...,
+    metadata: dict[str, t.Any] | None = ...,
+) -> bentoml.Model:
+    ...
+
+
+@t.overload
+def save_model(
+    name: str,
+    pipeline: ext.TransformersPipeline,
+    task_name: t.LiteralString | None = ...,
+    task_definition: TaskDefinition | None = ...,
+    *,
+    signatures: ModelSignaturesType | None = ...,
+    labels: dict[str, str] | None = ...,
+    custom_objects: dict[str, t.Any] | None = ...,
+    external_modules: t.List[ModuleType] | None = ...,
+    metadata: dict[str, t.Any] | None = ...,
+) -> bentoml.Model:
+    ...
 
 
 def save_model(
     name: str,
     pipeline: ext.TransformersPipeline,
     task_name: str | None = None,
-    task_definition: dict[str, t.Any] | None = None,
+    # NOTE: annotate dict[str, t.Any] so that type checker won't raise error when users
+    # pass in dictionary. The type for this should be TaskDefinition.
+    task_definition: dict[str, t.Any] | TaskDefinition | None = None,
     *,
     signatures: ModelSignaturesType | None = None,
     labels: dict[str, str] | None = None,
@@ -259,7 +524,7 @@ def save_model(
         task_definition: Task definition for the Transformers custom pipeline. The definition is a dictionary
                          consisting of the following keys:
 
-                        - ``impl`` (:code:`str`): The name of the pipeline implementation module. The name should be the same as the pipeline passed in the ``pipeline`` argument.
+                        - ``impl`` (``type[transformers.base.Pipeline]``): The name of the pipeline implementation module. The name should be the same as the pipeline passed in the ``pipeline`` argument.
                         - ``tf`` (:code:`tuple[AnyType]`): The name of the Tensorflow auto model class. One of ``tf`` and ``pt`` auto model class argument is required.
                         - ``pt`` (:code:`tuple[AnyType]`): The name of the PyTorch auto model class. One of ``tf`` and ``pt`` auto model class argument is required.
                         - ``default`` (:code:`Dict[str, AnyType]`): The names of the default models, tokenizers, feature extractors, etc.
@@ -283,9 +548,8 @@ def save_model(
         custom_objects: Custom objects to be saved with the model. An example is ``{"my-normalizer": normalizer}``.
 
                         Custom objects are currently serialized with cloudpickle, but this implementation is subject to change.
-        external_modules (:code:`List[ModuleType]`, `optional`, default to :code:`None`):
-            user-defined additional python modules to be saved alongside the model or custom objects,
-            e.g. a tokenizer module, preprocessor module, model configuration module
+        external_modules: user-defined additional python modules to be saved alongside the model or custom objects,
+                          e.g. a tokenizer module, preprocessor module, model configuration module
         metadata: Custom metadata for given model.
 
     .. note::
@@ -293,8 +557,7 @@ def save_model(
         Both arguments ``task_name`` and ``task_definition`` must be provided to set save a custom pipeline.
 
     Returns:
-        :obj:`~bentoml.Tag`: A :obj:`tag` with a format `name:version` where `name` is
-        the user-defined model's name, and a generated `version`.
+        :obj:`~bentoml.Tag`: A :obj:`tag` with a format ``name:version`` where ``name`` is the user-defined model's name, and a generated ``version``.
 
     Examples:
 
@@ -310,18 +573,17 @@ def save_model(
         bento_model = bentoml.transformers.save_model("text-generation-pipeline", generator)
     """  # noqa
     _check_flax_supported()
-    if not isinstance(
-        pipeline,
-        LazyType["ext.TransformersPipeline"]("transformers.pipelines.base.Pipeline"),  # type: ignore
+    if not LazyType["ext.TransformersPipeline"]("transformers.Pipeline").isinstance(
+        pipeline
     ):
         raise BentoMLException(
             "'pipeline' must be an instance of 'transformers.pipelines.base.Pipeline'. "
             "To save other Transformers types like models, tokenizers, configs, feature "
             "extractors, construct a pipeline with the model, tokenizer, config, or feature "
-            "extractor specified as arguments, then call save_model with the pipeline. "
+            "extractor specified as arguments, then call 'save_model' with the pipeline. "
             "Refer to https://huggingface.co/docs/transformers/main_classes/pipelines "
             "for more information on pipelines. If transformers doesn't provide a task you "
-            "need, refer to the custom pipeline section to create your own pipelines."
+            "need, refer to the custom pipeline section to create your own pipeline.\n"
             """
             ```python
             import bentoml
@@ -351,103 +613,92 @@ def save_model(
             name,
         )
 
-    if task_name is not None and task_definition is not None:
-        from transformers.pipelines import TASK_ALIASES
-        from transformers.pipelines import SUPPORTED_TASKS
+    from transformers.pipelines import check_task
+    from transformers.pipelines import get_supported_tasks
 
-        try:
-            import cloudpickle  # type: ignore
-        except ImportError:  # pragma: no cover
-            raise MissingDependencyException(
-                "Module `cloudpickle` is required in order to use to save custom pipelines."
-            )
+    # NOTE: safe casting to annotate task_definition types
+    definition: TaskDefinition | None = (
+        t.cast(TaskDefinition, task_definition)
+        if task_definition is not None
+        else task_definition
+    )
 
+    if metadata is None:
+        metadata = {}
+    metadata["_is_custom_pipeline"] = False
+
+    if task_name is not None and definition is not None:
         logger.info(
             "Arguments 'task_name' and 'task_definition' are provided. Saving model with pipeline task name '%s' and task definition '%s'.",
             task_name,
-            task_definition,
+            definition,
         )
-
-        if pipeline.task is None or pipeline.task != task_name:
+        if pipeline.task != task_name:
             raise BentoMLException(
                 f"Argument 'task_name' '{task_name}' does not match pipeline task name '{pipeline.task}'."
             )
 
-        impl: type = task_definition["impl"]
+        assert "impl" in definition, "'task_definition' requires 'impl' key."
+
+        impl = definition["impl"]
         if type(pipeline) != impl:
             raise BentoMLException(
                 f"Argument 'pipeline' is not an instance of {impl}. It is an instance of {type(pipeline)}."
             )
 
-        if task_name in TASK_ALIASES:
-            task_name = TASK_ALIASES[task_name]
+        # Should only use this for custom pipelines
+        metadata["_is_custom_pipeline"] = True
+        options_args = (task_name, definition)
 
-        if task_name in SUPPORTED_TASKS:
-            if SUPPORTED_TASKS[task_name] != task_definition:
-                raise BentoMLException(
-                    f"Argument `task_definition` '{task_definition}' does not match pipeline task "
-                    "definition '{SUPPORTED_TASKS[task_name]}'."
-                )
-        else:
-            SUPPORTED_TASKS[task_name] = task_definition
+        if task_name not in get_supported_tasks():
+            logger.info(
+                "Task '%s' is not available in the pipeline registry. Trying to register it.",
+                task_name,
+            )
+            register_pipeline(task_name, **definition)
 
-        options = TransformersOptions(
-            task=task_name,
-            pt=tuple(
-                auto_class.__qualname__ for auto_class in task_definition.get("pt", ())
-            ),
-            tf=tuple(
-                auto_class.__qualname__ for auto_class in task_definition.get("tf", ())
-            ),
-            default=task_definition.get("default", {}),
-            type=task_definition.get("type", "text"),
-        )
-
-        with bentoml.models.create(
-            name,
-            module=MODULE_NAME,
-            api_version=API_VERSION,
-            labels=labels,
-            context=context,
-            options=options,
-            signatures=signatures,
-            custom_objects=custom_objects,
-            external_modules=external_modules,
-            metadata=metadata,
-        ) as bento_model:
-            pipeline.save_pretrained(bento_model.path)
-
-            with open(bento_model.path_of(PIPELINE_PICKLE_NAME), "wb") as f:
-                cloudpickle.dump(pipeline, f)
-
-            return bento_model
-
+        assert (
+            task_name in get_supported_tasks()
+        ), f"Task '{task_name}' failed to register into pipeline registry."
     else:
-        options = TransformersOptions(task=pipeline.task)
+        assert (
+            definition is None
+        ), "'task_definition' must be None if 'task_name' is not provided."
 
-        with bentoml.models.create(
-            name,
-            module=MODULE_NAME,
-            api_version=API_VERSION,
-            labels=labels,
-            context=context,
-            options=options,
-            signatures=signatures,
-            custom_objects=custom_objects,
-            external_modules=external_modules,
-            metadata=metadata,
-        ) as bento_model:
-            pipeline.save_pretrained(bento_model.path)
+        # if task_name is None, then we derive the task from pipeline.task
+        options_args = t.cast(
+            "tuple[str, TaskDefinition, t.Any]",
+            check_task(pipeline.task if task_name is None else task_name),
+        )[:2]
 
-            return bento_model
+    with bentoml.models.create(
+        name,
+        module=MODULE_NAME,
+        api_version=API_VERSION,
+        labels=labels,
+        context=context,
+        options=TransformersOptions.from_task(*options_args),
+        signatures=signatures,
+        custom_objects=custom_objects,
+        external_modules=external_modules,
+        metadata=metadata,
+    ) as bento_model:
+        pipeline.save_pretrained(bento_model.path)
+
+        # NOTE: we want to pickle the class so that tensorflow, flax pipeline will also work.
+        # the weights is already save, so we only need to save the class.
+        with open(bento_model.path_of(PIPELINE_PICKLE_NAME), "wb") as f:
+            cloudpickle.dump(pipeline.__class__, f)
+        return bento_model
 
 
-def get_runnable(
-    bento_model: bentoml.Model,
-) -> t.Type[bentoml.Runnable]:
+def get_runnable(bento_model: bentoml.Model) -> type[bentoml.Runnable]:
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
+
+    model_options = t.cast(TransformersOptions, bento_model.info.options)
+    partial_kwargs = model_options.partial_kwargs
 
     class TransformersRunnable(bentoml.Runnable):
         SUPPORTED_RESOURCES = ("nvidia.com/gpu", "cpu")
@@ -456,30 +707,38 @@ def get_runnable(
         def __init__(self):
             super().__init__()
 
-            available_gpus: str = os.getenv("CUDA_VISIBLE_DEVICES", "")
-            if available_gpus is not None and available_gpus not in ("", "-1"):
+            available_gpus = os.getenv("CUDA_VISIBLE_DEVICES", "")
+            if available_gpus not in ("", "-1"):
                 # assign GPU resources
                 if not available_gpus.isdigit():
                     raise ValueError(
                         f"Expecting numeric value for CUDA_VISIBLE_DEVICES, got {available_gpus}."
                     )
                 else:
-                    kwargs = {
-                        "device": int(available_gpus),
-                    }
+                    kwargs = {"device": int(available_gpus)}
             else:
                 # assign CPU resources
                 kwargs = {}
+            kwargs.update(model_options.kwargs)
 
-            self.pipeline = load_model(bento_model, **kwargs)
+            self.model = load_model(bento_model, **kwargs)
+
+            # backward compatibility with previous BentoML versions.
+            self.pipeline = self.model
 
             self.predict_fns: dict[str, t.Callable[..., t.Any]] = {}
             for method_name in bento_model.info.signatures:
                 self.predict_fns[method_name] = getattr(self.pipeline, method_name)
 
     def add_runnable_method(method_name: str, options: ModelSignature):
-        def _run(self: TransformersRunnable, *args: t.Any, **kwargs: t.Any) -> t.Any:
-            return getattr(self.pipeline, method_name)(*args, **kwargs)
+        def _run(
+            runnable_self: TransformersRunnable, *args: t.Any, **kwargs: t.Any
+        ) -> t.Any:
+            raw_method = getattr(runnable_self.model, method_name)
+            method_partial_kwargs = partial_kwargs.get(method_name)
+            if method_partial_kwargs:
+                raw_method = functools.partial(raw_method, **method_partial_kwargs)
+            return raw_method(*args, **kwargs)
 
         TransformersRunnable.add_method(
             _run,

--- a/src/bentoml/transformers.py
+++ b/src/bentoml/transformers.py
@@ -2,15 +2,14 @@ from __future__ import annotations
 
 import typing as t
 import logging
-from typing import TYPE_CHECKING
 
 from ._internal.frameworks.transformers import get
 from ._internal.frameworks.transformers import load_model
 from ._internal.frameworks.transformers import save_model
 from ._internal.frameworks.transformers import get_runnable
-from ._internal.frameworks.transformers import TransformersOptions as ModelOptions  # type: ignore # noqa
+from ._internal.frameworks.transformers import TransformersOptions as ModelOptions
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from ._internal.tag import Tag
 
 logger = logging.getLogger(__name__)
@@ -52,4 +51,4 @@ def load_runner(tag: Tag | str, *args: t.Any, **kwargs: t.Any):
     return get(tag).to_runner()
 
 
-__all__ = ["load_model", "save_model", "get", "get_runnable"]
+__all__ = ["load_model", "save_model", "get", "get_runnable", "ModelOptions"]

--- a/tests/integration/frameworks/models/__init__.py
+++ b/tests/integration/frameworks/models/__init__.py
@@ -39,7 +39,7 @@ class FrameworkTestModelConfiguration:
 @attr.define
 class FrameworkTestModelInput:
     input_args: list[t.Any]
-    expected: t.Any | t.Callable[[t.Any], bool]
+    expected: t.Any | t.Callable[[t.Any], bool | None]
     input_kwargs: dict[str, t.Any] = attr.Factory(dict)
 
     preprocess: t.Callable[[t.Any], t.Any] = lambda v: v  # noqa: E731
@@ -50,11 +50,11 @@ class FrameworkTestModelInput:
             if result is not None:
                 assert (
                     result
-                ), f"Output from model call ({', '.join(map(str, self.input_args))}, **{self.input_kwargs}) is not as expected"
+                ), f"Output from model call (args={', '.join(map(str, self.input_args))}, kwargs={self.input_kwargs}) is not expected (output={outp})"
         else:
             check = outp == self.expected
             if isinstance(check, np.ndarray):
                 check = check.all()
             assert (
                 check
-            ), f"Output from model call ({', '.join(map(str, self.input_args))}, **{self.input_kwargs}) is not as expected"
+            ), f"Output from model call (args={', '.join(map(str, self.input_args))}, kwargs={self.input_kwargs}) is not expected (output={outp}, expected={self.expected})"

--- a/tests/integration/frameworks/test_transformers_unit.py
+++ b/tests/integration/frameworks/test_transformers_unit.py
@@ -264,14 +264,12 @@ def test_custom_pipeline(pair_classification_pipeline: PairClassificationPipelin
 
     # Test runners
     bento_model = bentoml.transformers.get("my_classification_model")
-    runner = bento_model.with_options(
-        partial_kwargs={"__call__": {"second_text": "I love you"}}
-    ).to_runner()
+    runner = bento_model.to_runner()
     runner.init_local()
 
-    assert runner.run("I hate you") == pair_classification_pipeline(
+    assert runner.run(
         "I hate you", second_text="I love you"
-    )
+    ) == pair_classification_pipeline("I hate you", second_text="I love you")
 
     runner.destroy()
 


### PR DESCRIPTION
This PR attempts a few things:

- Using the pipeline registry to handle registering custom pipelines if transformers > 4.21, otherwise use the current strategy.
- Additionally, the `pipeline.v1.pkl` nows only pickle the pipeline class, as the weights should be handled via `pipeline.save_pretrained`.

Fixes #3675 

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
