### PR TITLE
fix(inference-api): assigning name in callback is None branch

### DIFF
--- a/src/bentoml/_internal/service/inference_api.py
+++ b/src/bentoml/_internal/service/inference_api.py
@@ -39,7 +39,8 @@ class InferenceAPI:
             # Use user_defined_callback function docstring `__doc__` if doc not specified
             doc = user_defined_callback.__doc__ if doc is None else doc
         else:
-            name, doc = "", ""
+            name = "" if name is None else name
+            doc = "" if doc is None else doc
 
         # Use API name as route if route not specified
         route = name if route is None else route


### PR DESCRIPTION
Fixes a hidden bug where name and doc is not set in the branch for callback is
None.

InferenceAPI that created from user_defined_callback=None (mainly from client)
does assign name and doc. Currently on main, this fake_api won't have the name

This PRs address that

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
