### PR TITLE
improve: more explicit exception printing when configuration failed to register

### DIFF
--- a/src/bentoml/_internal/configuration/helpers.py
+++ b/src/bentoml/_internal/configuration/helpers.py
@@ -11,6 +11,7 @@ import yaml
 import schema as s
 
 from ..utils import LazyLoader
+from ...exceptions import BentoMLException
 from ...exceptions import BentoMLConfigException
 
 if TYPE_CHECKING:
@@ -113,7 +114,9 @@ def get_default_config(version: int) -> dict[str, t.Any]:
             % (version, e)
         ) from e
     except Exception as err:
-        raise BentoMLException("Unexpected error while setting configuration:\n") from err
+        raise BentoMLException(
+            "Unexpected error while setting configuration:\n"
+        ) from err
     finally:
         return config
 

--- a/src/bentoml/_internal/configuration/helpers.py
+++ b/src/bentoml/_internal/configuration/helpers.py
@@ -113,9 +113,7 @@ def get_default_config(version: int) -> dict[str, t.Any]:
             % (version, e)
         ) from e
     except Exception as err:
-        logger.error("Unexpected error while setting configuration:\n")
-        logger.error(err)
-        raise
+        raise BentoMLException("Unexpected error while setting configuration:\n") from err
     finally:
         return config
 

--- a/src/bentoml/_internal/configuration/helpers.py
+++ b/src/bentoml/_internal/configuration/helpers.py
@@ -105,17 +105,19 @@ def get_default_config(version: int) -> dict[str, t.Any]:
         )
     )
     mod = import_configuration_spec(version)
-    assert hasattr(mod, "SCHEMA"), (
-        "version %d does not have a validation schema" % version
-    )
     try:
         mod.SCHEMA.validate(config)
     except s.SchemaError as e:
         raise BentoMLConfigException(
             "Default configuration for version %d does not conform to given schema:\n%s"
             % (version, e)
-        ) from None
-    return config
+        ) from e
+    except Exception as err:
+        logger.error("Unexpected error while setting configuration:\n")
+        logger.error(err)
+        raise
+    finally:
+        return config
 
 
 def validate_tracing_type(tracing_type: str) -> bool:

--- a/src/bentoml/_internal/configuration/helpers.py
+++ b/src/bentoml/_internal/configuration/helpers.py
@@ -108,6 +108,7 @@ def get_default_config(version: int) -> dict[str, t.Any]:
     mod = import_configuration_spec(version)
     try:
         mod.SCHEMA.validate(config)
+        return config
     except s.SchemaError as e:
         raise BentoMLConfigException(
             "Default configuration for version %d does not conform to given schema:\n%s"
@@ -117,8 +118,6 @@ def get_default_config(version: int) -> dict[str, t.Any]:
         raise BentoMLException(
             "Unexpected error while setting configuration:\n"
         ) from err
-    finally:
-        return config
 
 
 def validate_tracing_type(tracing_type: str) -> bool:


### PR DESCRIPTION
Print more explicit exception when default configuration failed to register

I ran into this when running service from a directory with the file name
`schema.py`, which indirectly interfere with the `schema` module. The error
message was not very helpful, so I added a more explicit message to help with
debugging.

Note that the reason for this collision is that we are still importing
`service.py` into sys.path, so if the directory contains a file named
`schema.py`, it will be imported instead of the `schema` module

We probably need to figure out a way for parsing service.py without importing
it.

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
