### PR TITLE
fix: log converting runner name as debug

### DIFF
--- a/src/bentoml/_internal/runner/runner.py
+++ b/src/bentoml/_internal/runner/runner.py
@@ -58,7 +58,7 @@ class RunnerMethod(t.Generic[T, P, R]):
 def _to_lower_name(name: str) -> str:
     lname = name.lower()
     if name != lname:
-        logger.warning("Converting runner name '%s' to lowercase: '%s'", name, lname)
+        logger.debug("Converting runner name '%s' to lowercase: '%s'", name, lname)
 
     return lname
 

--- a/tests/unit/_internal/runner/test_runner.py
+++ b/tests/unit/_internal/runner/test_runner.py
@@ -17,7 +17,7 @@ def test_valid_runner_basic(caplog):
     assert dummy_runner.name == "dummyrunnable"
     assert (
         "bentoml._internal.runner.runner",
-        logging.WARNING,
+        logging.DEBUG,
         "Using lowercased runnable class name 'dummyrunnable' for runner.",
     ) in caplog.record_tuples
 


### PR DESCRIPTION
I'm don't remember why we originally chose warning for this log, I feel like it's not a real issue and so should be debug (or maybe info?)

/cc @aarnphm 