### PR TITLE
fix(import): make sure not to import grpc when not needed

### DIFF
--- a/src/bentoml/_internal/client/grpc.py
+++ b/src/bentoml/_internal/client/grpc.py
@@ -15,9 +15,9 @@ from ..utils import cached_property
 from ..service import Service
 from ...exceptions import BentoMLException
 from ...grpc.utils import import_grpc
+from ...grpc.utils import load_from_file
 from ...grpc.utils import import_generated_stubs
 from ...grpc.utils import LATEST_PROTOCOL_VERSION
-from ..server.grpc_app import load_from_file
 from ..service.inference_api import InferenceAPI
 
 logger = logging.getLogger(__name__)

--- a/src/bentoml/_internal/server/grpc_app.py
+++ b/src/bentoml/_internal/server/grpc_app.py
@@ -18,7 +18,7 @@ from bentoml.grpc.utils import import_generated_stubs
 
 from ..utils import LazyLoader
 from ..utils import cached_property
-from ..utils import resolve_user_filepath
+from ...grpc.utils import load_from_file
 from ...grpc.utils import LATEST_PROTOCOL_VERSION
 from ..configuration.containers import BentoMLContainer
 

--- a/src/bentoml/grpc/utils/__init__.py
+++ b/src/bentoml/grpc/utils/__init__.py
@@ -11,6 +11,7 @@ from ...exceptions import InvalidArgument
 from ._import_hook import import_grpc
 from ._import_hook import import_generated_stubs
 from ._import_hook import LATEST_PROTOCOL_VERSION
+from ..._internal.utils import resolve_user_filepath
 
 if TYPE_CHECKING:
     from enum import Enum
@@ -38,12 +39,19 @@ __all__ = [
     "import_grpc",
     "validate_proto_fields",
     "LATEST_PROTOCOL_VERSION",
+    "load_from_file",
 ]
 
 logger = logging.getLogger(__name__)
 
 # content-type is always application/grpc
 GRPC_CONTENT_TYPE = "application/grpc"
+
+
+def load_from_file(p: str) -> bytes:
+    rp = resolve_user_filepath(p, ctx=None)
+    with open(rp, "rb") as f:
+        return f.read()
 
 
 def validate_proto_fields(


### PR DESCRIPTION
address #3797

This is a regression when I added GrpcClient. I forgot that grpc_app eagerly
load for gRPC dependencies. This will fail when users want to use client and
don't have gRPC dependencies.

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
