### PR TITLE
feat: enable cork for non-batched workloads

### DIFF
--- a/src/bentoml/_internal/marshal/dispatcher.py
+++ b/src/bentoml/_internal/marshal/dispatcher.py
@@ -363,7 +363,10 @@ class CorkDispatcher:
                         continue
                     await asyncio.sleep(self.tick_interval)
                     continue
-                if n * (wn + dt + (a or 0)) <= self.optimizer.wait * decay:
+                if (
+                    n < self.max_batch_size
+                    and n * (wn + dt + (a or 0)) <= self.optimizer.wait * decay
+                ):
                     await asyncio.sleep(self.tick_interval)
                     continue
 

--- a/src/bentoml/_internal/server/runner_app.py
+++ b/src/bentoml/_internal/server/runner_app.py
@@ -55,11 +55,10 @@ class RunnerAppFactory(BaseAppFactory):
 
         self.dispatchers: dict[str, CorkDispatcher] = {}
         for method in runner.runner_methods:
-            if not method.config.batchable:
-                continue
+            max_batch_size = method.max_batch_size if method.config.batchable else 1
             self.dispatchers[method.name] = CorkDispatcher(
                 max_latency_in_ms=method.max_latency_ms,
-                max_batch_size=method.max_batch_size,
+                max_batch_size=max_batch_size,
                 fallback=functools.partial(
                     ServiceUnavailable, message="process is overloaded"
                 ),


### PR DESCRIPTION
Enable cork for non-batched workloads, and immediately dispatch a batch if the queue contains enough requests.

This didn't actually help much with the case I was looking at, but we should have done this to begin with anyway.