### PR TITLE
revert: "chore: bumping otlp deps to 1.15"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,14 +39,14 @@ dependencies = [
     # OpenTelemetry is the server dependencies, rather than SDK
     # Since there are discrepancies among API and instrumentation packages,
     # we should always pin the set version of Opentelemetry suite
-    "opentelemetry-api==1.15.0",
-    "opentelemetry-sdk==1.15.0",
-    "opentelemetry-exporter-otlp-proto-http==1.15.0",
-    "opentelemetry-instrumentation==0.36b0",
-    "opentelemetry-instrumentation-aiohttp-client==0.36b0",
-    "opentelemetry-instrumentation-asgi==0.36b0",
-    "opentelemetry-semantic-conventions==0.36b0",
-    "opentelemetry-util-http==0.36b0",
+    "opentelemetry-api==1.14.0",
+    "opentelemetry-sdk==1.14.0",
+    "opentelemetry-exporter-otlp-proto-http==1.14.0",
+    "opentelemetry-instrumentation==0.35b0",
+    "opentelemetry-instrumentation-aiohttp-client==0.35b0",
+    "opentelemetry-instrumentation-asgi==0.35b0",
+    "opentelemetry-semantic-conventions==0.35b0",
+    "opentelemetry-util-http==0.35b0",
     "packaging>=22.0",
     "pathspec",
     "pip-tools>=6.6.2",
@@ -136,7 +136,7 @@ grpc = [
     "protobuf",
     "grpcio",
     "grpcio-health-checking",
-    "opentelemetry-instrumentation-grpc==0.36b0",
+    "opentelemetry-instrumentation-grpc==0.35b0",
 ]
 grpc-reflection = ["bentoml[grpc]", "grpcio-reflection"]
 grpc-channelz = ["bentoml[grpc]", "grpcio-channelz"]
@@ -148,9 +148,9 @@ tracing = [
     "bentoml[tracing-otlp]",
     "bentoml[tracing-zipkin]",
 ]
-tracing-jaeger = ["opentelemetry-exporter-jaeger==1.15.0"]
-tracing-zipkin = ["opentelemetry-exporter-zipkin==1.15.0"]
-tracing-otlp = ["opentelemetry-exporter-otlp==1.15.0"]
+tracing-jaeger = ["opentelemetry-exporter-jaeger==1.14.0"]
+tracing-zipkin = ["opentelemetry-exporter-zipkin==1.14.0"]
+tracing-otlp = ["opentelemetry-exporter-otlp==1.14.0"]
 
 [tool.setuptools_scm]
 write_to = "src/bentoml/_version.py"

--- a/requirements/tests-requirements.txt
+++ b/requirements/tests-requirements.txt
@@ -19,4 +19,4 @@ build[virtualenv]==0.10.0
 protobuf<4.0dev
 grpcio
 grpcio-health-checking
-opentelemetry-instrumentation-grpc==0.36b0
+opentelemetry-instrumentation-grpc==0.35b0


### PR DESCRIPTION
Reverts bentoml/BentoML#3351 
It breaks the monitoring features.
```python
Traceback (most recent call last):                                                                                                                                                                                             
File "/home/agent/BentoML/src/bentoml/_internal/server/http_app.py", line 324, in api_func                                                                                                                                      
output = await api.func(input_data)                                                                                                                                                                                         
File "/home/agent/BentoML/examples/monitoring/task_classification/service.py", line 18, in classify                                                                                                                             
with bentoml.monitor("iris_classifier_prediction") as mon:                                                                                                                                                                  
File "/home/agent/.conda/envs/torch@py3.7/lib/python3.7/contextlib.py", line 112, in __enter__                                                                                                                                  
return next(self.gen)                                                                                                                                                                                                       
File "/home/agent/BentoML/src/bentoml/_internal/monitoring/api.py", line 307, in monitor                                                                                                                                        
from .otlp import OTLPMonitor                                                                                                                                                                                               
File "/home/agent/BentoML/src/bentoml/_internal/monitoring/otlp.py", line 14, in <module>                                                                                                                                       
from opentelemetry.sdk._logs import set_logger_provider                                                                                                                                                                   
ImportError: cannot import name 'set_logger_provider' from 'opentelemetry.sdk._logs' 
(/home/agent/.conda/envs/torch@py3.7/lib/python3.7/site-packages/opentelemetry/sdk/_logs/__init__.py)
```