### PR TITLE
feat: make file io descriptor allow any mime type by default

### DIFF
--- a/tests/e2e/bento_server_http/tests/test_io.py
+++ b/tests/e2e/bento_server_http/tests/test_io.py
@@ -176,7 +176,7 @@ async def test_file(host: str, bin_file: str):
         f"http://{host}/predict_file",
         data=b,
         headers={"Content-Type": "application/pdf"},
-        assert_data=b"",
+        assert_data=b"\x810\x899",
     )
 
 

--- a/tests/e2e/bento_server_http/tests/test_io.py
+++ b/tests/e2e/bento_server_http/tests/test_io.py
@@ -171,13 +171,12 @@ async def test_file(host: str, bin_file: str):
         assert_data=b"\x810\x899",
     )
 
-    # Test Exception
     await async_request(
         "POST",
         f"http://{host}/predict_file",
         data=b,
         headers={"Content-Type": "application/pdf"},
-        assert_status=500,
+        assert_data=b"",
     )
 
 


### PR DESCRIPTION
I think this makes more sense; the file IO descriptor shouldn't care what kind of data it receives unless the user specifies it.