### PR TITLE
fix: copy files before running `setup_script`

### DIFF
--- a/src/bentoml/_internal/container/frontend/dockerfile/templates/base.j2
+++ b/src/bentoml/_internal/container/frontend/dockerfile/templates/base.j2
@@ -64,6 +64,7 @@ COPY --chown={{ bento__user }}:{{ bento__user }} ./env/python ./env/python/
 {% set __pip_cache__ = common.mount_cache("/root/.cache/pip") %}
 # install python packages with install.sh
 {% call common.RUN(__enable_buildkit__) -%} {{ __pip_cache__ }} {% endcall -%} bash -euxo pipefail {{ __install_python_scripts__ }}
+COPY --chown={{ bento__user }}:{{ bento__user }} . ./
 {% if __options__setup_script is not none %}
 {% set __setup_script__ = expands_bento_path("env", "docker", "setup_script", bento_path=bento__path) %}
 ADD ./env/docker/setup_script {{ __setup_script__ }}
@@ -71,8 +72,6 @@ RUN chmod +x {{ __setup_script__ }}
 RUN {{ __setup_script__ }}
 {% endif %}
 {% endblock %}
-
-COPY --chown={{ bento__user }}:{{ bento__user }} . ./
 
 # Block SETUP_BENTO_ENTRYPOINT
 {% block SETUP_BENTO_ENTRYPOINT %}


### PR DESCRIPTION
This PR fixes a bug from #3673 where it only copies the pip layers first. This
breaks the setup_script features if setup_script requires files inside src layer

The copy layer should be moved before the setup_script is ran.

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
