### PR TITLE
refactor(client): move async and sync implementation

### DIFF
--- a/src/bentoml/_internal/client/__init__.py
+++ b/src/bentoml/_internal/client/__init__.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import enum
 import typing as t
 import asyncio
+import inspect
 import logging
 import functools
 from abc import ABC
@@ -10,6 +12,7 @@ from http.client import BadStatusLine
 
 from ...exceptions import BentoMLException
 from ..service.inference_api import InferenceAPI
+from ..io_descriptors.multipart import Multipart
 
 logger = logging.getLogger(__name__)
 
@@ -17,14 +20,189 @@ if t.TYPE_CHECKING:
     from types import TracebackType
 
     from .grpc import GrpcClient
+    from .grpc import AsyncGrpcClient
     from .http import HTTPClient
+    from .http import AsyncHTTPClient
     from ..service import Service
+
+    P = t.ParamSpec("P")
+    F = t.Callable[P, t.Any]
+
+    ClientKind = t.Literal[
+        "auto", "http", "grpc", "async_http", "async_grpc", "async-grpc", "async-http"
+    ]
+
+    class ConnectionProtocol(t.Protocol):
+        def close(self) -> t.Any:
+            ...
+
+    class ClientProtocol(t.Protocol):
+        server_url: str
+        endpoints: list[str]
+        supports_kwds_assignment: bool
+
+        _svc: Service
+        _conn_type: t.Any
+        _endpoint_kwds_map: dict[str, list[str]] | None
+
+        def __init__(self, svc: Service, server_url: str):
+            ...
+
+        def _getitem_from_kwds_map(self, api: InferenceAPI) -> list[str]:
+            ...
+
+
+def ensure_exec_coro(coro: t.Coroutine[t.Any, t.Any, t.Any]) -> t.Any:
+    loop = asyncio.get_event_loop()
+    if loop.is_running():
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        return future.result()
+    else:
+        return loop.run_until_complete(coro)
+
+
+def deprecated_async_warning(
+    func: t.Callable[P, t.Any] | functools.partial[t.Any]
+) -> t.Callable[..., t.Any]:
+    if isinstance(func, functools.partial):
+        callable_ = func.func
+    else:
+        callable_ = func
+
+    fname = callable_.__name__
+    frame = inspect.currentframe()
+    assert (
+        frame and frame.f_back
+    ), "This wrapper can only be used for a function within a class."
+
+    locals = frame.f_back.f_locals
+    qualname = (
+        locals["self"].__class__.__qualname__
+        if "self" in locals
+        else locals["__qualname__"]
+    )
+    if fname.startswith("async_"):
+        fname = fname[len("async_") :]
+
+    @functools.wraps(callable_)
+    def decorator(*args: P.args, **kwargs: P.kwargs) -> t.Any:
+        logger.warning(
+            "Calling 'async_%s' from '%s' is deprecated. Please create a 'Async%s' and use '%s' instead.",
+            fname,
+            qualname,
+            qualname,
+            fname,
+        )
+        return callable_(*args, **kwargs)
+
+    return decorator
+
+
+# NOTE: The purpose of this function is to wraps auto generated client function
+# with nice docstring and better naming.
+def wraps_call_attributes(
+    f: t.Callable[P, t.Any],
+    api: InferenceAPI,
+    svc: Service,
+    *,
+    _func_name: str | None = None,
+    _async_doc: bool = False,
+) -> t.Any:
+    if _func_name is None:
+        _func_name = f.func.__name__ if isinstance(f, functools.partial) else f.__name__
+
+    def _invoke(_: t.Any, *args: P.args, **kwargs: P.kwargs) -> t.Any:
+        return f(*args, **kwargs)
+
+    def _repr(self: t.Any) -> str:
+        return f"<generated client function '{_func_name}' of {svc.name}>"
+
+    input_type = api.input.input_type()
+    if api.multi_input:
+        # NOTE: Right now, only Multipart.input_type returns a dict
+        assert isinstance(input_type, dict) and isinstance(api.input, Multipart)
+        inputs = api.input._inputs
+        args = "\n".join(
+            [f"{key}: data with type {value}." for key, value in input_type.items()]
+        )
+        examples = (
+            f"result ={' await' if _async_doc else ''} client.{_func_name}("
+            + ", ".join(
+                [
+                    f"{key}={value.sample if value.sample else '<input>'}"
+                    for key, value in zip(input_type, inputs.values())
+                ]
+            )
+            + ")"
+        )
+    else:
+        args = f"inp: data with type {input_type}. This can be used either as keyword arguments or the first positional argument to {_func_name}"
+        examples = f"""result = {'await' if _async_doc else ''} client.{_func_name}({api.input.sample if api.input.sample else '<input>'})"""
+
+    f_docs = f"""\
+            Sending request to '{_func_name}' from service '{svc.name}'.
+
+            Usage for using '{_func_name}' endpoint with ``bentoml.client.Client``:
+
+            .. code-block:: python
+
+                {examples}
+
+            .. note::
+
+                See https://docs.bentoml.org/en/latest/reference/api_io_descriptors.html for more details on specific inputs/outputs types.
+
+            Args:
+                {args}
+
+            Returns:
+                data with type {api.output.input_type()}.
+    """
+
+    return type(
+        "_generated_" + _func_name,
+        (),
+        {
+            "__name__": _func_name,
+            "__call__": _invoke,
+            "__doc__": f_docs,
+            "__repr__": _repr,
+        },
+    )()
+
+
+class ClientType(enum.Enum):
+    ASYNC = "async"
+    SYNC = "sync"
+
+    def __eq__(self, other: t.Any) -> bool:
+        if isinstance(other, ClientType):
+            return self.value == other.value
+        return False
 
 
 class Client(ABC):
     server_url: str
-    _svc: Service
     endpoints: list[str]
+
+    _svc: Service
+
+    # _conn_type represents a Connection protocol that can be used
+    # to connect to the server. On gRPC, it is grpc.Channel, on HTTP, it is
+    # either requests.Session or aiohttp.ClientSession
+    _conn_type: ConnectionProtocol | None = None
+
+    _CLIENT_TYPE: ClientType
+
+    def __init_subclass__(
+        cls, *, client_type: t.Literal["sync", "async"] = "sync"
+    ) -> None:
+        try:
+            cls._CLIENT_TYPE = ClientType[client_type.upper()]
+        except KeyError:
+            raise BentoMLException(
+                f"client_type should be either 'sync' or 'async', got {client_type}"
+            )
 
     def __init__(self, svc: Service, server_url: str):
         self._svc = svc
@@ -37,41 +215,18 @@ class Client(ABC):
         for name, api in self._svc.apis.items():
             self.endpoints.append(name)
 
-            if not hasattr(self, name):
-                setattr(
-                    self, name, functools.partial(self._sync_call, _bentoml_api=api)
-                )
-
-            if not hasattr(self, f"async_{name}"):
-                setattr(
-                    self,
-                    f"async_{name}",
-                    functools.partial(self._call, _bentoml_api=api),
-                )
-
-    def call(self, bentoml_api_name: str, inp: t.Any = None, **kwargs: t.Any) -> t.Any:
-        return self._sync_call(
-            inp, _bentoml_api=self._svc.apis[bentoml_api_name], **kwargs
-        )
-
-    async def async_call(
-        self, bentoml_api_name: str, inp: t.Any = None, **kwargs: t.Any
-    ) -> t.Any:
-        return await self._call(
-            inp, _bentoml_api=self._svc.apis[bentoml_api_name], **kwargs
-        )
-
     @staticmethod
     def wait_until_server_ready(
         host: str, port: int, timeout: float = 30, **kwargs: t.Any
     ) -> None:
         try:
-            from .http import HTTPClient
+            from .http import HTTPClientMixin
 
-            HTTPClient.wait_until_server_ready(host, port, timeout, **kwargs)
-        except BadStatusLine:
-            # when address is a RPC
-            from .grpc import GrpcClient
+            HTTPClientMixin.wait_until_server_ready(host, port, timeout, **kwargs)
+        except Exception:
+            try:
+                # when address is a RPC
+                from .grpc import GrpcClient
 
             GrpcClient.wait_until_server_ready(host, port, timeout, **kwargs)
         except Exception as err:
@@ -84,7 +239,7 @@ class Client(ABC):
     @staticmethod
     def from_url(
         server_url: str, *, kind: None | t.Literal["auto"] = ...
-    ) -> GrpcClient | HTTPClient:
+    ) -> GrpcClient | HTTPClient | AsyncGrpcClient | AsyncHTTPClient:
         ...
 
     @t.overload
@@ -94,49 +249,224 @@ class Client(ABC):
 
     @t.overload
     @staticmethod
-    def from_url(server_url: str, *, kind: t.Literal["grpc"] = ...) -> GrpcClient:
+    def from_url(
+        server_url: str, *, kind: t.Literal["grpc"] = ..., **kwargs: t.Any
+    ) -> GrpcClient:
+        ...
+
+    @t.overload
+    @staticmethod
+    def from_url(
+        server_url: str, *, kind: t.Literal["async_http", "async-http"] = ...
+    ) -> AsyncHTTPClient:
+        ...
+
+    @t.overload
+    @staticmethod
+    def from_url(
+        server_url: str,
+        *,
+        kind: t.Literal["async_grpc", "async-grpc"] = ...,
+        **kwargs: t.Any,
+    ) -> AsyncGrpcClient:
         ...
 
     @staticmethod
     def from_url(
-        server_url: str, *, kind: str | None = None, **kwargs: t.Any
+        server_url: str,
+        *,
+        kind: ClientKind | None = None,
+        **kwargs: t.Any,
     ) -> Client:
+        """Construct a BentoML Client from a server URL.
+
+        Users can specify the client type by passing in the `kind` parameter.
+        If `kind` is either not specified or set to 'auto', BentoML will try to construct
+        a client.
+
+        .. note:: ``'kind=auto'`` behaviour
+
+           The client will implement a greedy check between HTTP and gRPC client. It will try to create
+           a HTTP client. If the server is not a HTTP server, it will try to create a gRPC client.
+
+           At the end of the check, if the client is not created, it will raise an exception.
+           Note that it will create an async client variant if the method is constructed within a running event loop.
+
+           :bdg-info:`Remarks:` We recommend you to explicitly specify the client type via the ``kind`` parameter to avoid breaking change.
+
+        Args:
+            server_url: The URL of the server to connect to.
+            kind: The type of client to create.
+            **kwargs: Additional keyword arguments to pass to the client constructor.
+        """
         if kind is None or kind == "auto":
-            try:
-                from .http import HTTPClient
+            # NOTE: Exhaustive check for all possible client types.
+            # TODO: Wrt exceptions, should be using PEP654
+            if asyncio.get_event_loop().is_running():
+                # We are inside a running event loop, create an async client.
+                try:
+                    from .http import AsyncHTTPClient
 
-                return HTTPClient.from_url(server_url, **kwargs)
-            except BadStatusLine:
-                from .grpc import GrpcClient
+                    return AsyncHTTPClient.from_url(server_url, **kwargs)
+                except Exception:
+                    try:
+                        from .grpc import AsyncGrpcClient
 
-                return GrpcClient.from_url(server_url, **kwargs)
-            except Exception as e:  # pylint: disable=broad-except
-                raise BentoMLException(
-                    f"Failed to create a BentoML client from given URL '{server_url}': {e} ({e.__class__.__name__})"
-                ) from e
+                        return AsyncGrpcClient.from_url(server_url, **kwargs)
+                    except Exception as err:
+                        logger.error(
+                            "Failed to instantiate a client after trying all possible async type. Exception:\n"
+                        )
+                        logger.error(err)
+                        raise BentoMLException(
+                            f"Failed to create a BentoML client from given URL '{server_url}'."
+                        ) from err
+            else:
+                try:
+                    from .http import HTTPClient
+
+                    return HTTPClient.from_url(server_url, **kwargs)
+                except Exception:
+                    try:
+                        from .grpc import GrpcClient
+
+                        return GrpcClient.from_url(server_url, **kwargs)
+                    except Exception as err:
+                        logger.error(
+                            "Failed to instantiate a client after trying all possible async type. Exception:\n"
+                        )
+                        logger.error(err)
+                        raise BentoMLException(
+                            f"Failed to create a BentoML client from given URL '{server_url}': {err} ({err.__class__.__name__})"
+                        ) from err
         elif kind == "http":
             from .http import HTTPClient
 
             return HTTPClient.from_url(server_url, **kwargs)
-        elif kind == "grpc":
+        elif kind.replace("-", "_") == "async_http":
+            from .http import AsyncHTTPClient
+
+            return AsyncHTTPClient.from_url(server_url, **kwargs)
+        elif kind.replace("-", "_") == "grpc":
             from .grpc import GrpcClient
 
             return GrpcClient.from_url(server_url, **kwargs)
+        elif kind.replace("-", "_") == "async_grpc":
+            from .grpc import AsyncGrpcClient
+
+            return AsyncGrpcClient.from_url(server_url, **kwargs)
         else:
             raise BentoMLException(
-                f"Invalid client kind '{kind}'. Must be one of 'http', 'grpc', or 'auto'."
+                f"Invalid client kind '{kind}'. Must be one of 'http', 'grpc', 'async_http', 'async_grpc' or 'auto'."
             )
-
-    def _sync_call(
-        self, inp: t.Any = None, *, _bentoml_api: InferenceAPI, **kwargs: t.Any
-    ):
-        return asyncio.run(self._call(inp, _bentoml_api=_bentoml_api, **kwargs))
 
     @abstractmethod
     async def _call(
         self, inp: t.Any = None, *, _bentoml_api: InferenceAPI, **kwargs: t.Any
     ) -> t.Any:
         raise NotImplementedError
+
+    supports_kwds_assignment: bool = False
+    _endpoint_kwds_map: dict[str, list[str]] | None = None
+
+    def _getitem_from_kwds_map(self, api: InferenceAPI) -> list[str]:
+        # type-safe getters
+        if self.supports_kwds_assignment:
+            assert self._endpoint_kwds_map is not None
+            if api.name not in self._endpoint_kwds_map:
+                raise BentoMLException(
+                    f"{api.name} is not available in OpenAPI spec (malformed spec)."
+                )
+            return self._endpoint_kwds_map[api.name]
+        raise ValueError("Given API Service doesn't support keyword assignment.")
+
+    def _prepare_call_inputs(
+        self: ClientProtocol,
+        inp: t.Any | None = None,
+        *,
+        io_kwargs: dict[str, t.Any],
+        api: InferenceAPI,
+    ) -> t.Any:
+        """Prepare the actual inputs for the call method. With newer service,
+        it will also send the function signatures through OpenAPI, hence this will help
+        to determine whether the input can be get from the kwargs.
+
+        This function also handles cases for multipart inputs vs. single inputs.
+        """
+        if api.multi_input:
+            if inp is not None:
+                raise BentoMLException(
+                    f"'{api.name}' takes multiple inputs; all inputs must be passed as keyword arguments."
+                )
+            if self.supports_kwds_assignment:
+                diff = set(io_kwargs).difference(self._getitem_from_kwds_map(api))
+                if len(diff) > 0:
+                    raise BentoMLException(
+                        f"Mismatch input kwargs from spec and given: {diff}"
+                    )
+            inp = io_kwargs
+        else:
+            # NOTE: Currently, we only support one input per service APIs.
+            attr = self._getitem_from_kwds_map(api)[0]
+            if inp is None:
+                if attr not in io_kwargs:
+                    raise ValueError(
+                        f"'inp' is not set, and '{attr}' kwargs is missing."
+                    )
+                inp = io_kwargs[attr]
+        return inp
+
+
+class BaseSyncClient(Client, client_type="sync"):
+    def __init__(self, svc: Service, server_url: str):
+        super().__init__(svc, server_url)
+        for name, api in self._svc.apis.items():
+            if not hasattr(self, name):
+                setattr(
+                    self,
+                    name,
+                    wraps_call_attributes(
+                        functools.partial(self._sync_call, _bentoml_api=api),
+                        api,
+                        svc,
+                        _func_name=name,
+                    ),
+                )
+
+            # Backwards compatibility
+            if not hasattr(self, f"async_{name}"):
+                setattr(
+                    self,
+                    f"async_{name}",
+                    deprecated_async_warning(
+                        wraps_call_attributes(
+                            functools.partial(self._call, _bentoml_api=api),
+                            api,
+                            svc,
+                            _func_name=f"async_{name}",
+                            _async_doc=True,
+                        )
+                    ),
+                )
+
+    # XXX: This is for backward compatibility only.
+    async def async_call(
+        self, bentoml_api_name: str, inp: t.Any = None, **kwargs: t.Any
+    ) -> t.Any:
+        assert self._CLIENT_TYPE == ClientType.SYNC
+        logger.warning(
+            "Calling 'async_call' for '%s' from a sync client is deprecated. Use 'Async%s.call' instead",
+            bentoml_api_name,
+            self.__class__.__name__,
+        )
+        return await self._call(
+            inp, _bentoml_api=self._svc.apis[bentoml_api_name], **kwargs
+        )
+
+    def call(self, bentoml_api_name: str, inp: t.Any = None, **kwargs: t.Any):
+        return self._sync_call(
+            inp, _bentoml_api=self._svc.apis[bentoml_api_name], **kwargs
+        )
 
     def __enter__(self):
         return self
@@ -147,8 +477,61 @@ class Client(ABC):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> bool | None:
-        pass
+        if self._conn_type:
+            try:
+                self._conn_type.close()
+            except Exception as err:
+                logger.error(
+                    "Exception while closing client session: %s", self._conn_type
+                )
+                logger.error(err)
+                raise
 
+    def _sync_call(
+        self, inp: t.Any = None, *, _bentoml_api: InferenceAPI, **kwargs: t.Any
+    ) -> t.Any:
+        raise NotImplementedError
+
+    def health(self) -> t.Any:
+        raise NotImplementedError("'health' is not implemented.")
+
+    def __del__(self):
+        # Close connection when this object is destroyed
+        if self._conn_type and hasattr(self._conn_type, "close"):
+            try:
+                self._conn_type.close()
+            except Exception as e:
+                logger.error("Exception caught while gc the client object:\n")
+                logger.error(e)
+                raise
+
+
+class BaseAsyncClient(Client, client_type="async"):
+    def __init__(self, svc: Service, server_url: str):
+        super().__init__(svc, server_url)
+
+        for name, api in self._svc.apis.items():
+            if not hasattr(self, name):
+                setattr(
+                    self,
+                    name,
+                    wraps_call_attributes(
+                        functools.partial(self._call, _bentoml_api=api),
+                        api,
+                        svc,
+                        _func_name=name,
+                        _async_doc=True,
+                    ),
+                )
+
+    async def call(
+        self, bentoml_api_name: str, inp: t.Any = None, **kwargs: t.Any
+    ) -> t.Any:
+        return await self._call(
+            inp=inp, _bentoml_api=self._svc.apis[bentoml_api_name], **kwargs
+        )
+
+    # NOTE: Context-manager related to manage long-running session.
     async def __aenter__(self):
         return self
 
@@ -158,4 +541,28 @@ class Client(ABC):
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> bool | None:
-        pass
+        if self._conn_type:
+            try:
+                await self._conn_type.close()
+            except Exception as err:
+                logger.error(
+                    "Exception while closing client session: %s", self._conn_type
+                )
+                logger.error(err)
+                raise
+
+    def __del__(self):
+        # Close connection when this object is destroyed
+        if (
+            self._conn_type
+            and hasattr(self._conn_type, "close")
+            and asyncio.iscoroutinefunction(self._conn_type.close)
+        ):
+            try:
+                # We probably want to use `run` here to close the session.
+                asyncio.run(self._conn_type.close())
+            except Exception as err:
+                logger.error("\nException caught while gc the client object:")
+                logger.error(err)
+                raise
+                # pass

--- a/src/bentoml/_internal/client/__init__.py
+++ b/src/bentoml/_internal/client/__init__.py
@@ -8,7 +8,6 @@ import logging
 import functools
 from abc import ABC
 from abc import abstractmethod
-from http.client import BadStatusLine
 
 from ...exceptions import BentoMLException
 from ..service.inference_api import InferenceAPI
@@ -226,14 +225,14 @@ class Client(ABC):
         except Exception:
             try:
                 # when address is a RPC
-                from .grpc import GrpcClient
+                from .grpc import GrpcClientMixin
 
-            GrpcClient.wait_until_server_ready(host, port, timeout, **kwargs)
-        except Exception as err:
-            # caught all other exceptions
-            logger.error("Failed to connect to server %s:%s", host, port)
-            logger.error(err)
-            raise
+                GrpcClientMixin.wait_until_server_ready(host, port, timeout, **kwargs)
+            except Exception as err:
+                # caught all other exceptions
+                logger.error("Failed to connect to server %s:%s", host, port)
+                logger.error(err)
+                raise
 
     @t.overload
     @staticmethod
@@ -492,7 +491,7 @@ class BaseSyncClient(Client, client_type="sync"):
     ) -> t.Any:
         raise NotImplementedError
 
-    def health(self) -> t.Any:
+    def health(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
         raise NotImplementedError("'health' is not implemented.")
 
     def __del__(self):
@@ -523,6 +522,9 @@ class BaseAsyncClient(Client, client_type="async"):
                         _async_doc=True,
                     ),
                 )
+
+    async def health(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
+        raise NotImplementedError("'health' is not implemented.")
 
     async def call(
         self, bentoml_api_name: str, inp: t.Any = None, **kwargs: t.Any

--- a/src/bentoml/_internal/service/openapi/__init__.py
+++ b/src/bentoml/_internal/service/openapi/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing as t
+import inspect
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 from functools import lru_cache
@@ -28,7 +29,6 @@ from .specification import Components
 from .specification import OpenAPISpecification
 
 if TYPE_CHECKING:
-
     from .. import Service
     from ..inference_api import InferenceAPI
 
@@ -98,6 +98,14 @@ def generate_service_components(svc: Service) -> Components:
     return Components(**components)
 
 
+def get_func_kwds(api: InferenceAPI) -> list[str]:
+    sig = inspect.signature(api.func)
+    # We probably want to pop out ctx from the signature.
+    return (
+        list(sig.parameters)[:-1] if len(sig.parameters) == 2 else list(sig.parameters)
+    )
+
+
 def generate_spec(svc: Service, *, openapi_version: str = "3.0.2"):
     """Generate a OpenAPI specification for a service."""
     mounted_app_paths = {}
@@ -162,6 +170,7 @@ def generate_spec(svc: Service, *, openapi_version: str = "3.0.2"):
                         "consumes": [api.input.mime_type],
                         "produces": [api.output.mime_type],
                         "x-bentoml-name": api.name,
+                        "x-bentoml-func-kwds": get_func_kwds(api),
                         "summary": str(api),
                         "description": api.doc or "",
                         "requestBody": api.input.openapi_request_body(),

--- a/tests/e2e/bento_server_http/tests/test_client.py
+++ b/tests/e2e/bento_server_http/tests/test_client.py
@@ -1,5 +1,6 @@
 import pytest
 
+import bentoml
 from bentoml.client import HTTPClient
 
 
@@ -15,4 +16,18 @@ def test_health(host: str) -> None:
     http_client = HTTPClient.from_url(f"http://{host}")
     resp = http_client.health()
 
-    assert resp.status == 200
+    assert resp.status_code == 200
+
+
+def test_client_request(host: str) -> None:
+    http_client = HTTPClient.from_url(f"http://{host}")
+    assert http_client.request("GET", "/readyz").status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_async_client(host: str) -> None:
+    client = bentoml.client.Client.from_url(f"http://{host}", kind="async-http")
+
+    assert await client.request("GET", "/readyz")
+
+    assert await client.echo_json({"hello": "world"}) == {"hello": "world"}


### PR DESCRIPTION
added auto-generated docs per function

add supports for client.kwargs parsing

```python
client.predict(input_series=np.array([1,2,3,4]))
```

Client now also support parsing kwargs for the server api.

update protocol interface and use asyncio.run during destructor

fix(client): create a client type protocol

Move common to main metaclass

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
