### PR TITLE
fix(configuration): CORS docs, `allow_origins` and `allow_headers`

### DIFF
--- a/docs/source/guides/configuration.rst
+++ b/docs/source/guides/configuration.rst
@@ -275,13 +275,16 @@ If specified, all fields under ``api_server.http.cors`` will then be parsed to `
      http:
        cors:
          enabled: true
-         allow_origin: ["myorg.com"]
-         allow_methods: ["GET", "OPTIONS", "POST", "HEAD", "PUT"]
-         allow_credentials: true
-         allow_headers: "*"
-         allow_origin_regex: 'https://.*\.my_org\.com'
-         max_age: 1200
-         expose_headers: ["Content-Length"]
+         access_control_allow_origins: ["http://myorg.com:8080", "https://myorg.com:8080"]
+         access_control_allow_methods: ["GET", "OPTIONS", "POST", "HEAD", "PUT"]
+         access_control_allow_credentials: true
+         access_control_allow_headers: ["*"]
+         access_control_allow_origin_regex: 'https://.*\.my_org\.com'
+         access_control_max_age: 1200
+         access_control_expose_headers: ["Content-Length"]
+
+.. deprecated:: 1.0.16
+   :code:`access_control_allow_origin` is deprecated. Use :code:`access_control_allow_origins` instead.
 
 ``grpc``
 """"""""

--- a/src/bentoml/_internal/configuration/containers.py
+++ b/src/bentoml/_internal/configuration/containers.py
@@ -243,7 +243,8 @@ class _BentoMLContainerClass:
     @providers.SingletonFactory
     @staticmethod
     def access_control_options(
-        allow_origin: str | None = Provide[cors.access_control_allow_origin],
+        allow_origin: str | None = Provide[cors.access_control_allow_origin],  # deprecated
+        allow_origins: list[str] | None = Provide[cors.access_control_allow_origins],
         allow_origin_regex: str
         | None = Provide[cors.access_control_allow_origin_regex],
         allow_credentials: bool | None = Provide[cors.access_control_allow_credentials],
@@ -258,10 +259,28 @@ class _BentoMLContainerClass:
         | str
         | None = Provide[cors.access_control_expose_headers],
     ) -> dict[str, list[str] | str | int]:
+
+        if allow_origin is not None:
+            deprecated_field: str = "api_server.http.cors.access_control_allow_origin"
+            new_field: str = "api_server.http.cors.access_control_allow_origins"
+            if allow_origins is None:
+                allow_origins = [allow_origin]
+                logger.warning(
+                    "'%s' is deprecated, please use '%s' instead."
+                    % (deprecated_field, new_field)
+                )
+            else:
+                msg = (
+                    f"'{deprecated_field}' is deprecated_field, "
+                    f"when '{deprecated_field}' and '{new_field}' are both set"
+                    f"'{deprecated_field} will be ignored"
+                )
+                logger.warning(msg)
+
         return {
             k: v
             for k, v in {
-                "allow_origins": allow_origin,
+                "allow_origins": allow_origins,
                 "allow_origin_regex": allow_origin_regex,
                 "allow_credentials": allow_credentials,
                 "allow_methods": allow_methods,

--- a/src/bentoml/_internal/configuration/containers.py
+++ b/src/bentoml/_internal/configuration/containers.py
@@ -243,8 +243,9 @@ class _BentoMLContainerClass:
     @providers.SingletonFactory
     @staticmethod
     def access_control_options(
-        allow_origin: str | None = Provide[cors.access_control_allow_origin],  # deprecated
-        allow_origins: list[str] | None = Provide[cors.access_control_allow_origins],
+        allow_origins: list[str]
+        | str
+        | None = Provide[cors.access_control_allow_origins],
         allow_origin_regex: str
         | None = Provide[cors.access_control_allow_origin_regex],
         allow_credentials: bool | None = Provide[cors.access_control_allow_credentials],
@@ -260,22 +261,11 @@ class _BentoMLContainerClass:
         | None = Provide[cors.access_control_expose_headers],
     ) -> dict[str, list[str] | str | int]:
 
-        if allow_origin is not None:
-            deprecated_field: str = "api_server.http.cors.access_control_allow_origin"
-            new_field: str = "api_server.http.cors.access_control_allow_origins"
-            if allow_origins is None:
-                allow_origins = [allow_origin]
-                logger.warning(
-                    "'%s' is deprecated, please use '%s' instead."
-                    % (deprecated_field, new_field)
-                )
-            else:
-                msg = (
-                    f"'{deprecated_field}' is deprecated_field, "
-                    f"when '{deprecated_field}' and '{new_field}' are both set"
-                    f"'{deprecated_field} will be ignored"
-                )
-                logger.warning(msg)
+        if isinstance(allow_origins, str):
+            allow_origins = [allow_origins]
+
+        if isinstance(allow_headers, str):
+            allow_headers = [allow_headers]
 
         return {
             k: v

--- a/src/bentoml/_internal/configuration/v1/__init__.py
+++ b/src/bentoml/_internal/configuration/v1/__init__.py
@@ -98,6 +98,7 @@ _API_SERVER_CONFIG = {
         "cors": {
             "enabled": bool,
             "access_control_allow_origin": s.Or(str, None),
+            "access_control_allow_origins": s.Or([str], None),
             "access_control_allow_origin_regex": s.Or(
                 s.And(str, s.Use(re.compile)), None
             ),

--- a/src/bentoml/_internal/configuration/v1/__init__.py
+++ b/src/bentoml/_internal/configuration/v1/__init__.py
@@ -97,8 +97,7 @@ _API_SERVER_CONFIG = {
         "port": s.And(int, ensure_larger_than_zero),
         "cors": {
             "enabled": bool,
-            "access_control_allow_origin": s.Or(str, None),
-            "access_control_allow_origins": s.Or([str], None),
+            "access_control_allow_origins": s.Or([str], str, None),
             "access_control_allow_origin_regex": s.Or(
                 s.And(str, s.Use(re.compile)), None
             ),
@@ -222,6 +221,12 @@ def migration(*, override_config: dict[str, t.Any]):
             current=f"api_server.cors.access_control_{f}",
             replace_with=f"api_server.http.cors.access_control_{f}",
         )
+
+    rename_fields(
+        override_config,
+        current="api_server.http.cors.access_control_allow_origin",
+        replace_with="api_server.http.cors.access_control_allow_origins",
+    )
 
     # 4. if ssl is present, in version 2 we introduce a api_server.ssl.enabled field to determine
     # whether user want to enable SSL.

--- a/src/bentoml/_internal/configuration/v1/default_configuration.yaml
+++ b/src/bentoml/_internal/configuration/v1/default_configuration.yaml
@@ -54,7 +54,6 @@ api_server:
     port: 3000
     cors:
       enabled: false
-      access_control_allow_origin: ~
       access_control_allow_origins: ~
       access_control_allow_credentials: ~
       access_control_allow_methods: ~

--- a/src/bentoml/_internal/configuration/v1/default_configuration.yaml
+++ b/src/bentoml/_internal/configuration/v1/default_configuration.yaml
@@ -55,6 +55,7 @@ api_server:
     cors:
       enabled: false
       access_control_allow_origin: ~
+      access_control_allow_origins: ~
       access_control_allow_credentials: ~
       access_control_allow_methods: ~
       access_control_allow_headers: ~

--- a/tests/e2e/bento_server_http/configs/cors_enabled.yml
+++ b/tests/e2e/bento_server_http/configs/cors_enabled.yml
@@ -2,7 +2,7 @@ api_server:
   http:
     cors: # standard: https://fetch.spec.whatwg.org/#http-cors-protocol
       enabled: True
-      access_control_allow_origin: "*"
+      access_control_allow_origins: ["http://bentoml.ai:8080", "https://bentoml.ai:8080"]
       access_control_allow_methods: ["GET", "OPTIONS", "POST", "HEAD", "PUT"]
       access_control_allow_credentials: True
       access_control_allow_headers: Null


### PR DESCRIPTION
## What does this PR address?

- The CORS configuration naming mistake in docs
- deprecate `access_control_ allow_origin`, use `access_control_allow_origins` instead
- `access_control_allow_origins` and `access_control_allow_headers` should be converted to list when passed to starlette's `CORSMiddleware`
- more test cases to cover origin mismatch

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
