### PR TITLE
fix: correctly reraise `CancelledError`

### DIFF
--- a/src/bentoml/_internal/marshal/dispatcher.py
+++ b/src/bentoml/_internal/marshal/dispatcher.py
@@ -269,6 +269,8 @@ class CorkDispatcher:
                     "BentoML has detected that a service has a max latency that is likely too low for serving. If many 503 errors are encountered, try raising the 'runner.max_latency' in your BentoML configuration YAML file."
                 )
             logger.debug("Dispatcher optimizer training complete.")
+        except asyncio.CancelledError:
+            raise
         except Exception as e:  # pylint: disable=broad-except
             logger.error(traceback.format_exc(), exc_info=e)
 


### PR DESCRIPTION
This prevents the dispatcher from slowing down shutdown significantly.