### PR TITLE
chore: enable plugins on CI only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
   LINES: 120
   COLUMNS: 120
   BENTOML_DO_NOT_TRACK: True
+  PYTEST_PLUGINS: bentoml.testing.pytest.plugin
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun
 defaults:

--- a/.github/workflows/frameworks.yml
+++ b/.github/workflows/frameworks.yml
@@ -12,6 +12,7 @@ env:
   LINES: 120
   COLUMNS: 120
   BENTOML_DO_NOT_TRACK: True
+  PYTEST_PLUGINS: bentoml.testing.pytest.plugin
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun
 defaults:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,7 +236,7 @@ exclude = '''
 '''
 
 [tool.pytest.ini_options]
-addopts = ["-rfEX", "-pbentoml.testing.pytest.plugin"]
+addopts = ["-rfEX", "-pno:warnings"]
 python_files = ["test_*.py", "*_test.py"]
 testpaths = ["tests"]
 


### PR DESCRIPTION
Only enable pytest plugins via envvar so that we can run tests inside examples
without using the plugins. The plugins are meant to be used with our general
tests suite only

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
