### PR TITLE
tests: migrate to use new client and server API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,19 @@
 name: CI
-
 on:
   push:
     branches: [main]
   pull_request:
   schedule:
-    - cron: "0 0 * * 1/2"
-
+    - cron: '0 0 * * 1/2'
 env:
   LINES: 120
   COLUMNS: 120
   BENTOML_DO_NOT_TRACK: True
   PYTEST_PLUGINS: bentoml.testing.pytest.plugin
-
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun
 defaults:
   run:
     shell: bash --noprofile --norc -exo pipefail {0}
-
 jobs:
   diff:
     runs-on: ubuntu-latest
@@ -31,7 +27,7 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
-          base: "main"
+          base: 'main'
           filters: |
             related: &related
               - .github/workflows/ci.yml
@@ -51,35 +47,28 @@ jobs:
               - *related
               - requirements/docs-requirements.txt
               - "docs/**"
-
   codestyle_check:
     runs-on: ubuntu-latest
     needs:
       - diff
-
     if: ${{ (github.event_name == 'pull_request' && needs.diff.outputs.bentoml == 'true') || github.event_name == 'push' }}
-
     steps:
       - uses: actions/checkout@v3
-
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10.6"
+          python-version: '3.10.6'
           architecture: x64
-
       - name: Get pip cache dir
         id: cache-dir
         run: |
           echo ::set-output name=dir::$(pip cache dir)
-
       - name: Fetch origin
         run: git fetch origin "$GITHUB_BASE_REF"
-
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: "17"
+          node-version: '17'
       - name: Install pyright
         run: |
           npm install -g npm@^7 pyright
@@ -87,19 +76,16 @@ jobs:
         uses: bufbuild/buf-setup-action@v1.18.0
         with:
           github_token: ${{ github.token }}
-
       - name: Cache pip dependencies
         uses: actions/cache@v3
         id: cache-pip
         with:
           path: ${{ steps.cache-dir.outputs.dir }}
           key: codestyle-${{ hashFiles('requirements/dev-requirements.txt') }}
-
       - name: Install dependencies
         run: |
           pip install .
           pip install -r requirements/dev-requirements.txt
-
       - name: Format check
         run: |
           black --check src examples tests
@@ -114,125 +100,100 @@ jobs:
         if: ${{ (github.event_name == 'pull_request' && needs.diff.outputs.protos == 'true') || github.event_name == 'push' }}
         run: |
           buf lint --config "src/bentoml/grpc/buf.yaml" --error-format msvs src
-
   documentation_spelling_check:
     runs-on: ubuntu-latest
     needs:
       - diff
-
     if: ${{ (github.event_name == 'pull_request' && needs.diff.outputs.docs == 'true') || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # fetch all tags and branches
-
       - name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
-
       - name: Get pip cache dir
         id: cache-dir
         run: |
           echo ::set-output name=dir::$(pip cache dir)
-
       - name: Cache pip dependencies
         uses: actions/cache@v3
         id: cache-pip
         with:
           path: ${{ steps.cache-dir.outputs.dir }}
           key: ${{ runner.os }}-docs-${{ hashFiles('requirements/docs-requirements.txt') }}
-
       - name: Install dependencies
         run: |
           pip install .
           pip install -r requirements/docs-requirements.txt
-
       - name: Install libenchant
         run: |
           sudo apt-get update && sudo apt-get install -y libenchant-2-dev
-
       - name: Run spellcheck script
         run: make spellcheck-docs
-
   unit_tests:
     needs:
       - diff
-
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     if: ${{ (github.event_name == 'pull_request' && needs.diff.outputs.bentoml == 'true') || github.event_name == 'push' }}
     name: python${{ matrix.python-version }}_unit_tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # fetch all tags and branches
-
       - name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-
       - name: Get pip cache dir
         id: cache-dir
         run: |
           echo ::set-output name=dir::$(pip cache dir)
-
       - name: Cache pip dependencies
         uses: actions/cache@v3
         id: cache-pip
         with:
           path: ${{ steps.cache-dir.outputs.dir }}
           key: ${{ runner.os }}-tests-${{ hashFiles('requirements/tests-requirements.txt') }}
-
       - name: Install dependencies
         run: |
           pip install ".[grpc]"
           pip install -r requirements/tests-requirements.txt
-
+      - name: Run unit tests (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: pytest tests/unit
       - name: Run unit tests
-        run: |
-          OPTS=(--cov-config pyproject.toml --cov=src/bentoml --cov-append)
-          if [ "${{ matrix.os }}" != 'windows-latest' ]; then
-            # we will use pytest-xdist to improve tests run-time.
-            OPTS=(${OPTS[@]} --dist loadfile -n auto --run-grpc-tests)
-          fi
-          # Now run the unit tests
-          coverage run -m pytest tests/unit "${OPTS[@]}"
-
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: pytest tests/unit --dist loadfile -n auto
   bento_server_e2e_tests:
     needs:
       - diff
-
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        server_type: ["http", "grpc"]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        server_type: ['http', 'grpc']
         exclude:
           - os: windows-latest
-            server_type: "grpc"
+            server_type: 'grpc'
           - os: macos-latest
-            server_type: "grpc"
-            python-version: "3.10"
-
+            server_type: 'grpc'
+            python-version: '3.10'
     if: ${{ (github.event_name == 'pull_request' && needs.diff.outputs.bentoml == 'true') || github.event_name == 'push' }}
     name: python${{ matrix.python-version }}_${{ matrix.server_type }}_e2e_tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
-
+    timeout-minutes: 90
     env:
       SETUPTOOLS_USE_DISTUTILS: stdlib
       BENTOML_BUNDLE_LOCAL_BUILD: True
-
     steps:
       - uses: actions/checkout@v3
         with:
@@ -242,7 +203,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -250,36 +210,23 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         id: buildx
         uses: docker/setup-buildx-action@v2
-
       - name: Get pip cache dir
         id: cache-dir
         run: |
           echo ::set-output name=dir::$(pip cache dir)
-
       - name: Cache pip dependencies
         uses: actions/cache@v3
         id: cache-pip
         with:
           path: ${{ steps.cache-dir.outputs.dir }}
           key: ${{ runner.os }}-tests-${{ hashFiles('requirements/tests-requirements.txt') }}
-
-      - name: Install dependencies for ${{ matrix.server_type }}-based tests.
-        run: |
-          pip install -r requirements/tests-requirements.txt
-          if [ "${{ matrix.server_type }}" == 'grpc' ]; then
-            pip install -e ".[grpc]"
-          else
-            pip install -e .
-          fi
-          if [ -f "tests/e2e/bento_server_${{ matrix.server_type }}/requirements.txt" ]; then
-            pip install -r tests/e2e/bento_server_${{ matrix.server_type }}/requirements.txt
-          fi
-
+      - name: Install BentoML from source
+        run: pip install -e ".[grpc]" -r requirements/tests-requirements.txt
       - name: Run ${{ matrix.server_type }} tests and generate coverage report
+        working-directory: tests/e2e/bento_server_${{ matrix.server_type }}
         run: |
-          OPTS=(--cov-config pyproject.toml --cov=src/bentoml --cov-append)
-          coverage run -m pytest tests/e2e/bento_server_${{ matrix.server_type }} "${OPTS[@]}"
-
+          pip install -r requirements.txt
+          pytest . -vvv --capture=tee-sys
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/frameworks.yml
+++ b/.github/workflows/frameworks.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework catboost)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
 
   diffusers_integration_tests:
     needs: diff
@@ -224,7 +224,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework diffusers)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
   detectron_integration_tests:
     needs: diff
     if: ${{ (github.event_name == 'pull_request' && needs.diff.outputs.detectron == 'true') || github.event_name == 'push' }}
@@ -258,7 +258,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework detectron)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
   easyocr_integration_tests:
     needs: diff
     if: ${{ (github.event_name == 'pull_request' && needs.diff.outputs.easyocr == 'true') || github.event_name == 'push' }}
@@ -289,7 +289,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework easyocr)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
   flax_integration_tests:
     needs: diff
     if: ${{ (github.event_name == 'pull_request' && needs.diff.outputs.flax == 'true') || github.event_name == 'push' }}
@@ -324,7 +324,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework flax)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
 
   fastai_integration_tests:
     needs: diff
@@ -360,7 +360,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework fastai)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py tests/integration/frameworks/test_fastai_unit.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py tests/integration/frameworks/test_fastai_unit.py "${OPTS[@]}"
 
   keras_integration_tests:
     needs: diff
@@ -396,7 +396,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework keras)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
 
   lightgbm_integration_tests:
     needs: diff
@@ -432,7 +432,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework lightgbm)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
 
   mlflow_integration_tests:
     needs: diff
@@ -468,7 +468,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append)
-          coverage run -m pytest tests/integration/frameworks/mlflow "${OPTS[@]}"
+          pytest tests/integration/frameworks/mlflow "${OPTS[@]}"
 
   onnx_integration_tests:
     needs: diff
@@ -504,7 +504,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework onnx)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
 
   picklable_model_integration_tests:
     needs: diff
@@ -539,7 +539,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework picklable_model)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
 
   pytorch_integration_tests:
     needs: diff
@@ -575,7 +575,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework pytorch)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py tests/integration/frameworks/test_pytorch_unit.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py tests/integration/frameworks/test_pytorch_unit.py "${OPTS[@]}"
 
   pytorch_lightning_integration_tests:
     needs: diff
@@ -611,7 +611,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework pytorch_lightning)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
 
   torchscript_integration_tests:
     needs: diff
@@ -647,7 +647,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework torchscript)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
 
   sklearn_integration_tests:
     needs: diff
@@ -683,7 +683,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework sklearn)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
 
   tensorflow_integration_tests:
     needs: diff
@@ -719,7 +719,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework tensorflow)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py tests/integration/frameworks/test_tensorflow_unit.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py tests/integration/frameworks/test_tensorflow_unit.py "${OPTS[@]}"
 
       - name: Generate coverage
         run: coverage xml
@@ -727,7 +727,7 @@ jobs:
       - name: Run tests for no eager execution
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --disable-tf-eager-execution --cov-report=xml:no_eager_execution.xml)
-          coverage run -m pytest tests/integration/frameworks/test_tensorflow_unit.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_tensorflow_unit.py "${OPTS[@]}"
 
       - name: Upload test coverage to Codecov
         uses: codecov/codecov-action@v3
@@ -769,7 +769,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework transformers)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py tests/integration/frameworks/test_transformers_unit.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py tests/integration/frameworks/test_transformers_unit.py "${OPTS[@]}"
 
       - name: Generate coverage
         run: coverage xml
@@ -814,7 +814,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           OPTS=(--cov-config pyproject.toml --cov src/bentoml --cov-append --framework xgboost)
-          coverage run -m pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
+          pytest tests/integration/frameworks/test_frameworks.py "${OPTS[@]}"
 
 concurrency:
   group: frameworks${{ github.event.pull_request.number || github.sha }}

--- a/docs/source/guides/client.rst
+++ b/docs/source/guides/client.rst
@@ -64,3 +64,41 @@ The client call would look like:
 .. code-block:: python
 
     res = client.combine(a="a", b="b")
+
+.. note:: 
+
+   For all API functions that use ``pydantic_model`` for validation, The output from the client will
+   be a dictionary. The keys of the dictionary will be the names of the fields in the output model.
+   One can then use ``pydantic_model.parse_obj`` to parse the dictionary into the model.
+
+   .. code-block:: python
+
+      class ModelOutput(pydantic.BaseModel):
+          a: str
+          b: str
+
+      @svc.api(input=JSON(), output=JSON(pydantic_model=ModelOutput))
+      def combine_json(inputs) -> ModelOutput:
+          outputs = iris_clf_runner.run(inputs)
+          return ModelOutput(**outputs)
+
+   The output of the client would then be:
+
+   .. code-block:: python
+
+      res = client.combine_json({"a": "a", "b": "b"})
+      # res = {"a": "a", "b": "b"}
+      model_output = ModelOutput.parse_obj(res)
+
+.. note::
+
+   If a custom ``json_encoder`` is used, the output from the client will also be a dictionary. Make sure 
+   to use the same ``json_encoder`` if you need to parse the outputs to somewhere else.
+
+   .. code-block:: python
+
+      import json
+
+      res = client.combine_json_with_custom_encoder({"a": "a", "b": "b"})
+      # res = {"a": "a", "b": "b"}
+      o = json.dumps(res, cls=MyCustomJsonEncoder, ...)

--- a/examples/pytorch_mnist/tests/test_prediction.py
+++ b/examples/pytorch_mnist/tests/test_prediction.py
@@ -6,7 +6,7 @@ import json
 import numpy as np
 import pytest
 
-from bentoml.testing.utils import async_request
+from bentoml.testing.http import async_request
 
 
 @pytest.fixture()
@@ -37,12 +37,11 @@ async def test_numpy(host, img_data):
         img_arr_json = json.dumps(img_arr.tolist())
         bdigit = f"{digit}".encode()
         await async_request(
-            "POST",
-            f"http://{host}/predict_ndarray",
+            f"http://{host}",
+            api_name="predict_ndarray",
             headers={"Content-Type": "application/json"},
             data=img_arr_json,
-            assert_status=200,
-            assert_data=bdigit,
+            assert_output=bdigit,
         )
 
 
@@ -52,10 +51,9 @@ async def test_image(host, img_data):
         img_bytes = d["bytes"]
         bdigit = f"{digit}".encode()
         await async_request(
-            "POST",
-            f"http://{host}/predict_image",
+            f"http://{host}",
+            api_name="predict_image",
             data=img_bytes,
             headers={"Content-Type": "image/png"},
-            assert_status=200,
-            assert_data=bdigit,
+            assert_output=bdigit,
         )

--- a/examples/tensorflow2_keras/tests/test_prediction.py
+++ b/examples/tensorflow2_keras/tests/test_prediction.py
@@ -7,7 +7,7 @@ import asyncio
 import numpy as np
 import pytest
 
-from bentoml.testing.utils import async_request
+from bentoml.testing.http import async_request
 
 
 @pytest.fixture()
@@ -38,21 +38,19 @@ async def test_numpy(host, img_data):
     # request one by one
     for data in datas[:-3]:
         await async_request(
-            "POST",
-            f"http://{host}/predict_ndarray",
+            f"http://{host}",
+            api_name="predict_ndarray",
             headers={"Content-Type": "application/json"},
             data=datas[0],
-            assert_status=200,
         )
 
     # request all at once, should trigger micro-batch prediction
     tasks = tuple(
         async_request(
-            "POST",
-            f"http://{host}/predict_ndarray",
+            f"http://{host}",
+            api_name="predict_ndarray",
             headers={"Content-Type": "application/json"},
             data=data,
-            assert_status=200,
         )
         for data in datas[-3:]
     )
@@ -64,9 +62,8 @@ async def test_image(host, img_data):
     for d in img_data.values():
         img_bytes = d["bytes"]
         await async_request(
-            "POST",
-            f"http://{host}/predict_image",
+            f"http://{host}",
+            api_name="predict_image",
             data=img_bytes,
             headers={"Content-Type": "image/png"},
-            assert_status=200,
         )

--- a/examples/tensorflow2_native/tests/conftest.py
+++ b/examples/tensorflow2_native/tests/conftest.py
@@ -17,5 +17,5 @@ def pytest_configure(config):  # pylint: disable=unused-argument
 
 @pytest.fixture(scope="session")
 def host() -> t.Generator[str, None, None]:
-    with host_bento(bento="tensorflow_mnist_demo:latest") as host:
+    with host_bento(bento_name="tensorflow_mnist_demo:latest") as host:
         yield host

--- a/examples/tensorflow2_native/tests/test_prediction.py
+++ b/examples/tensorflow2_native/tests/test_prediction.py
@@ -7,7 +7,7 @@ import asyncio
 import numpy as np
 import pytest
 
-from bentoml.testing.utils import async_request
+from bentoml.testing.http import async_request
 
 
 @pytest.fixture()
@@ -38,21 +38,19 @@ async def test_numpy(host, img_data):
     # request one by one
     for data in datas[:-3]:
         await async_request(
-            "POST",
-            f"http://{host}/predict_ndarray",
+            f"http://{host}",
+            api_name="predict_ndarray",
             headers={"Content-Type": "application/json"},
             data=datas[0],
-            assert_status=200,
         )
 
     # request all at once, should trigger micro-batch prediction
     tasks = tuple(
         async_request(
-            "POST",
-            f"http://{host}/predict_ndarray",
+            f"http://{host}",
+            api_name="predict_ndarray",
             headers={"Content-Type": "application/json"},
             data=data,
-            assert_status=200,
         )
         for data in datas[-3:]
     )
@@ -64,9 +62,8 @@ async def test_image(host, img_data):
     for d in img_data.values():
         img_bytes = d["bytes"]
         await async_request(
-            "POST",
-            f"http://{host}/predict_image",
+            f"http://{host}",
+            api_name="predict_image",
             data=img_bytes,
             headers={"Content-Type": "image/png"},
-            assert_status=200,
         )

--- a/src/bentoml/_internal/client/grpc.py
+++ b/src/bentoml/_internal/client/grpc.py
@@ -2,16 +2,12 @@ from __future__ import annotations
 
 import time
 import typing as t
+import asyncio
 import logging
-import functools
-from typing import TYPE_CHECKING
-
-from packaging.version import parse
 
 from . import Client
 from .. import io_descriptors
 from ..utils import LazyLoader
-from ..utils import cached_property
 from ..service import Service
 from ...exceptions import BentoMLException
 from ...grpc.utils import import_grpc
@@ -23,18 +19,15 @@ from ..service.inference_api import InferenceAPI
 logger = logging.getLogger(__name__)
 
 PROTOBUF_EXC_MESSAGE = "'protobuf' is required to use gRPC Client. Install with 'pip install bentoml[grpc]'."
-REFLECTION_EXC_MESSAGE = "'grpcio-reflection' is required to use gRPC Client. Install with 'pip install bentoml[grpc-reflection]'."
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     import grpc
     from grpc import aio
-    from grpc._channel import Channel as GrpcSyncChannel
     from grpc_health.v1 import health_pb2 as pb_health
+    from grpc_health.v1 import health_pb2_grpc as services_health
     from google.protobuf import json_format as _json_format
 
     from ..types import PathType
-    from ...grpc.v1.service_pb2 import Response
-    from ...grpc.v1.service_pb2 import ServiceMetadataResponse
 
     class ClientCredentials(t.TypedDict):
         root_certificates: t.NotRequired[PathType | bytes]
@@ -44,12 +37,57 @@ if TYPE_CHECKING:
 else:
     grpc, aio = import_grpc()
     pb_health = LazyLoader("pb_health", globals(), "grpc_health.v1.health_pb2")
+    services_health = LazyLoader(
+        "services_health", globals(), "grpc_health.v1.health_pb2_grpc"
+    )
     _json_format = LazyLoader(
         "_json_format",
         globals(),
         "google.protobuf.json_format",
         exc_msg=PROTOBUF_EXC_MESSAGE,
     )
+
+
+def _create_async_channel(
+    server_url: str,
+    ssl: bool = False,
+    ssl_client_credentials: ClientCredentials | None = None,
+    options: t.Any | None = None,
+    compression: grpc.Compression | None = None,
+    interceptors: t.Sequence[aio.ClientInterceptor] | None = None,
+) -> aio._channel.Channel:
+    if ssl:
+        assert (
+            ssl_client_credentials is not None
+        ), "'ssl=True' requires 'ssl_client_credentials'"
+        return aio.secure_channel(
+            server_url,
+            credentials=grpc.ssl_channel_credentials(
+                **{
+                    k: load_from_file(v) if isinstance(v, str) else v
+                    for k, v in ssl_client_credentials.items()
+                }
+            ),
+            options=options,
+            compression=compression,
+            interceptors=interceptors,
+        )
+    else:
+        return aio.insecure_channel(
+            server_url,
+            options=options,
+            compression=compression,
+            interceptors=interceptors,
+        )
+
+
+def _ensure_exec_coro(coro: t.Coroutine[t.Any, t.Any, t.Any]) -> t.Any:
+    loop = asyncio.get_event_loop()
+    if loop.is_running():
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        return future.result()
+    else:
+        return loop.run_until_complete(coro)
 
 
 # TODO: xDS support
@@ -60,7 +98,7 @@ class GrpcClient(Client):
         svc: Service,
         # gRPC specific options
         ssl: bool = False,
-        channel_options: aio.ChannelArgumentType | None = None,
+        options: aio.ChannelArgumentType | None = None,
         interceptors: t.Sequence[aio.ClientInterceptor] | None = None,
         compression: grpc.Compression | None = None,
         ssl_client_credentials: ClientCredentials | None = None,
@@ -68,169 +106,83 @@ class GrpcClient(Client):
         protocol_version: str = LATEST_PROTOCOL_VERSION,
         **kwargs: t.Any,
     ):
-        self._pb, _ = import_generated_stubs(protocol_version)
+        self._pb, self._services = import_generated_stubs(protocol_version)
 
-        self._protocol_version = protocol_version
         self._compression = compression
-        self._options = channel_options
+        self._options = options
         self._interceptors = interceptors
-        self._credentials = None
-        if ssl:
-            assert (
-                ssl_client_credentials is not None
-            ), "'ssl=True' requires 'ssl_client_credentials'"
-            self._credentials = grpc.ssl_channel_credentials(
-                **{
-                    k: load_from_file(v) if isinstance(v, str) else v
-                    for k, v in ssl_client_credentials.items()
-                }
-            )
-        self._call_rpc = f"/bentoml.grpc.{protocol_version}.BentoService/Call"
+        self._ssl = ssl
+        self._ssl_client_credentials = ssl_client_credentials
+
         super().__init__(svc, server_url)
 
-    @property
-    def channel(self):
-        if self._credentials is not None:
-            return aio.secure_channel(
-                self.server_url,
-                credentials=self._credentials,
-                options=self._options,
-                compression=self._compression,
-                interceptors=self._interceptors,
-            )
-        else:
-            return aio.insecure_channel(
-                self.server_url,
-                options=self._options,
-                compression=self._compression,
-                interceptors=self._interceptors,
-            )
-
-    @staticmethod
-    def _create_sync_channel(
-        server_url: str,
-        ssl: bool = False,
-        ssl_client_credentials: ClientCredentials | None = None,
-        channel_options: t.Any | None = None,
-        compression: grpc.Compression | None = None,
-    ) -> GrpcSyncChannel:
-        if ssl:
-            assert (
-                ssl_client_credentials is not None
-            ), "'ssl=True' requires 'ssl_client_credentials'"
-            return grpc.secure_channel(
-                server_url,
-                credentials=grpc.ssl_channel_credentials(
-                    **{
-                        k: load_from_file(v) if isinstance(v, str) else v
-                        for k, v in ssl_client_credentials.items()
-                    }
-                ),
-                options=channel_options,
-                compression=compression,
-            )
-        return grpc.insecure_channel(
-            server_url, options=channel_options, compression=compression
+    def create_channel(self):
+        return _create_async_channel(
+            self.server_url,
+            ssl=self._ssl,
+            ssl_client_credentials=self._ssl_client_credentials,
+            options=self._options,
+            compression=self._compression,
+            interceptors=self._interceptors,
         )
 
     @staticmethod
     def wait_until_server_ready(
         host: str,
         port: int,
-        timeout: float = 30,
+        timeout: int = 30,
         check_interval: int = 1,
         # set kwargs here to omit gRPC kwargs
         **kwargs: t.Any,
     ) -> None:
-        protocol_version = kwargs.get("protocol_version", LATEST_PROTOCOL_VERSION)
-
-        channel = GrpcClient._create_sync_channel(
-            f"{host}:{port}",
-            ssl=kwargs.get("ssl", False),
-            ssl_client_credentials=kwargs.get("ssl_client_credentials", None),
-            channel_options=kwargs.get("channel_options", None),
+        with grpc.insecure_channel(
+            f"{host.replace(r'localhost', '0.0.0.0')}:{port}",
+            options=kwargs.get("options", None),
             compression=kwargs.get("compression", None),
-        )
-        rpc = channel.unary_unary(
-            "/grpc.health.v1.Health/Check",
-            request_serializer=pb_health.HealthCheckRequest.SerializeToString,
-            response_deserializer=pb_health.HealthCheckResponse.FromString,
-        )
-
-        start_time = time.time()
-        while time.time() - start_time < timeout:
-            try:
-                response = t.cast(
-                    pb_health.HealthCheckResponse,
-                    rpc(
-                        pb_health.HealthCheckRequest(
-                            service=f"bentoml.grpc.{protocol_version}.BentoService"
-                        )
-                    ),
-                )
-                if response.status == pb_health.HealthCheckResponse.SERVING:
-                    break
-                else:
+        ) as channel:
+            req = pb_health.HealthCheckRequest()
+            req.service = ""
+            health_stub = services_health.HealthStub(channel)
+            start_time = time.time()
+            while time.time() - start_time < timeout:
+                try:
+                    resp = health_stub.Check(req)
+                    if resp.status == pb_health.HealthCheckResponse.SERVING:
+                        break
+                    else:
+                        time.sleep(check_interval)
+                except grpc.RpcError:
+                    logger.debug("Waiting for server to be ready...")
                     time.sleep(check_interval)
-            except grpc.RpcError:
-                logger.debug("Server is not ready. Retrying...")
-                time.sleep(check_interval)
-
-        try:
-            response = t.cast(
-                pb_health.HealthCheckResponse,
-                rpc(
-                    pb_health.HealthCheckRequest(
-                        service=f"bentoml.grpc.{protocol_version}.BentoService"
+            try:
+                resp = health_stub.Check(req)
+                if resp.status != pb_health.HealthCheckResponse.SERVING:
+                    raise TimeoutError(
+                        f"Timed out waiting {timeout} seconds for server at '{host}:{port}' to be ready."
                     )
-                ),
-            )
-            if response.status != pb_health.HealthCheckResponse.SERVING:
-                raise TimeoutError(
-                    f"Timed out waiting {timeout} seconds for server at '{host}:{port}' to be ready."
-                )
-        except (grpc.RpcError, TimeoutError) as err:
-            logger.error("Caught exception while connecting to %s:%s:", host, port)
-            logger.error(err)
-            raise
-        finally:
-            channel.close()
+            except grpc.RpcError as err:
+                logger.error("Caught RpcError while connecting to %s:%s:\n", host, port)
+                logger.error(err)
+                raise
 
-    @cached_property
-    def _rpc_metadata(self) -> dict[str, dict[str, t.Any]]:
-        # Currently all RPCs in BentoService are unary-unary
-        # NOTE: we will set the types of the stubs to be Any.
-        return {
-            method: {"input_type": input_type, "output_type": output_type}
-            for method, input_type, output_type in (
-                (
-                    self._call_rpc,
-                    self._pb.Request,
-                    self._pb.Response,
-                ),
-                (
-                    f"/bentoml.grpc.{self._protocol_version}.BentoService/ServiceMetadata",
-                    self._pb.ServiceMetadataRequest,
-                    self._pb.ServiceMetadataResponse,
-                ),
-                (
-                    "/grpc.health.v1.Health/Check",
-                    pb_health.HealthCheckRequest,
-                    pb_health.HealthCheckResponse,
-                ),
-            )
-        }
+    def sync_health(self, service_name: str, *, timeout: int = 30) -> t.Any:
+        return _ensure_exec_coro(self.health(service_name, timeout=timeout))
 
     async def health(self, service_name: str, *, timeout: int = 30) -> t.Any:
-        return await self._invoke(
-            method_name="/grpc.health.v1.Health/Check",
-            service=service_name,
-            _grpc_channel_timeout=timeout,
-        )
+        async with self.create_channel() as channel:
+            req = pb_health.HealthCheckRequest()
+            req.service = service_name
+            health_stub = services_health.HealthStub(channel)
+            return await health_stub.Check(req, timeout=timeout)
 
-    async def _invoke(self, method_name: str, **attrs: t.Any):
-        # channel kwargs include timeout, metadata, credentials, wait_for_ready and compression
-        # to pass it in kwargs add prefix _grpc_channel_<args>
+    def _sync_call(
+        self, inp: t.Any = None, *, _bentoml_api: InferenceAPI, **attrs: t.Any
+    ) -> t.Any:
+        return _ensure_exec_coro(self._call(inp, _bentoml_api=_bentoml_api, **attrs))
+
+    async def _call(
+        self, inp: t.Any = None, *, _bentoml_api: InferenceAPI, **attrs: t.Any
+    ) -> t.Any:
         channel_kwargs = {
             k: attrs.pop(f"_grpc_channel_{k}", None)
             for k in {
@@ -241,48 +193,12 @@ class GrpcClient(Client):
                 "compression",
             }
         }
-        if method_name not in self._rpc_metadata:
-            raise ValueError(
-                f"'{method_name}' is a yet supported rpc. Current supported are: {self._rpc_metadata}"
-            )
-        metadata = self._rpc_metadata[method_name]
-        rpc = self.channel.unary_unary(
-            method_name,
-            request_serializer=metadata["input_type"].SerializeToString,
-            response_deserializer=metadata["output_type"].FromString,
-        )
 
-        return await t.cast(
-            "t.Awaitable[Response]",
-            rpc(metadata["input_type"](**attrs), **channel_kwargs),
-        )
-
-    async def _call(
-        self,
-        inp: t.Any = None,
-        *,
-        _bentoml_api: InferenceAPI,
-        **attrs: t.Any,
-    ) -> t.Any:
-        state = self.channel.get_state(try_to_connect=True)
+        channel = self.create_channel()
+        state = channel.get_state(try_to_connect=True)
         if state != grpc.ChannelConnectivity.READY:
             # create a blocking call to wait til channel is ready.
-            await self.channel.channel_ready()
-
-        fn = functools.partial(
-            self._invoke,
-            method_name=f"/bentoml.grpc.{self._protocol_version}.BentoService/Call",
-            **{
-                f"_grpc_channel_{k}": attrs.pop(f"_grpc_channel_{k}", None)
-                for k in {
-                    "timeout",
-                    "metadata",
-                    "credentials",
-                    "wait_for_ready",
-                    "compression",
-                }
-            },
-        )
+            await channel.channel_ready()
 
         if _bentoml_api.multi_input:
             if inp is not None:
@@ -295,69 +211,30 @@ class GrpcClient(Client):
 
         # A call includes api_name and given proto_fields
         api_fn = {v: k for k, v in self._svc.apis.items()}
-        return await fn(
-            **{
-                "api_name": api_fn[_bentoml_api],
-                _bentoml_api.input.proto_fields[0]: serialized_req,
-            },
-        )
+
+        async with channel:
+            stubs = self._services.BentoServiceStub(channel)
+            req = self._pb.Request(
+                **{
+                    "api_name": api_fn[_bentoml_api],
+                    _bentoml_api.input.proto_fields[0]: serialized_req,
+                }
+            )
+            return await stubs.Call(req, **channel_kwargs)
 
     @classmethod
     def from_url(cls, server_url: str, **kwargs: t.Any) -> GrpcClient:
         protocol_version = kwargs.get("protocol_version", LATEST_PROTOCOL_VERSION)
+        pb, services = import_generated_stubs(protocol_version)
 
-        # Since v1, we introduce a ServiceMetadata rpc to retrieve bentoml.Service metadata.
-        # then `client.predict` or `client.classify` won't be available.
-        # client.Call will still persist for both protocol version.
-        if parse(protocol_version) < parse("v1"):
-            exception_message = [
-                f"Using protocol version {protocol_version} older than v1. 'bentoml.client.Client' will only support protocol version v1 onwards. To create client with protocol version '{protocol_version}', do the following:\n"
-                f"""\
-
-from bentoml.grpc.utils import import_generated_stubs, import_grpc
-
-pb, services = import_generated_stubs("{protocol_version}")
-
-grpc, _ = import_grpc()
-
-def run():
-    with grpc.insecure_channel("localhost:3000") as channel:
-        stubs = services.BentoServiceStub(channel)
-        req = stubs.Call(
-            request=pb.Request(
-                api_name="predict",
-                ndarray=pb.NDArray(
-                    dtype=pb.NDArray.DTYPE_FLOAT,
-                    shape=(1, 4),
-                    float_values=[5.9, 3, 5.1, 1.8],
-                    ),
-                )
-            )
-            print(req)
-
-if __name__ == '__main__':
-    run()
-"""
-            ]
-            raise BentoMLException("\n".join(exception_message))
-        pb, _ = import_generated_stubs(protocol_version)
-
-        with GrpcClient._create_sync_channel(
+        with grpc.insecure_channel(
             server_url.replace(r"localhost", "0.0.0.0"),
-            ssl=kwargs.get("ssl", False),
-            ssl_client_credentials=kwargs.get("ssl_client_credentials", None),
-            channel_options=kwargs.get("channel_options", None),
-            compression=kwargs.get("compression", None),
+            options=kwargs.get("options", None),
         ) as channel:
+            stubs = services.BentoServiceStub(channel)
             # create an insecure channel to invoke ServiceMetadata rpc
-            metadata = t.cast(
-                "ServiceMetadataResponse",
-                channel.unary_unary(
-                    f"/bentoml.grpc.{protocol_version}.BentoService/ServiceMetadata",
-                    request_serializer=pb.ServiceMetadataRequest.SerializeToString,
-                    response_deserializer=pb.ServiceMetadataResponse.FromString,
-                )(pb.ServiceMetadataRequest()),
-            )
+            metadata = stubs.ServiceMetadata(pb.ServiceMetadataRequest())
+
         dummy_service = Service(metadata.name)
 
         for api in metadata.apis:
@@ -385,5 +262,6 @@ if __name__ == '__main__':
                 )
             except BentoMLException as e:
                 logger.error("Failed to instantiate client for API %s: ", api.name, e)
+                raise
 
         return cls(server_url, dummy_service, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def img_file(tmpdir: str) -> str:
+    """Create a random image/bmp file."""
+    from PIL.Image import fromarray
+
+    img_file_ = tmpdir.join("test_img.bmp")
+    img = fromarray(np.random.randint(255, size=(10, 10, 3)).astype("uint8"))
+    img.save(str(img_file_))
+    return str(img_file_)
+
+
+@pytest.fixture()
+def bin_file(tmpdir: str) -> str:
+    """Create a random binary file."""
+    bin_file_ = tmpdir.join("bin_file.bin")
+    with open(bin_file_, "wb") as of:
+        of.write("â".encode("gb18030"))
+    return str(bin_file_)

--- a/tests/e2e/bento_server_grpc/tests/conftest.py
+++ b/tests/e2e/bento_server_grpc/tests/conftest.py
@@ -24,20 +24,9 @@ PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 def pytest_collection_modifyitems(
     session: Session, config: Config, items: list[Item]
 ) -> None:
-    subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "-r",
-            f"{os.path.join(PROJECT_DIR, 'requirements.txt')}",
-        ]
-    )
     subprocess.check_call([sys.executable, f"{os.path.join(PROJECT_DIR, 'train.py')}"])
 
 
-@pytest.mark.usefixtures("change_test_dir")
 @pytest.fixture(scope="module")
 def host(
     bentoml_home: str,

--- a/tests/e2e/bento_server_grpc/tests/test_custom_components.py
+++ b/tests/e2e/bento_server_grpc/tests/test_custom_components.py
@@ -1,41 +1,30 @@
 from __future__ import annotations
 
-import typing as t
-
 import pytest
 from grpc import aio
 from grpc_health.v1 import health_pb2 as pb_health
 from google.protobuf import wrappers_pb2
 
-from bentoml.testing.grpc import create_channel
-from bentoml.testing.grpc import async_client_call
+import bentoml
 
 
-@pytest.mark.asyncio
-async def test_success_invocation_custom_servicer(host: str) -> None:
-    async with create_channel(host) as channel:
-        HealthCheck = channel.unary_unary(
-            "/grpc.health.v1.Health/Check",
-            request_serializer=pb_health.HealthCheckRequest.SerializeToString,  # type: ignore (no grpc_health type)
-            response_deserializer=pb_health.HealthCheckResponse.FromString,  # type: ignore (no grpc_health type)
-        )
-        health = await t.cast(
-            t.Awaitable[pb_health.HealthCheckResponse],
-            HealthCheck(
-                pb_health.HealthCheckRequest(service="bentoml.grpc.v1.BentoService")
-            ),
-        )
-        assert health.status == pb_health.HealthCheckResponse.SERVING  # type: ignore ( no generated enum types)
+def test_success_invocation_custom_servicer(host: str) -> None:
+    client = bentoml.client.GrpcClient.from_url(host)
+    health = client.health("bentoml.grpc.v1.BentoService")
+    assert health.status == pb_health.HealthCheckResponse.SERVING  # type: ignore ( no generated enum types)
 
 
 @pytest.mark.asyncio
 async def test_trailing_metadata_interceptors(host: str) -> None:
-    async with create_channel(host) as channel:
-        await async_client_call(
-            "bonjour",
-            channel=channel,
-            data={"text": wrappers_pb2.StringValue(value="BentoML")},
-            assert_trailing_metadata=aio.Metadata.from_tuple(
-                (("usage", "NLP"), ("accuracy_score", "0.8247"))
-            ),
+    client = bentoml.client.GrpcClient.from_url(host)
+    async with client.create_channel() as channel:
+        stubs = client._services.BentoServiceStub(channel)
+        resp = stubs.Call(
+            client._pb.Request(
+                api_name="bonjour", text=wrappers_pb2.StringValue(value="BentoML")
+            )
+        )
+        trailing_metadata = await resp.trailing_metadata()
+        assert trailing_metadata == aio.Metadata.from_tuple(
+            (("usage", "NLP"), ("accuracy_score", "0.8247"))
         )

--- a/tests/e2e/bento_server_grpc/tests/test_descriptors.py
+++ b/tests/e2e/bento_server_grpc/tests/test_descriptors.py
@@ -2,21 +2,20 @@ from __future__ import annotations
 
 import io
 import random
+import typing as t
 import traceback
-from typing import TYPE_CHECKING
 from functools import partial
 
 import pytest
 
 from bentoml.grpc.utils import import_grpc
 from bentoml.grpc.utils import import_generated_stubs
-from bentoml.testing.grpc import create_channel
 from bentoml.testing.grpc import async_client_call
 from bentoml.testing.grpc import randomize_pb_ndarray
 from bentoml._internal.types import LazyType
 from bentoml._internal.utils import LazyLoader
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     import grpc
     import numpy as np
     import pandas as pd
@@ -69,126 +68,124 @@ def make_iris_proto(**fields: struct_pb2.Value) -> struct_pb2.Value:
 
 @pytest.mark.asyncio
 async def test_numpy(host: str):
-    async with create_channel(host) as channel:
-        await async_client_call(
-            "double_ndarray",
-            channel=channel,
-            data={"ndarray": randomize_pb_ndarray((1000,))},
-            assert_data=partial(
-                assert_ndarray, assert_shape=[1000], assert_dtype=pb.NDArray.DTYPE_FLOAT
-            ),
-        )
-        await async_client_call(
-            "double_ndarray",
-            channel=channel,
-            data={"ndarray": pb.NDArray(shape=[2, 2], int32_values=[1, 2, 3, 4])},
-            assert_data=lambda resp: resp.ndarray.int32_values == [2, 4, 6, 8],
-        )
-        await async_client_call(
-            "double_ndarray",
-            channel=channel,
-            data={"ndarray": pb.NDArray(string_values=np.array(["2", "2f"]))},
-            assert_code=grpc.StatusCode.INTERNAL,
-        )
-        await async_client_call(
-            "double_ndarray",
-            channel=channel,
-            data={
-                "ndarray": pb.NDArray(
-                    dtype=123, string_values=np.array(["2", "2f"])  # type: ignore (test exception)
-                )
-            },
-            assert_code=grpc.StatusCode.INVALID_ARGUMENT,
-        )
-        await async_client_call(
-            "double_ndarray",
-            channel=channel,
-            data={"serialized_bytes": np.array([1, 2, 3, 4]).ravel().tobytes()},
-        )
-        await async_client_call(
-            "double_ndarray",
-            channel=channel,
-            data={"text": wrappers_pb2.StringValue(value="asdf")},
-            assert_code=grpc.StatusCode.INVALID_ARGUMENT,
-        )
-        await async_client_call(
-            "echo_ndarray_enforce_shape",
-            channel=channel,
-            data={"ndarray": randomize_pb_ndarray((1000,))},
-            assert_code=grpc.StatusCode.INVALID_ARGUMENT,
-        )
-        await async_client_call(
-            "echo_ndarray_enforce_dtype",
-            channel=channel,
-            data={"ndarray": pb.NDArray(string_values=np.array(["2", "2f"]))},
-            assert_code=grpc.StatusCode.INVALID_ARGUMENT,
-        )
+    await async_client_call(
+        "double_ndarray",
+        host,
+        data={"ndarray": randomize_pb_ndarray((1000,))},
+        assert_data=partial(
+            assert_ndarray, assert_shape=[1000], assert_dtype=pb.NDArray.DTYPE_FLOAT
+        ),
+    )
+    await async_client_call(
+        "double_ndarray",
+        host,
+        data={"ndarray": pb.NDArray(shape=[2, 2], int32_values=[1, 2, 3, 4])},
+        assert_data=lambda resp: resp.ndarray.int32_values == [2, 4, 6, 8],
+    )
+    await async_client_call(
+        "double_ndarray",
+        host,
+        data={"ndarray": pb.NDArray(string_values=np.array(["2", "2f"]))},
+        assert_code=grpc.StatusCode.INTERNAL,
+    )
+    await async_client_call(
+        "double_ndarray",
+        host,
+        data={
+            "ndarray": pb.NDArray(
+                dtype=123, string_values=np.array(["2", "2f"])  # type: ignore (test exception)
+            )
+        },
+        assert_code=grpc.StatusCode.INVALID_ARGUMENT,
+    )
+    await async_client_call(
+        "double_ndarray",
+        host,
+        data={"serialized_bytes": np.array([1, 2, 3, 4]).ravel().tobytes()},
+    )
+    await async_client_call(
+        "double_ndarray",
+        host,
+        data={"text": wrappers_pb2.StringValue(value="asdf")},
+        assert_code=grpc.StatusCode.INVALID_ARGUMENT,
+    )
+    await async_client_call(
+        "echo_ndarray_enforce_shape",
+        host,
+        data={"ndarray": randomize_pb_ndarray((1000,))},
+        assert_code=grpc.StatusCode.INVALID_ARGUMENT,
+    )
+    await async_client_call(
+        "echo_ndarray_enforce_dtype",
+        host,
+        data={"ndarray": pb.NDArray(string_values=np.array(["2", "2f"]))},
+        assert_code=grpc.StatusCode.INVALID_ARGUMENT,
+    )
 
 
 @pytest.mark.asyncio
 async def test_json(host: str):
-    async with create_channel(host) as channel:
-        await async_client_call(
-            "echo_json",
-            channel=channel,
-            data={"json": struct_pb2.Value(string_value='"hi"')},
-            assert_data=lambda resp: resp.json.string_value == '"hi"',
-        )
-        await async_client_call(
-            "echo_json",
-            channel=channel,
-            data={
-                "serialized_bytes": b'{"request_id": "123", "iris_features": {"sepal_len":2.34,"sepal_width":1.58, "petal_len":6.52, "petal_width":3.23}}'
-            },
-            assert_data=lambda resp: resp.json  # type: ignore (bad lambda types)
-            == make_iris_proto(
+    await async_client_call(
+        "echo_json",
+        host,
+        data={"json": struct_pb2.Value(string_value='"hi"')},
+        assert_data=lambda resp: resp.json.string_value == '"hi"',
+    )
+    await async_client_call(
+        "echo_json",
+        host,
+        data={
+            "serialized_bytes": b'{"request_id": "123", "iris_features": {"sepal_len":2.34,"sepal_width":1.58, "petal_len":6.52, "petal_width":3.23}}'
+        },
+        assert_data=lambda resp: resp.json  # type: ignore (bad lambda types)
+        == make_iris_proto(
+            sepal_len=struct_pb2.Value(number_value=2.34),
+            sepal_width=struct_pb2.Value(number_value=1.58),
+            petal_len=struct_pb2.Value(number_value=6.52),
+            petal_width=struct_pb2.Value(number_value=3.23),
+        ),
+    )
+    await async_client_call(
+        "echo_json_validate",
+        host,
+        data={
+            "json": make_iris_proto(
+                **{
+                    k: struct_pb2.Value(number_value=random.uniform(1.0, 6.0))
+                    for k in [
+                        "sepal_len",
+                        "sepal_width",
+                        "petal_len",
+                        "petal_width",
+                    ]
+                }
+            )
+        },
+    )
+    await async_client_call(
+        "echo_json",
+        host,
+        data={"serialized_bytes": b"\n?xfa"},
+        assert_code=grpc.StatusCode.INVALID_ARGUMENT,
+    )
+    await async_client_call(
+        "echo_json",
+        host,
+        data={"text": wrappers_pb2.StringValue(value="asdf")},
+        assert_code=grpc.StatusCode.INVALID_ARGUMENT,
+    )
+    await async_client_call(
+        "echo_json_validate",
+        host,
+        data={
+            "json": make_iris_proto(
                 sepal_len=struct_pb2.Value(number_value=2.34),
                 sepal_width=struct_pb2.Value(number_value=1.58),
                 petal_len=struct_pb2.Value(number_value=6.52),
-                petal_width=struct_pb2.Value(number_value=3.23),
             ),
-        )
-        await async_client_call(
-            "echo_json_validate",
-            channel=channel,
-            data={
-                "json": make_iris_proto(
-                    **{
-                        k: struct_pb2.Value(number_value=random.uniform(1.0, 6.0))
-                        for k in [
-                            "sepal_len",
-                            "sepal_width",
-                            "petal_len",
-                            "petal_width",
-                        ]
-                    }
-                )
-            },
-        )
-        await async_client_call(
-            "echo_json",
-            channel=channel,
-            data={"serialized_bytes": b"\n?xfa"},
-            assert_code=grpc.StatusCode.INVALID_ARGUMENT,
-        )
-        await async_client_call(
-            "echo_json",
-            channel=channel,
-            data={"text": wrappers_pb2.StringValue(value="asdf")},
-            assert_code=grpc.StatusCode.INVALID_ARGUMENT,
-        )
-        await async_client_call(
-            "echo_json_validate",
-            channel=channel,
-            data={
-                "json": make_iris_proto(
-                    sepal_len=struct_pb2.Value(number_value=2.34),
-                    sepal_width=struct_pb2.Value(number_value=1.58),
-                    petal_len=struct_pb2.Value(number_value=6.52),
-                ),
-            },
-            assert_code=grpc.StatusCode.INVALID_ARGUMENT,
-        )
+        },
+        assert_code=grpc.StatusCode.INVALID_ARGUMENT,
+    )
 
 
 @pytest.mark.asyncio
@@ -197,32 +194,31 @@ async def test_file(host: str, bin_file: str):
     with open(str(bin_file), "rb") as f:
         fb = f.read()
 
-    async with create_channel(host) as channel:
-        await async_client_call(
-            "predict_file",
-            channel=channel,
-            data={"serialized_bytes": fb},
-            assert_data=lambda resp: resp.file.content == fb,
-        )
-        await async_client_call(
-            "predict_file",
-            channel=channel,
-            data={"file": pb.File(kind="application/octet-stream", content=fb)},
-            assert_data=lambda resp: resp.file.content == b"\x810\x899"
-            and resp.file.kind == "application/octet-stream",
-        )
-        await async_client_call(
-            "predict_file",
-            channel=channel,
-            data={"file": pb.File(kind="application/pdf", content=fb)},
-            assert_code=grpc.StatusCode.INVALID_ARGUMENT,
-        )
-        await async_client_call(
-            "predict_file",
-            channel=channel,
-            data={"text": wrappers_pb2.StringValue(value="asdf")},
-            assert_code=grpc.StatusCode.INVALID_ARGUMENT,
-        )
+    await async_client_call(
+        "predict_file",
+        host,
+        data={"serialized_bytes": fb},
+        assert_data=lambda resp: resp.file.content == fb,
+    )
+    await async_client_call(
+        "predict_file",
+        host,
+        data={"file": pb.File(kind="application/octet-stream", content=fb)},
+        assert_data=lambda resp: resp.file.content == b"\x810\x899"
+        and resp.file.kind == "application/octet-stream",
+    )
+    await async_client_call(
+        "predict_file",
+        host,
+        data={"file": pb.File(kind="application/pdf", content=fb)},
+        assert_code=grpc.StatusCode.INVALID_ARGUMENT,
+    )
+    await async_client_call(
+        "predict_file",
+        host,
+        data={"text": wrappers_pb2.StringValue(value="asdf")},
+        assert_code=grpc.StatusCode.INVALID_ARGUMENT,
+    )
 
 
 def assert_image(
@@ -253,108 +249,90 @@ async def test_image(host: str, img_file: str):
     with open(str(img_file), "rb") as f:
         fb = f.read()
 
-    async with create_channel(host) as channel:
-        await async_client_call(
-            "echo_image",
-            channel=channel,
-            data={"serialized_bytes": fb},
-            assert_data=partial(
-                assert_image, im_file=img_file, assert_kind="image/bmp"
-            ),
-        )
-        await async_client_call(
-            "echo_image",
-            channel=channel,
-            data={"file": pb.File(kind="image/bmp", content=fb)},
-            assert_data=partial(
-                assert_image, im_file=img_file, assert_kind="image/bmp"
-            ),
-        )
-        await async_client_call(
-            "echo_image",
-            channel=channel,
-            data={"file": pb.File(kind="application/pdf", content=fb)},
-            assert_code=grpc.StatusCode.INVALID_ARGUMENT,
-        )
-        await async_client_call(
-            "echo_image",
-            channel=channel,
-            data={"text": wrappers_pb2.StringValue(value="asdf")},
-            assert_code=grpc.StatusCode.INVALID_ARGUMENT,
-        )
+    await async_client_call(
+        "echo_image",
+        host,
+        data={"serialized_bytes": fb},
+        assert_data=partial(assert_image, im_file=img_file, assert_kind="image/bmp"),
+    )
+    await async_client_call(
+        "echo_image",
+        host,
+        data={"file": pb.File(kind="image/bmp", content=fb)},
+        assert_data=partial(assert_image, im_file=img_file, assert_kind="image/bmp"),
+    )
+    await async_client_call(
+        "echo_image",
+        host,
+        data={"file": pb.File(kind="application/pdf", content=fb)},
+        assert_code=grpc.StatusCode.INVALID_ARGUMENT,
+    )
+    await async_client_call(
+        "echo_image",
+        host,
+        data={"text": wrappers_pb2.StringValue(value="asdf")},
+        assert_code=grpc.StatusCode.INVALID_ARGUMENT,
+    )
 
 
 @pytest.mark.asyncio
 async def test_pandas(host: str):
-    async with create_channel(host) as channel:
-        await async_client_call(
-            "echo_dataframe",
-            channel=channel,
-            data={
-                "dataframe": pb.DataFrame(
-                    column_names=[
-                        str(i) for i in pd.RangeIndex(0, 3, 1, dtype=np.int64).tolist()
-                    ],
-                    columns=[
-                        pb.Series(int32_values=[1]),
-                        pb.Series(int32_values=[2]),
-                        pb.Series(int32_values=[3]),
-                    ],
-                ),
-            },
-        )
-        await async_client_call(
-            "echo_dataframe_from_sample",
-            channel=channel,
-            data={
-                "dataframe": pb.DataFrame(
-                    column_names=["age", "height", "weight"],
-                    columns=[
-                        pb.Series(int64_values=[12, 23]),
-                        pb.Series(int64_values=[40, 83]),
-                        pb.Series(int64_values=[32, 89]),
-                    ],
-                ),
-            },
-        )
-        await async_client_call(
-            "double_dataframe",
-            channel=channel,
-            data={
-                "dataframe": pb.DataFrame(
-                    column_names=["col1"],
-                    columns=[pb.Series(int64_values=[23])],
-                ),
-            },
-            assert_data=lambda resp: resp.dataframe  # type: ignore (bad lambda types)
-            == pb.DataFrame(
-                column_names=["col1"],
-                columns=[pb.Series(int64_values=[46])],
+    await async_client_call(
+        "echo_dataframe",
+        host,
+        data={
+            "dataframe": pb.DataFrame(
+                column_names=[
+                    str(i) for i in pd.RangeIndex(0, 3, 1, dtype=np.int64).tolist()
+                ],
+                columns=[
+                    pb.Series(int32_values=[1]),
+                    pb.Series(int32_values=[2]),
+                    pb.Series(int32_values=[3]),
+                ],
             ),
-        )
-        await async_client_call(
-            "echo_dataframe",
-            channel=channel,
-            data={
-                "dataframe": pb.DataFrame(
-                    column_names=["col1"],
-                    columns=[pb.Series(int64_values=[23], int32_values=[23])],
-                ),
-            },
-            assert_code=grpc.StatusCode.INVALID_ARGUMENT,
-        )
-
-
-@pytest.mark.asyncio
-async def test_pandas_series(host: str):
-    async with create_channel(host) as channel:
-        await async_client_call(
-            "echo_series_from_sample",
-            channel=channel,
-            data={"series": pb.Series(float_values=[1.0, 2.0, 3.0])},
-            assert_data=lambda resp: resp.series
-            == pb.Series(float_values=[1.0, 2.0, 3.0]),
-        )
+        },
+    )
+    await async_client_call(
+        "echo_dataframe_from_sample",
+        host,
+        data={
+            "dataframe": pb.DataFrame(
+                column_names=["age", "height", "weight"],
+                columns=[
+                    pb.Series(int64_values=[12, 23]),
+                    pb.Series(int64_values=[40, 83]),
+                    pb.Series(int64_values=[32, 89]),
+                ],
+            ),
+        },
+    )
+    await async_client_call(
+        "double_dataframe",
+        host,
+        data={
+            "dataframe": pb.DataFrame(
+                column_names=["col1"],
+                columns=[pb.Series(int64_values=[23])],
+            ),
+        },
+        assert_data=lambda resp: resp.dataframe  # type: ignore (bad lambda types)
+        == pb.DataFrame(
+            column_names=["col1"],
+            columns=[pb.Series(int64_values=[46])],
+        ),
+    )
+    await async_client_call(
+        "echo_dataframe",
+        host,
+        data={
+            "dataframe": pb.DataFrame(
+                column_names=["col1"],
+                columns=[pb.Series(int64_values=[23], int32_values=[23])],
+            ),
+        },
+        assert_code=grpc.StatusCode.INVALID_ARGUMENT,
+    )
 
 
 def assert_multi_images(resp: pb.Response, method: str, im_file: str) -> bool:
@@ -374,19 +352,18 @@ async def test_multipart(host: str, img_file: str):
     with open(str(img_file), "rb") as f:
         fb = f.read()
 
-    async with create_channel(host) as channel:
-        await async_client_call(
-            "predict_multi_images",
-            channel=channel,
-            data={
-                "multipart": {
-                    "fields": {
-                        "original": pb.Part(file=pb.File(kind="image/bmp", content=fb)),
-                        "compared": pb.Part(file=pb.File(kind="image/bmp", content=fb)),
-                    }
+    await async_client_call(
+        "predict_multi_images",
+        host,
+        data={
+            "multipart": {
+                "fields": {
+                    "original": pb.Part(file=pb.File(kind="image/bmp", content=fb)),
+                    "compared": pb.Part(file=pb.File(kind="image/bmp", content=fb)),
                 }
-            },
-            assert_data=partial(
-                assert_multi_images, method="pred_multi_images", im_file=img_file
-            ),
-        )
+            }
+        },
+        assert_data=partial(
+            assert_multi_images, method="pred_multi_images", im_file=img_file
+        ),
+    )

--- a/tests/e2e/bento_server_grpc/tests/test_metrics.py
+++ b/tests/e2e/bento_server_grpc/tests/test_metrics.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 
-from bentoml.client import Client
+import bentoml
 from bentoml.grpc.utils import import_generated_stubs
 
 if TYPE_CHECKING:
@@ -16,11 +16,12 @@ else:
 
 @pytest.mark.asyncio
 async def test_metrics_available(host: str):
-    client = Client.from_url(host)
-    resp = await client.async_predict_multi_images(
+    client = bentoml.client.GrpcClient.from_url(host)
+    resp = await client.async_call(
+        "predict_multi_images",
         original=np.random.randint(255, size=(10, 10, 3)).astype("uint8"),
         compared=np.random.randint(255, size=(10, 10, 3)).astype("uint8"),
     )
     assert isinstance(resp, pb.Response)
-    resp = await client.async_ensure_metrics_are_registered("input_data")
+    resp = await client.async_call("ensure_metrics_are_registered", "input_data")
     assert isinstance(resp, pb.Response)

--- a/tests/e2e/bento_server_http/tests/test_client.py
+++ b/tests/e2e/bento_server_http/tests/test_client.py
@@ -1,18 +1,18 @@
 import pytest
 
-from bentoml.client import HTTPClient
+import bentoml
 
 
 @pytest.mark.asyncio
 async def test_async_health(host: str) -> None:
-    http_client = HTTPClient.from_url(f"http://{host}")
-    resp = await http_client.async_health()
+    client = bentoml.client.HTTPClient.from_url(f"http://{host}")
+    resp = await client.async_health()
 
     assert resp.status == 200
 
 
 def test_health(host: str) -> None:
-    http_client = HTTPClient.from_url(f"http://{host}")
-    resp = http_client.health()
+    client = bentoml.client.HTTPClient.from_url(f"http://{host}")
+    resp = client.health()
 
     assert resp.status == 200

--- a/tests/e2e/bento_server_http/tests/test_io.py
+++ b/tests/e2e/bento_server_http/tests/test_io.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
 import io
-import sys
 import json
-from typing import TYPE_CHECKING
+import typing as t
 
 import numpy as np
 import pytest
 import aiohttp
 
-from bentoml.testing.utils import async_request
-from bentoml.testing.utils import parse_multipart_form
+import bentoml
+from bentoml.testing.http import parse_multipart_form
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     import PIL.Image as PILImage
+
+    F = t.Callable[..., t.Coroutine[t.Any, t.Any, t.Any]]
 else:
     from bentoml._internal.utils import LazyLoader
 
@@ -21,203 +22,176 @@ else:
 
 
 @pytest.mark.asyncio
-async def test_numpy(host: str):
-    await async_request(
-        "POST",
-        f"http://{host}/predict_ndarray_enforce_shape",
+async def test_numpy(arequest: F):
+    await arequest(
+        api_name="predict_ndarray_enforce_shape",
         headers={"Content-Type": "application/json"},
-        data="[[1,2],[3,4]]",
-        assert_status=200,
-        assert_data=b"[[2, 4], [6, 8]]",
+        data=np.array([[1, 2], [3, 4]]),
+        assert_output=np.array([[2, 4], [6, 8]]),
     )
-    await async_request(
-        "POST",
-        f"http://{host}/predict_ndarray_multi_output",
+    await arequest(
+        api_name="predict_ndarray_enforce_shape",
         headers={"Content-Type": "application/json"},
-        data="[[1,2],[3,4]]",
-        assert_status=200,
-        assert_data=b"[[2, 4], [6, 8]]",
+        data=np.array([1, 2, 3, 4]),
+        assert_exception=bentoml.exceptions.BadInput,
+        assert_exception_match="NumpyNdarray: Expecting ndarray of shape *",
     )
-    await async_request(
-        "POST",
-        f"http://{host}/predict_ndarray_enforce_shape",
-        headers={"Content-Type": "application/json"},
-        data="[1,2,3,4]",
-        assert_status=400,
+
+    await arequest(
+        api_name="predict_ndarray_enforce_dtype",
+        data=np.array([[2, 1], [4, 3]], dtype=np.uint8),
+        assert_output=np.array([[4, 2], [8, 6]], dtype="str"),
     )
-    await async_request(
-        "POST",
-        f"http://{host}/predict_ndarray_enforce_dtype",
+    await arequest(
+        api_name="predict_ndarray_enforce_dtype",
         headers={"Content-Type": "application/json"},
-        data="[[2,1],[4,3]]",
-        assert_status=200,
-        assert_data=b'[["4", "2"], ["8", "6"]]',
-    )
-    await async_request(
-        "POST",
-        f"http://{host}/predict_ndarray_enforce_dtype",
-        headers={"Content-Type": "application/json"},
-        data='[["2f",1],[4,3]]',
-        assert_status=400,
+        data=np.array([["2f", 1], [4, 3]]),
+        assert_exception=bentoml.exceptions.BadInput,
+        assert_exception_match='Expecting ndarray of dtype "uint8", but "<U21" was received.',
     )
 
 
 @pytest.mark.asyncio
-async def test_json(host: str):
+async def test_json(arequest: F):
     ORIGIN = "http://bentoml.ai"
 
-    await async_request(
-        "POST",
-        f"http://{host}/echo_json",
+    await arequest(
+        api_name="echo_json",
         headers=(("Content-Type", "application/json"), ("Origin", ORIGIN)),
         data='"hi"',
-        assert_status=200,
-        assert_data=b'"hi"',
+        assert_output='"hi"',
     )
-
-    await async_request(
-        "POST",
-        f"http://{host}/echo_json_sync",
+    await arequest(
+        api_name="echo_json_sync",
         headers=(("Content-Type", "application/json"), ("Origin", ORIGIN)),
         data='"hi"',
-        assert_status=200,
-        assert_data=b'"hi"',
     )
 
-    await async_request(
-        "POST",
-        f"http://{host}/echo_json_enforce_structure",
+    await arequest(
+        api_name="echo_json_enforce_structure",
         headers=(("Content-Type", "application/json"), ("Origin", ORIGIN)),
-        data='{"name":"test","endpoints":["predict","health"]}',
-        assert_status=200,
-        assert_data=b'{"name":"test","endpoints":["predict","health"]}',
+        data={"name": "test", "endpoints": ["predict", "health"]},
+        assert_output={"name": "test", "endpoints": ["predict", "health"]},
+    )
+
+    from service import ValidateSchema
+
+    # test sending pydantic model
+    await arequest(
+        api_name="echo_json_enforce_structure",
+        headers=(("Content-Type", "application/json"), ("Origin", ORIGIN)),
+        data=ValidateSchema(name="test", endpoints=["predict", "health"]),
+        assert_output={"name": "test", "endpoints": ["predict", "health"]},
     )
 
 
 @pytest.mark.asyncio
-async def test_obj(host: str):
+async def test_obj(arequest: F):
     for obj in [1, 2.2, "str", [1, 2, 3], {"a": 1, "b": 2}]:
         obj_str = json.dumps(obj, separators=(",", ":"))
-        await async_request(
-            "POST",
-            f"http://{host}/echo_obj",
-            headers=(("Content-Type", "application/json"),),
-            data=obj_str,
-            assert_status=200,
-            assert_data=obj_str.encode("utf-8"),
-        )
+        await arequest(api_name="echo_obj", data=obj_str, assert_output=obj_str)
 
 
 @pytest.mark.asyncio
-async def test_pandas(host: str):
+async def test_pandas(arequest: F, host: str):
     import pandas as pd
 
     ORIGIN = "http://bentoml.ai"
-
     df = pd.DataFrame([[101]], columns=["col1"])
+    client = bentoml.client.HTTPClient.from_url(f"http://{host}")
 
-    await async_request(
+    resp = await client.async_request(
         "POST",
-        f"http://{host}/predict_dataframe",
-        headers=(("Content-Type", "application/json"), ("Origin", ORIGIN)),
-        data=df.to_json(orient="records"),
-        assert_status=200,
-        assert_data=b'[{"col1":202}]',
+        "/predict_dataframe",
+        headers=(("Content-Type", "application/octet-stream"), ("Origin", ORIGIN)),
+        data=df.to_parquet(),
     )
+    assert resp.ok and resp.status == 200
+    assert await resp.read() == b'[{"col1":202}]'
 
-    # pyarrow only support python 3.7+
-    if sys.version_info >= (3, 7):
-        await async_request(
-            "POST",
-            f"http://{host}/predict_dataframe",
-            headers=(("Content-Type", "application/octet-stream"), ("Origin", ORIGIN)),
-            data=df.to_parquet(),
-            assert_status=200,
-            assert_data=b'[{"col1":202}]',
-        )
-
-    await async_request(
+    resp = await client.async_request(
         "POST",
-        f"http://{host}/predict_dataframe",
+        "/predict_dataframe",
         headers=(("Content-Type", "text/csv"), ("Origin", ORIGIN)),
         data=df.to_csv(),
-        assert_status=200,
-        assert_data=b'[{"col1":202}]',
+    )
+    assert resp.ok and resp.status == 200
+    assert await resp.read() == b'[{"col1":202}]'
+
+    await arequest(
+        api_name="predict_dataframe",
+        data=df,
+        assert_output=lambda out: True
+        if all((out == pd.DataFrame([{"col1": 202}])).all())
+        else False,
     )
 
 
 @pytest.mark.asyncio
-async def test_file(host: str, bin_file: str):
+async def test_file(arequest: F, bin_file: str, host: str):
     # Test File as binary
     with open(str(bin_file), "rb") as f:
         b = f.read()
 
-    await async_request(
-        "POST",
-        f"http://{host}/predict_file",
+    await arequest(
+        api_name="predict_file",
         data=b,
         headers={"Content-Type": "application/octet-stream"},
-        assert_data=b"\x810\x899",
+        assert_output=b"\x810\x899",
     )
+
+    client = bentoml.client.HTTPClient.from_url(f"http://{host}")
 
     # Test File as multipart binary
     form = aiohttp.FormData()
     form.add_field("file", b, content_type="application/octet-stream")
 
-    await async_request(
+    resp = await client.async_request(
         "POST",
-        f"http://{host}/predict_file",
+        "/predict_file",
         data=form,
-        assert_data=b"\x810\x899",
     )
+    assert resp.ok and resp.status == 200
+    assert await resp.read() == b"\x810\x899"
 
-    await async_request(
-        "POST",
-        f"http://{host}/predict_file",
+    await arequest(
+        api_name="predict_file",
         data=b,
         headers={"Content-Type": "application/pdf"},
-        assert_data=b"\x810\x899",
+        assert_output=b"\x810\x899",
     )
 
 
 @pytest.mark.asyncio
-async def test_image(host: str, img_file: str):
-    with open(str(img_file), "rb") as f1:
-        img_bytes = f1.read()
-
-    status, headers, body = await async_request(
-        "POST",
-        f"http://{host}/echo_image",
-        data=img_bytes,
+async def test_image(arequest: F, img_file: str, host: str):
+    await arequest(
+        api_name="echo_image",
+        data=PILImage.open(img_file),
         headers={"Content-Type": "image/bmp"},
     )
-    assert status == 200
-    assert headers["Content-Type"] == "image/bmp"
 
-    bio = io.BytesIO(body)
-    bio.name = "test.bmp"
-    img = PILImage.open(bio)
-    array1 = np.array(img)
-    array2 = PILImage.open(img_file)
-
-    np.testing.assert_array_almost_equal(array1, np.array(array2))
-
-    await async_request(
-        "POST",
-        f"http://{host}/echo_image",
-        data=img_bytes,
-        headers={"Content-Type": "application/json"},
-        assert_status=400,
-    )
+    client = bentoml.client.HTTPClient.from_url(f"http://{host}")
+    with open(str(img_file), "rb") as f1:
+        res = await client.async_request(
+            "POST",
+            "/echo_image",
+            data=f1.read(),
+            headers={"Content-Type": "application/json"},
+        )
+        assert res.status == 400
 
     with open(str(img_file), "rb") as f1:
         b = f1.read()
-    await async_request(
-        "POST",
-        f"http://{host}/echo_image",
-        data=b,
+
+    bio = io.BytesIO(b)
+    bio.name = "test.bmp"
+
+    res = await arequest(
+        api_name="echo_image",
+        data=PILImage.open(bio),
         headers={"Content-Type": "application/pdf"},
-        assert_status=400,
+        assert_exception=bentoml.exceptions.BentoMLException,
+        assert_exception_match="BentoService error handling API request: mime type application/pdf is not allowed *",
     )
 
 
@@ -232,16 +206,20 @@ def fixture_img_form_data(img_file: str):
 
 @pytest.mark.asyncio
 async def test_multipart_image_io(host: str, img_form_data: aiohttp.FormData):
+    from starlette.datastructures import Headers
     from starlette.datastructures import UploadFile
 
-    _, headers, body = await async_request(
+    client = bentoml.client.HTTPClient.from_url(f"http://{host}")
+    resp = await client.async_request(
         "POST",
-        f"http://{host}/predict_multi_images",
+        "/predict_multi_images",
         data=img_form_data,
-        assert_status=200,
     )
+    assert resp.ok and resp.status == 200
 
-    form = await parse_multipart_form(headers=headers, body=body)
+    form = await parse_multipart_form(
+        headers=Headers(headers=resp.headers), body=await resp.read()
+    )
     for _, v in form.items():
         assert isinstance(v, UploadFile)
         img = PILImage.open(v.file)
@@ -250,9 +228,10 @@ async def test_multipart_image_io(host: str, img_form_data: aiohttp.FormData):
 
 @pytest.mark.asyncio
 async def test_multipart_different_args(host: str, img_form_data: aiohttp.FormData):
-    await async_request(
+    client = bentoml.client.HTTPClient.from_url(f"http://{host}")
+    resp = await client.async_request(
         "POST",
-        f"http://{host}/predict_different_args",
+        "/predict_different_args",
         data=img_form_data,
-        assert_status=200,
     )
+    assert resp.ok and resp.status == 200

--- a/tests/unit/grpc/interceptors/test_prometheus.py
+++ b/tests/unit/grpc/interceptors/test_prometheus.py
@@ -123,13 +123,13 @@ async def test_metrics_interceptors(
         )
         try:
             await server.start()
-            async with create_channel(host_url) as channel:
-                await async_client_call(
-                    "noop_sync",
-                    channel=channel,
-                    data={"text": wrappers_pb2.StringValue(value="BentoML")},
-                    protocol_version=protocol_version,
-                )
+            await server.wait_for_termination()
+            await async_client_call(
+                "noop_sync",
+                host_url,
+                data={"text": wrappers_pb2.StringValue(value="BentoML")},
+                protocol_version=protocol_version,
+            )
             for m in metrics_client.text_string_to_metric_families():
                 for sample in m.samples:
                     if m.type == metric_type:


### PR DESCRIPTION
## What does this PR address?

<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->

Migrate current `bentoml.testing` to use the recent server and client API.

Remove broken pandas series tests for now, will investigate on a
different tickets.

depends on #3843, #3844, #3845, #3846

- In addition to the test improvement, this PR also introduces a `async_request` and `request` to `HTTPClient`. This enables users to send request other that `POST` to the server.

This is useful when BentoService is mounted with a fastapi or other ASGI app.

`client.async_request` is a thin wrapper for `aiohttp.ClientSession.request`.

- all attributes that ``aio.ClientSession.post`` accepts that has prefix of `_http_*` can also be passed from `client.<endpoint>`

```python

client.predict(np.array([1,2]), _http_timeout=90, _http_headers={"Content-Type": "application/json"})

```


Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>


## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
