### PR TITLE
fix(dispatcher): prevent possible dispatcher bad behavior

### DIFF
--- a/src/bentoml/_internal/marshal/dispatcher.py
+++ b/src/bentoml/_internal/marshal/dispatcher.py
@@ -318,12 +318,23 @@ class CorkDispatcher:
                         continue
                     await asyncio.sleep(self.tick_interval)
                     continue
-                if (
+
+                # we are now free to dispatch whenever we like
+                while (
+                    # if we don't already have enough requests,
                     n < self.max_batch_size
-                    and n * (wn + dt + (a or 0)) <= self.optimizer.wait * decay
+                    # we are not about to cancel the first request,
+                    and latency_0 + dt <= self.max_latency_in_ms * 0.95
+                    # and waiting will cause average latency to decrese
+                    and n * (wn + dt + a) <= self.optimizer.wait * decay
                 ):
+                    n = len(self._queue)
+                    now = time.time()
+                    wn = now - self._queue[-1][0]
+                    latency_0 = w0 + a * n + b
+
+                    # wait for additional requests to arrive
                     await asyncio.sleep(self.tick_interval)
-                    continue
 
                 if self.max_batch_size == -1:  # batching is disabled
                     n_call_out = 1


### PR DESCRIPTION
Previously, it was possible that if request load was fast enough and max latency set low enough, the dispatcher would enter a loop of waiting for new requests while cancelling the oldest ones while doing no work, this change seeks to fix that.

 - The optimizer values for slope and intercept are now bounded below at 0; we may want to eventually try to collect cases where the linear optimizer does this, but for now we do this to avoid the most pathological cases.
 - If the first request is in danger of being cancelled, we now stop waiting and begin processing immediately.