### PR TITLE
feat(observability): support `service.name`

### DIFF
--- a/src/bentoml/_internal/configuration/containers.py
+++ b/src/bentoml/_internal/configuration/containers.py
@@ -5,6 +5,7 @@ import math
 import uuid
 import typing as t
 import logging
+import urllib.parse
 from copy import deepcopy
 from typing import TYPE_CHECKING
 from dataclasses import dataclass
@@ -22,6 +23,7 @@ from .helpers import flatten_dict
 from .helpers import load_config_file
 from .helpers import get_default_config
 from .helpers import import_configuration_spec
+from ..context import trace_context
 from ..context import component_context
 from ..resource import CpuResource
 from ..resource import system_resources
@@ -289,7 +291,6 @@ class _BentoMLContainerClass:
         | str
         | None = Provide[cors.access_control_expose_headers],
     ) -> dict[str, list[str] | str | int]:
-
         if isinstance(allow_origins, str):
             allow_origins = [allow_origins]
 
@@ -363,6 +364,19 @@ class _BentoMLContainerClass:
                 "'tracing.sample_rate' is set to zero. No traces will be collected. Please refer to https://docs.bentoml.org/en/latest/guides/tracing.html for more details."
             )
         resource = {}
+
+        def process_resource_attributes(
+            resource_attributes: str, target_resource: dict[str, str]
+        ):
+            for item in resource_attributes.split(","):
+                try:
+                    key, value = item.split("=", maxsplit=1)
+                except ValueError as e:
+                    logger.warning("Invalid key,value resource pair %s: %s", item, e)
+                    continue
+                value_url_decoded = urllib.parse.unquote(value)
+                target_resource[key.strip()] = value_url_decoded
+
         # User can optionally configure the resource with the following environment variables. Only
         # configure resource if user has not explicitly configured it.
         if (
@@ -371,12 +385,67 @@ class _BentoMLContainerClass:
         ):
             if component_context.component_name:
                 resource[SERVICE_NAME] = component_context.component_name
+                trace_context.service_name = component_context.component_name
             if component_context.component_index:
                 resource[SERVICE_INSTANCE_ID] = component_context.component_index
             if component_context.bento_name:
                 resource[SERVICE_NAMESPACE] = component_context.bento_name
             if component_context.bento_version:
                 resource[SERVICE_VERSION] = component_context.bento_version
+
+        elif (
+            OTEL_RESOURCE_ATTRIBUTES in os.environ
+            and OTEL_SERVICE_NAME not in os.environ
+        ):
+            process_resource_attributes(os.environ[OTEL_RESOURCE_ATTRIBUTES], resource)
+            if SERVICE_NAME in resource:
+                trace_context.service_name = resource[SERVICE_NAME]
+            else:
+                if component_context.component_name:
+                    resource[SERVICE_NAME] = component_context.component_name
+                    trace_context.service_name = component_context.component_name
+            if (
+                component_context.component_index
+                and SERVICE_INSTANCE_ID not in resource
+            ):
+                resource[SERVICE_INSTANCE_ID] = component_context.component_index
+            if component_context.bento_name and SERVICE_NAMESPACE not in resource:
+                resource[SERVICE_NAMESPACE] = component_context.bento_name
+            if component_context.bento_version and SERVICE_VERSION not in resource:
+                resource[SERVICE_VERSION] = component_context.bento_version
+
+        elif (
+            OTEL_SERVICE_NAME in os.environ
+            and OTEL_RESOURCE_ATTRIBUTES not in os.environ
+        ):
+            resource[SERVICE_NAME] = os.environ[OTEL_SERVICE_NAME]
+            trace_context.service_name = os.environ[OTEL_SERVICE_NAME]
+            if (
+                component_context.component_index
+                and SERVICE_INSTANCE_ID not in resource
+            ):
+                resource[SERVICE_INSTANCE_ID] = component_context.component_index
+            if component_context.bento_name and SERVICE_NAMESPACE not in resource:
+                resource[SERVICE_NAMESPACE] = component_context.bento_name
+            if component_context.bento_version and SERVICE_VERSION not in resource:
+                resource[SERVICE_VERSION] = component_context.bento_version
+        else:
+            # the branch that contains both environment variables
+            process_resource_attributes(os.environ[OTEL_RESOURCE_ATTRIBUTES], resource)
+            # OTEL_SERVICE_NAME will always take precedent.
+            # See https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/
+            resource[SERVICE_NAME] = os.environ[OTEL_SERVICE_NAME]
+            trace_context.service_name = os.environ[OTEL_SERVICE_NAME]
+            if (
+                component_context.component_index
+                and SERVICE_INSTANCE_ID not in resource
+            ):
+                resource[SERVICE_INSTANCE_ID] = component_context.component_index
+            if component_context.bento_name and SERVICE_NAMESPACE not in resource:
+                resource[SERVICE_NAMESPACE] = component_context.bento_name
+            if component_context.bento_version and SERVICE_VERSION not in resource:
+                resource[SERVICE_VERSION] = component_context.bento_version
+
         # create tracer provider
         provider = TracerProvider(
             sampler=ParentBasedTraceIdRatio(sample_rate),

--- a/src/bentoml/_internal/context.py
+++ b/src/bentoml/_internal/context.py
@@ -152,6 +152,9 @@ class _ServiceTraceContext:
     _request_id_var = contextvars.ContextVar(
         "_request_id_var", default=t.cast("t.Optional[int]", None)
     )
+    _service_name_var = contextvars.ContextVar(
+        "_service_name_var", default=t.cast("t.Optional[str]", None)
+    )
 
     @property
     def trace_id(self) -> t.Optional[int]:
@@ -164,7 +167,7 @@ class _ServiceTraceContext:
 
     @property
     def sampled(self) -> int:
-        from opentelemetry import trace  # type: ignore
+        from opentelemetry import trace
 
         span = trace.get_current_span()
         if span is None:
@@ -173,7 +176,7 @@ class _ServiceTraceContext:
 
     @property
     def span_id(self) -> t.Optional[int]:
-        from opentelemetry import trace  # type: ignore
+        from opentelemetry import trace
 
         span = trace.get_current_span()
         if span is None:
@@ -190,6 +193,14 @@ class _ServiceTraceContext:
     @request_id.setter
     def request_id(self, request_id: t.Optional[int]) -> None:
         self._request_id_var.set(request_id)
+
+    @property
+    def service_name(self) -> t.Optional[str]:
+        return self._service_name_var.get()
+
+    @service_name.setter
+    def service_name(self, service_name: t.Optional[str]) -> None:
+        self._service_name_var.set(service_name)
 
 
 class _ComponentContext:

--- a/src/bentoml/_internal/log.py
+++ b/src/bentoml/_internal/log.py
@@ -112,11 +112,11 @@ def trace_record_factory(*args: t.Any, **kwargs: t.Any):
     record = default_factory(*args, **kwargs)
     if record.name in ("bentoml_monitor_data", "bentoml_monitor_schema"):
         return record
-    record.levelname_bracketed = f"[{record.levelname}]"  # type: ignore (adding fields to record)
-    record.component = f"[{_component_name()}]"  # type: ignore (adding fields to record)
+    record.levelname_bracketed = f"[{record.levelname}]"
+    record.component = f"[{_component_name()}]"
     trace_id = trace_context.trace_id
     if trace_id in (0, None):
-        record.trace_msg = ""  # type: ignore (adding fields to record)
+        record.trace_msg = ""
     else:
         from .configuration.containers import BentoMLContainer
 
@@ -126,8 +126,9 @@ def trace_record_factory(*args: t.Any, **kwargs: t.Any):
 
         trace_id = format(trace_id, trace_id_format)
         span_id = format(trace_context.span_id, span_id_format)
-        record.trace_msg = f" (trace={trace_id},span={span_id},sampled={trace_context.sampled})"  # type: ignore (adding fields to record)
-    record.request_id = trace_context.request_id  # type: ignore (adding fields to record)
+        record.trace_msg = f" (trace={trace_id},span={span_id},sampled={trace_context.sampled},service.name={trace_context.service_name})"
+    record.request_id = trace_context.request_id
+    record.service_name = trace_context.service_name
 
     return record
 

--- a/src/bentoml/_internal/server/http_app.py
+++ b/src/bentoml/_internal/server/http_app.py
@@ -225,9 +225,6 @@ class HTTPAppFactory(BaseAppFactory):
         def client_request_hook(span: Span, _: dict[str, t.Any]) -> None:
             if span is not None:
                 trace_context.request_id = span.context.span_id
-                trace_context.service_name = span.resource.attributes.get(
-                    "service.name"
-                )
 
         middlewares.append(
             Middleware(

--- a/src/bentoml/_internal/server/http_app.py
+++ b/src/bentoml/_internal/server/http_app.py
@@ -230,7 +230,7 @@ class HTTPAppFactory(BaseAppFactory):
                     if trace_context.service_name is None:
                         trace_context.service_name = service_name
                     else:
-                        raise ValueError(
+                        logger.warning(
                             f"'service.name={service_name}' found inconsistent from incoming trace with current trace context ({trace_context.service_name})."
                         )
 

--- a/src/bentoml/_internal/server/http_app.py
+++ b/src/bentoml/_internal/server/http_app.py
@@ -223,16 +223,11 @@ class HTTPAppFactory(BaseAppFactory):
         from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 
         def client_request_hook(span: Span, _: dict[str, t.Any]) -> None:
-            if span:
+            if span is not None:
                 trace_context.request_id = span.context.span_id
-                service_name = span.resource.attributes.get("service.name")
-                if service_name != trace_context.service_name:
-                    if trace_context.service_name is None:
-                        trace_context.service_name = service_name
-                    else:
-                        logger.warning(
-                            f"'service.name={service_name}' found inconsistent from incoming trace with current trace context ({trace_context.service_name})."
-                        )
+                trace_context.service_name = span.resource.attributes.get(
+                    "service.name"
+                )
 
         middlewares.append(
             Middleware(

--- a/src/bentoml/_internal/server/runner_app.py
+++ b/src/bentoml/_internal/server/runner_app.py
@@ -164,16 +164,11 @@ class RunnerAppFactory(BaseAppFactory):
         from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 
         def client_request_hook(span: Span, _scope: t.Dict[str, t.Any]) -> None:
-            if span:
+            if span is not None:
                 trace_context.request_id = span.context.span_id
-                service_name = span.resource.attributes.get("service.name")
-                if service_name != trace_context.service_name:
-                    if trace_context.service_name is None:
-                        trace_context.service_name = service_name
-                    else:
-                        logger.warning(
-                            f"'service.name={service_name}' found inconsistent from incoming trace with current trace context ({trace_context.service_name})."
-                        )
+                trace_context.service_name = span.resource.attributes.get(
+                    "service.name"
+                )
 
         middlewares.append(
             Middleware(

--- a/src/bentoml/_internal/server/runner_app.py
+++ b/src/bentoml/_internal/server/runner_app.py
@@ -166,9 +166,6 @@ class RunnerAppFactory(BaseAppFactory):
         def client_request_hook(span: Span, _scope: t.Dict[str, t.Any]) -> None:
             if span is not None:
                 trace_context.request_id = span.context.span_id
-                trace_context.service_name = span.resource.attributes.get(
-                    "service.name"
-                )
 
         middlewares.append(
             Middleware(

--- a/src/bentoml/_internal/server/runner_app.py
+++ b/src/bentoml/_internal/server/runner_app.py
@@ -160,18 +160,24 @@ class RunnerAppFactory(BaseAppFactory):
     def middlewares(self) -> list[Middleware]:
         middlewares = super().middlewares
 
-        # otel middleware
-        import opentelemetry.instrumentation.asgi as otel_asgi  # type: ignore[import]
         from starlette.middleware import Middleware
+        from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 
         def client_request_hook(span: Span, _scope: t.Dict[str, t.Any]) -> None:
-            if span is not None:
-                span_id: int = span.context.span_id
-                trace_context.request_id = span_id
+            if span:
+                trace_context.request_id = span.context.span_id
+                service_name = span.resource.attributes.get("service.name")
+                if service_name != trace_context.service_name:
+                    if trace_context.service_name is None:
+                        trace_context.service_name = service_name
+                    else:
+                        raise ValueError(
+                            f"'service.name={service_name}' found inconsistent from incoming trace with current trace context ({trace_context.service_name})."
+                        )
 
         middlewares.append(
             Middleware(
-                otel_asgi.OpenTelemetryMiddleware,
+                OpenTelemetryMiddleware,
                 excluded_urls=BentoMLContainer.tracing_excluded_urls.get(),
                 default_span_details=None,
                 server_request_hook=None,
@@ -370,7 +376,6 @@ class RunnerAppFactory(BaseAppFactory):
 
 
 def _deserialize_single_param(request: Request, bs: bytes) -> Params[t.Any]:
-
     container = request.headers["Payload-Container"]
     meta = json.loads(request.headers["Payload-Meta"])
     batch_size = int(request.headers["Batch-Size"])

--- a/src/bentoml/_internal/server/runner_app.py
+++ b/src/bentoml/_internal/server/runner_app.py
@@ -171,7 +171,7 @@ class RunnerAppFactory(BaseAppFactory):
                     if trace_context.service_name is None:
                         trace_context.service_name = service_name
                     else:
-                        raise ValueError(
+                        logger.warning(
                             f"'service.name={service_name}' found inconsistent from incoming trace with current trace context ({trace_context.service_name})."
                         )
 


### PR DESCRIPTION
Added support for service.name to appear in trace. 

<img width="2049" alt="Screenshot 2023-05-03 at 19 49 55" src="https://user-images.githubusercontent.com/29749331/236101285-915d4ec7-32df-4b4d-adad-1df95874d1d4.png">

When set with `OTEL_SERVICE_NAME`
<img width="2044" alt="Screenshot 2023-05-03 at 19 50 35" src="https://user-images.githubusercontent.com/29749331/236101396-26805446-a33e-4efa-bc90-ffe781286585.png">

cc @ssheng 

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
