### PR TITLE
ci: Adding formatter jobs

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -1,0 +1,37 @@
+name: Setup repo
+description: Setup repo with all features on CI
+inputs:
+  python-version:
+    description: 'Python version'
+    required: true
+    default: '3.8'
+  architecture:
+    description: 'Which architecture to run on'
+    required: true
+    default: x64
+runs:
+  using: composite
+  steps:
+    - name: Fetch base reference.
+      shell: bash
+      run: git fetch origin $GITHUB_BASE_REF
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+        architecture: ${{ inputs.architecture }}
+    - uses: bazelbuild/setup-bazelisk@v2
+    - name: Get cache key prefix
+      id: get-cache-key-prefix
+      shell: bash
+      run: echo "prefix=${{ runner.os }}-${{ inputs.python-version }}" >> $GITHUB_OUTPUT
+    - name: Bazel cache
+      id: bazel-cache
+      uses: actions/cache@v3
+      with:
+        key: ${{ steps.get-cache-key-prefix.outputs.prefix }}-bazel
+        path: |
+          ~/.cache/bazel
+          tools/
+        restore-keys: |
+          ${{ steps.get-cache-key-prefix.outputs.prefix }}-bazel-

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -1,0 +1,73 @@
+name: general-admin
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  schedule:
+    # run this everyday at 12:00AM UTC
+    - cron: '0 0 * * *'
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun
+defaults:
+  run:
+    shell: bash --noprofile --norc -exo pipefail {0}
+concurrency:
+  group: general-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+env:
+  BRANCH_NAME: bot/style
+  GIT_AUTHOR_NAME: ${{ github.repository_owner }}
+  GIT_AUTHOR_EMAIL: ${{ github.repository_owner }}@users.noreply.github.com
+jobs:
+  format:
+    name: 'Create a style PR'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup CI
+        uses: ./.github/actions/setup-repo
+      - name: Setup buf
+        uses: bufbuild/buf-setup-action@v1.9.0
+        with:
+          github_token: ${{ github.token }}
+      - name: Run tooling
+        run: |
+          pip install -r requirements/dev-requirements.txt
+
+          # bazel BUILD format
+          bazel run //:buildfmt
+          # Black and isort
+          black "${{ github.workspace }}/src"
+          black --pyi "${{ github.workspace }}/typings" "${{ github.workspace }}/src/bentoml/metrics.pyi"
+          isort "${{ github.workspace }}/src"
+          # Ruff fix (if available)
+          ruff src docs examples tests --fix
+          # Proto files
+          buf format --config "${{ github.workspace }}/src/bentoml/grpc/buf.yaml" -w src/bentoml/grpc
+      - name: Install jq and curl
+        run: sudo apt-get install -y jq curl
+      - name: Get infos
+        id: meta
+        run: |
+          COMMIT_INFO="$(curl "https://api.github.com/repos/bentoml/bentoml/commits/main")"
+          SHA="$(echo $COMMIT_INFO | jq -r ".sha")"
+          URL="$(echo $COMMIT_INFO | jq -r ".html_url")"
+          DATE="$(date "+%Y-%m-%d %H:%M:%S %Z%z")"
+
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          echo "url=$URL" >> $GITHUB_OUTPUT
+          echo "date=$DATE" >> $GITHUB_OUTPUT
+      - name: Create a PR
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: 'ci: formatter and style (follow up from ${{ steps.meta.outputs.sha }})'
+          commit-message: 'style: format and lint (${{ steps.meta.outputs.sha }})'
+          body: Follow up from commit ${{ steps.meta.outputs.sha }} [${{ steps.meta.outputs.url }}] at ${{ steps.meta.outputs.date }}
+          branch-suffix: timestamp
+          signoff: true
+          delete-branch: true
+          reviewers: bentoml/bentoml-reviewers
+          author: ${{ env.GIT_AUTHOR_NAME }} <${{ env.GIT_AUTHOR_EMAIL }}>
+          branch: ${{ env.BRANCH_NAME }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,7 +247,8 @@ testpaths = ["tests"]
 # similar to black's
 line-length = 88
 # We ignore E501 (line too long) here because we keep user-visible strings on one line.
-ignore = ["E501"]
+# We ignore D407 (missing dashed underline after section) because it's not compatible with Google docstring style.
+ignore = ["E501", "D407"]
 exclude = [
     "bazel-*/",
     "venv",

--- a/requirements/tests-requirements.txt
+++ b/requirements/tests-requirements.txt
@@ -3,7 +3,7 @@ pandas
 pydantic
 scikit-learn
 yamllint==1.30.0
-black[jupyter]==22.12.0
+black[jupyter]==23.1.0
 codecov==2.1.12
 coverage[toml]==7.2.2
 setuptools>=63


### PR DESCRIPTION
Fixes some docs-related rules as well as using black 23.1

For now, we will run all formatters and linter after a PR is merged. GitHub Actions will create a PR for us.

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
