### PR TITLE
fix: passing serve_cmd and passthrough kwargs

### DIFF
--- a/src/bentoml/server.py
+++ b/src/bentoml/server.py
@@ -96,6 +96,18 @@ class Server(ABC):
             def __init__(
                 self, blocking: bool = False, env: dict[str, str] | None = None
             ):
+                """Start the server programmatically.
+
+                To get the client, use the context manager.
+
+                .. note::
+
+                   ``blocking=True`` and using ``start()`` as a context manager is mutually exclusive.
+
+                Args:
+                    blocking: If True, the server will block until it is stopped.
+                    env: A dictionary of environment variables to pass to the server. Default to ``None``.
+                """
                 logger.info(f"starting server with arguments: {server.args}")
 
                 server.process = subprocess.Popen(

--- a/src/bentoml/server.py
+++ b/src/bentoml/server.py
@@ -64,7 +64,7 @@ class Server(ABC):
             sys.executable,
             "-m",
             "bentoml",
-            "serve-http",
+            serve_cmd,
             bento_str,
             "--host",
             host,
@@ -93,7 +93,7 @@ class Server(ABC):
 
     def _create_startmanager(server):  # type: ignore # not calling self self
         class _StartManager:
-            def __init__(self, blocking: bool = False):
+            def __init__(self, blocking: bool = False, **kwargs: t.Any):
                 logger.info(f"starting server with arguments: {server.args}")
 
                 server.process = subprocess.Popen(
@@ -101,6 +101,7 @@ class Server(ABC):
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     stdin=subprocess.PIPE,
+                    **kwargs,
                 )
 
                 if blocking:

--- a/src/bentoml/server.py
+++ b/src/bentoml/server.py
@@ -93,7 +93,9 @@ class Server(ABC):
 
     def _create_startmanager(server):  # type: ignore # not calling self self
         class _StartManager:
-            def __init__(self, blocking: bool = False, **kwargs: t.Any):
+            def __init__(
+                self, blocking: bool = False, env: dict[str, str] | None = None
+            ):
                 logger.info(f"starting server with arguments: {server.args}")
 
                 server.process = subprocess.Popen(
@@ -101,7 +103,7 @@ class Server(ABC):
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     stdin=subprocess.PIPE,
-                    **kwargs,
+                    env=env,
                 )
 
                 if blocking:


### PR DESCRIPTION
Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>

## What does this PR address?

<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->

This PR addresses two issues:
1. Currently on main, `bentoml.Server` defaults to use `serve-http` as serve_cmd, which means GrpcServer won't work. This PR fixes that by passing `serve_cmd` to the server args.
2. After creating the server, there is no way to pass down subprocess args to the actual process. This PR adds `**kwargs` as passthrough to server.process 

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
