### PR TITLE
feat: Implement `workers_per_resource` as `resources_per_worker`

### DIFF
--- a/src/bentoml/_internal/configuration/containers.py
+++ b/src/bentoml/_internal/configuration/containers.py
@@ -145,7 +145,8 @@ class BentoMLConfiguration:
             "logging",
             "metrics",
             "timeout",
-            "workers_per_resource",
+            "workers_per_resource",  # Deprecated, use resources_per_worker
+            "resources_per_worker",
         ]
         global_runner_cfg = {k: self.config["runners"][k] for k in RUNNER_CFG_KEYS}
         custom_runners_cfg = dict(

--- a/src/bentoml/_internal/configuration/helpers.py
+++ b/src/bentoml/_internal/configuration/helpers.py
@@ -165,3 +165,13 @@ def is_valid_ip_address(addr: str) -> bool:
         return True
     except socket.error:
         return False
+
+
+def warn_deprecated(value: t.Any, deprecated: str, replacement: str) -> bool:
+    """Warn user that given field is deprecated and has been replaced with another field."""
+    if value is not None:
+        logger.warning(
+            "Field '%s' is deprecated and has been replaced with '%s'"
+            % (deprecated, replacement)
+        )
+    return True

--- a/src/bentoml/_internal/configuration/v1/__init__.py
+++ b/src/bentoml/_internal/configuration/v1/__init__.py
@@ -8,6 +8,7 @@ import schema as s
 from ..helpers import depth
 from ..helpers import ensure_range
 from ..helpers import rename_fields
+from ..helpers import warn_deprecated
 from ..helpers import ensure_larger_than
 from ..helpers import is_valid_ip_address
 from ..helpers import ensure_iterable_type
@@ -146,7 +147,20 @@ _RUNNER_CONFIG = {
     # NOTE: there is a distinction between being unset and None here; if set to 'None'
     # in configuration for a specific runner, it will override the global configuration.
     s.Optional("resources"): s.Or({s.Optional(str): object}, lambda s: s == "system", None),  # type: ignore (incomplete schema typing)
-    s.Optional("workers_per_resource"): s.And(int, ensure_larger_than_zero),
+    # NOTE: 'workers_per_resource' option is deprecated and is replaced with the `resources_per_worker` option.
+    s.Optional("workers_per_resource"): s.Or(
+        s.And(
+            int,
+            ensure_larger_than_zero,
+            lambda value: warn_deprecated(
+                value, "workers_per_resource", "resources_per_worker"
+            ),
+        ),
+        None,
+    ),
+    s.Optional("resources_per_worker"): {
+        s.Optional(str): s.And(s.Or(float, int), ensure_larger_than_zero)
+    },
     s.Optional("logging"): {
         s.Optional("access"): {
             s.Optional("enabled"): bool,

--- a/src/bentoml/_internal/configuration/v1/default_configuration.yaml
+++ b/src/bentoml/_internal/configuration/v1/default_configuration.yaml
@@ -80,6 +80,7 @@ api_server:
     period: 10
 runners:
   resources: ~
+  resources_per_worker: {}
   workers_per_resource: 1
   timeout: 300
   batching:

--- a/src/bentoml/_internal/runner/runner.py
+++ b/src/bentoml/_internal/runner/runner.py
@@ -124,7 +124,7 @@ class Runner(AbstractRunner):
 
     runner_methods: list[RunnerMethod[t.Any, t.Any, t.Any]]
     scheduling_strategy: type[Strategy]
-    workers_per_resource: int = 1
+    resources_per_worker: dict[str, int | float] = {}
     runnable_init_params: dict[str, t.Any] = attr.field(
         default=None, converter=attr.converters.default_if_none(factory=dict)
     )
@@ -245,7 +245,7 @@ class Runner(AbstractRunner):
             runnable_class=runnable_class,
             runnable_init_params=runnable_init_params,
             resource_config=config["resources"],
-            workers_per_resource=config.get("workers_per_resource", 1),
+            resources_per_worker=config.get("resources_per_worker", {}),
             runner_methods=list(runner_method_map.values()),
             scheduling_strategy=scheduling_strategy,
         )
@@ -328,7 +328,7 @@ class Runner(AbstractRunner):
         return self.scheduling_strategy.get_worker_count(
             self.runnable_class,
             self.resource_config,
-            self.workers_per_resource,
+            self.resources_per_worker,
         )
 
     @property
@@ -337,7 +337,7 @@ class Runner(AbstractRunner):
             worker_id: self.scheduling_strategy.get_worker_env(
                 self.runnable_class,
                 self.resource_config,
-                self.workers_per_resource,
+                self.resources_per_worker,
                 worker_id,
             )
             for worker_id in range(self.scheduled_worker_count)

--- a/tests/integration/frameworks/test_frameworks.py
+++ b/tests/integration/frameworks/test_frameworks.py
@@ -298,7 +298,7 @@ def test_runner_cpu_multi_threading(
         for meth, inputs in config.test_inputs.items():
             strategy = DefaultStrategy()
 
-            os.environ.update(strategy.get_worker_env(runnable, resource_cfg, 1, 0))
+            os.environ.update(strategy.get_worker_env(runnable, resource_cfg, {}, 0))
 
             runner.init_local()
 
@@ -344,7 +344,7 @@ def test_runner_cpu(
         for meth, inputs in config.test_inputs.items():
             strategy = DefaultStrategy()
 
-            os.environ.update(strategy.get_worker_env(runnable, resource_cfg, 1, 0))
+            os.environ.update(strategy.get_worker_env(runnable, resource_cfg, {}, 0))
 
             runner.init_local()
 
@@ -392,7 +392,7 @@ def test_runner_nvidia_gpu(
         for meth, inputs in config.test_inputs.items():
             strategy = DefaultStrategy()
 
-            os.environ.update(strategy.get_worker_env(runnable, resource_cfg, 1, 0))
+            os.environ.update(strategy.get_worker_env(runnable, resource_cfg, {}, 0))
 
             runner.init_local()
 

--- a/tests/unit/_internal/configuration/test_containers.py
+++ b/tests/unit/_internal/configuration/test_containers.py
@@ -57,17 +57,20 @@ runners:
         max_batch_size: 10
     resources:
         cpu: 4
-    workers_per_resource: 1
+    resources_per_worker:
+        cpu: 4
     logging:
         access:
             enabled: False
     test_runner_1:
         resources: system
-        workers_per_resource: 2
+        resources_per_worker:
+            cpu: 0.5
     test_runner_2:
         resources:
             cpu: 2
-        workers_per_resource: 4
+        resources_per_worker:
+            cpu: 0.25
     test_runner_gpu:
         resources:
             nvidia.com/gpu: 1
@@ -87,7 +90,7 @@ runners:
     assert test_runner_1["batching"]["enabled"] is False
     assert test_runner_1["batching"]["max_batch_size"] == 10
     assert test_runner_1["logging"]["access"]["enabled"] is False
-    assert test_runner_1["workers_per_resource"] == 2
+    assert test_runner_1["resources_per_worker"]["cpu"] == 0.5
     # assert test_runner_1["resources"]["cpu"] == 4
 
     # test_runner_2
@@ -96,7 +99,7 @@ runners:
     assert test_runner_2["batching"]["max_batch_size"] == 10
     assert test_runner_2["logging"]["access"]["enabled"] is False
     assert test_runner_2["resources"]["cpu"] == 2
-    assert test_runner_2["workers_per_resource"] == 4
+    assert test_runner_2["resources_per_worker"]["cpu"] == 0.25
 
     # test_runner_gpu
     test_runner_gpu = runner_cfg["test_runner_gpu"]
@@ -105,7 +108,7 @@ runners:
     assert test_runner_gpu["logging"]["access"]["enabled"] is False
     assert test_runner_gpu["resources"]["cpu"] == 4  # should use global
     assert test_runner_gpu["resources"]["nvidia.com/gpu"] == 1
-    assert test_runner_gpu["workers_per_resource"] == 1
+    assert test_runner_gpu["resources_per_worker"]["cpu"] == 4
 
     # test_runner_batching
     test_runner_batching = runner_cfg["test_runner_batching"]
@@ -123,22 +126,24 @@ def test_runner_gpu_configuration(
 runners:
     resources:
         nvidia.com/gpu: [1, 2, 4]
-    workers_per_resource: 1
+    resources_per_worker:
+        nvidia.com/gpu: 1
 """
     bentoml_cfg = container_from_file(GPU_INDEX)
     assert bentoml_cfg["runners"]["resources"] == {"nvidia.com/gpu": [1, 2, 4]}
-    assert bentoml_cfg["runners"]["workers_per_resource"] == 1
+    assert bentoml_cfg["runners"]["resources_per_worker"] == {"nvidia.com/gpu": 1}
 
     GPU_INDEX_WITH_STRING = """\
 runners:
     resources:
         nvidia.com/gpu: "[1, 2, 4]"
-    workers_per_resource: 2
+    resources_per_worker:
+        nvidia.com/gpu: 0.5
 """
     bentoml_cfg = container_from_file(GPU_INDEX_WITH_STRING)
     # this behaviour can be confusing
     assert bentoml_cfg["runners"]["resources"] == {"nvidia.com/gpu": "[1, 2, 4]"}
-    assert bentoml_cfg["runners"]["workers_per_resource"] == 2
+    assert bentoml_cfg["runners"]["resources_per_worker"] == {"nvidia.com/gpu": 0.5}
 
 
 @pytest.mark.usefixtures("container_from_file")


### PR DESCRIPTION
## What does this PR address?

<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->

Exploratory implementation of `workers_per_resource` as a potentially more intuitive `resources_per_worker`. Will update documentation if contributors agree with this approach.

GPU: the following config will spawn 4 runners, 2 on each device.
```
runners:
  resources:
    nvidia.com/gpu: 2
  resources_per_worker:
    nvidia.com/gpu: 0.5
```

CPU: the following config will spawn 4 runners, regardless of `SUPPORTS_CPU_MULTI_THREADING`.
```
runners:
  resources:
    cpu: 2
  resources_per_worker:
    cpu: 0.5
```

Log a warning if `workers_per_resource` is specified.
```
> BENTOML_CONFIG=config.yaml b serve
Field 'workers_per_resource' is deprecated and has been replaced with 'resources_per_worker'
Field 'workers_per_resource' is deprecated and has been replaced with 'resources_per_worker'
2023-04-27T17:55:22-0700 [INFO] [cli] Prometheus metrics for HTTP BentoServer from "." can be accessed at http://localhost:3000/metrics.
```

Fixes #(issue)

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
