### PR TITLE
chore(dispatcher): cancel jobs with a for loop

### DIFF
--- a/src/bentoml/_internal/marshal/dispatcher.py
+++ b/src/bentoml/_internal/marshal/dispatcher.py
@@ -145,12 +145,8 @@ class CorkDispatcher:
     def shutdown(self):
         if self._controller is not None:
             self._controller.cancel()
-        try:
-            while True:
-                fut = self._queue.pop().future
-                fut.cancel()
-        except IndexError:
-            pass
+        for job in self._queue:
+            job.future.cancel()
 
     @cached_property
     def _loop(self):


### PR DESCRIPTION
Cleans up a minor strange code segment that used `IndexError` to exit out of a loop popping the queue, which I don't think is necessary.

@bojiang does this look fine?