### PR TITLE
fix: use a semaphore to limit runner connections

### DIFF
--- a/src/bentoml/_internal/configuration/v1/__init__.py
+++ b/src/bentoml/_internal/configuration/v1/__init__.py
@@ -66,6 +66,7 @@ _API_SERVER_CONFIG = {
     "workers": s.Or(s.And(int, ensure_larger_than_zero), None),
     "timeout": s.And(int, ensure_larger_than_zero),
     "backlog": s.And(int, ensure_larger_than(64)),
+    "max_runner_connections": s.And(int, ensure_larger_than_zero),
     "metrics": {
         "enabled": bool,
         "namespace": str,

--- a/src/bentoml/_internal/configuration/v1/default_configuration.yaml
+++ b/src/bentoml/_internal/configuration/v1/default_configuration.yaml
@@ -3,6 +3,8 @@ api_server:
   workers: ~ # cpu_count() will be used when null
   timeout: 60
   backlog: 2048
+  # the maximum number of connections that will be made to any given runner server at once
+  max_runner_connections: 16
   metrics:
     enabled: true
     namespace: bentoml_api_server

--- a/src/bentoml/_internal/runner/runner_handle/remote.py
+++ b/src/bentoml/_internal/runner/runner_handle/remote.py
@@ -64,6 +64,7 @@ class RemoteRunnerClient(RunnerHandle):
         self._client_cache: ClientSession | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._addr: str | None = None
+        self._semaphore = asyncio.Semaphore(16)
 
     @property
     def _remote_runner_server_map(self) -> dict[str, str]:
@@ -179,42 +180,43 @@ class RemoteRunnerClient(RunnerHandle):
                 ) from None
 
         path = "" if __bentoml_method.name == "__call__" else __bentoml_method.name
-        try:
-            async with self._client.post(
-                f"{self._addr}/{path}",
-                data=pickle.dumps(payload_params),  # FIXME: pickle inside pickle
-                headers={
-                    "Bento-Name": component_context.bento_name,
-                    "Bento-Version": component_context.bento_version,
-                    "Runner-Name": self._runner.name,
-                    "Yatai-Bento-Deployment-Name": component_context.yatai_bento_deployment_name,
-                    "Yatai-Bento-Deployment-Namespace": component_context.yatai_bento_deployment_namespace,
-                },
-            ) as resp:
-                body = await resp.read()
-        except aiohttp.ClientOSError as e:
-            if os.getenv("BENTOML_RETRY_RUNNER_REQUESTS", "").lower() == "true":
-                try:
-                    # most likely the TCP connection has been closed; retry after reconnecting
-                    await self._reset_client()
-                    async with self._client.post(
-                        f"{self._addr}/{path}",
-                        data=pickle.dumps(
-                            payload_params
-                        ),  # FIXME: pickle inside pickle
-                        headers={
-                            "Bento-Name": component_context.bento_name,
-                            "Bento-Version": component_context.bento_version,
-                            "Runner-Name": self._runner.name,
-                            "Yatai-Bento-Deployment-Name": component_context.yatai_bento_deployment_name,
-                            "Yatai-Bento-Deployment-Namespace": component_context.yatai_bento_deployment_namespace,
-                        },
-                    ) as resp:
-                        body = await resp.read()
-                except aiohttp.ClientOSError:
-                    raise RemoteException("Failed to connect to runner server.")
-            else:
-                raise RemoteException("Failed to connect to runner server.") from e
+        async with self._semaphore:
+            try:
+                async with self._client.post(
+                    f"{self._addr}/{path}",
+                    data=pickle.dumps(payload_params),  # FIXME: pickle inside pickle
+                    headers={
+                        "Bento-Name": component_context.bento_name,
+                        "Bento-Version": component_context.bento_version,
+                        "Runner-Name": self._runner.name,
+                        "Yatai-Bento-Deployment-Name": component_context.yatai_bento_deployment_name,
+                        "Yatai-Bento-Deployment-Namespace": component_context.yatai_bento_deployment_namespace,
+                    },
+                ) as resp:
+                    body = await resp.read()
+            except aiohttp.ClientOSError as e:
+                if os.getenv("BENTOML_RETRY_RUNNER_REQUESTS", "").lower() == "true":
+                    try:
+                        # most likely the TCP connection has been closed; retry after reconnecting
+                        await self._reset_client()
+                        async with self._client.post(
+                            f"{self._addr}/{path}",
+                            data=pickle.dumps(
+                                payload_params
+                            ),  # FIXME: pickle inside pickle
+                            headers={
+                                "Bento-Name": component_context.bento_name,
+                                "Bento-Version": component_context.bento_version,
+                                "Runner-Name": self._runner.name,
+                                "Yatai-Bento-Deployment-Name": component_context.yatai_bento_deployment_name,
+                                "Yatai-Bento-Deployment-Namespace": component_context.yatai_bento_deployment_namespace,
+                            },
+                        ) as resp:
+                            body = await resp.read()
+                    except aiohttp.ClientOSError:
+                        raise RemoteException("Failed to connect to runner server.")
+                else:
+                    raise RemoteException("Failed to connect to runner server.") from e
 
         try:
             content_type = resp.headers["Content-Type"]

--- a/src/bentoml/_internal/runner/runner_handle/remote.py
+++ b/src/bentoml/_internal/runner/runner_handle/remote.py
@@ -64,7 +64,7 @@ class RemoteRunnerClient(RunnerHandle):
         self._client_cache: ClientSession | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._addr: str | None = None
-        self._semaphore = asyncio.Semaphore(16)
+        self._semaphore = asyncio.Semaphore(BentoMLContainer.api_server_config.max_runner_connections.get())
 
     @property
     def _remote_runner_server_map(self) -> dict[str, str]:

--- a/src/bentoml/_internal/runner/runner_handle/remote.py
+++ b/src/bentoml/_internal/runner/runner_handle/remote.py
@@ -64,7 +64,9 @@ class RemoteRunnerClient(RunnerHandle):
         self._client_cache: ClientSession | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._addr: str | None = None
-        self._semaphore = asyncio.Semaphore(BentoMLContainer.api_server_config.max_runner_connections.get())
+        self._semaphore = asyncio.Semaphore(
+            BentoMLContainer.api_server_config.max_runner_connections.get()
+        )
 
     @property
     def _remote_runner_server_map(self) -> dict[str, str]:


### PR DESCRIPTION
This is a band-aid workaround to an issue where the runner server gets overloaded by request load, especially in synthetic scenarios, which causes significant CPU usage to be dedicated purely to parsing requests.