### PR TITLE
use path as resource for non-OS paths

### DIFF
--- a/src/bentoml/_internal/exportable.py
+++ b/src/bentoml/_internal/exportable.py
@@ -197,7 +197,7 @@ class Exportable(ABC):
                 protocol = "osfs"
                 resource = path if os.sep == "/" else path.replace(os.sep, "/")
             else:
-                resource = ""
+                resource = path
         else:
             if any(v is not None for v in [protocol, user, passwd, params, subpath]):
                 raise ValueError(


### PR DESCRIPTION
Previously we ignored the path argument if it was not an OSFS path; we no longer do this.

See #3789