### PR TITLE
chore(type): cleanup

### DIFF
--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -8,7 +8,6 @@ import logging
 import subprocess
 from sys import version_info
 from shlex import quote
-from typing import TYPE_CHECKING
 
 import fs
 import attr
@@ -34,7 +33,7 @@ from ..container.frontend.dockerfile import ALLOWED_CUDA_VERSION_ARGS
 from ..container.frontend.dockerfile import SUPPORTED_PYTHON_VERSIONS
 from ..container.frontend.dockerfile import CONTAINER_SUPPORTED_DISTROS
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from attr import Attribute
     from fs.base import FS
 
@@ -278,7 +277,7 @@ class DockerOptions:
         return bentoml_cattr.unstructure(self)
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     CondaPipType = dict[t.Literal["pip"], list[str]]
     DependencyType = list[str | CondaPipType]
 else:
@@ -312,7 +311,7 @@ def conda_dependencies_validator(
                 )
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     ListStr: t.TypeAlias = list[str]
     CondaYamlDict = dict[str, DependencyType | list[str]]
 else:
@@ -689,7 +688,7 @@ def _python_options_structure_hook(d: t.Any, _: t.Type[PythonOptions]) -> Python
 bentoml_cattr.register_structure_hook(PythonOptions, _python_options_structure_hook)
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     OptionsCls = DockerOptions | CondaOptions | PythonOptions
 
 
@@ -740,7 +739,7 @@ class BentoBuildConfig:
         converter=dict_options_converter(CondaOptions),
     )
 
-    if TYPE_CHECKING:
+    if t.TYPE_CHECKING:
         # NOTE: This is to ensure that BentoBuildConfig __init__
         # satisfies type checker. docker, python, and conda accepts
         # dict[str, t.Any] since our converter will handle the conversion.

--- a/src/bentoml/bentos.py
+++ b/src/bentoml/bentos.py
@@ -372,7 +372,7 @@ def build(
         bentofile_path = os.path.join(os.path.dirname(f.name), f.name)
         build_args.extend(["--bentofile", bentofile_path])
         try:
-            output = subprocess.check_output(build_args, env=os.environ.copy())
+            output = subprocess.check_output(build_args)
         except subprocess.CalledProcessError as e:
             logger.error("Failed to build BentoService bundle: %s", e)
             raise
@@ -414,7 +414,7 @@ def build_bentofile(
     build_args.extend(["--bentofile", bentofile, "--output", "tag"])
 
     try:
-        output = subprocess.check_output(build_args, env=os.environ.copy())
+        output = subprocess.check_output(build_args)
     except subprocess.CalledProcessError as e:
         logger.error("Failed to build BentoService bundle: %s", e)
         raise

--- a/src/bentoml/bentos.py
+++ b/src/bentoml/bentos.py
@@ -26,6 +26,9 @@ if t.TYPE_CHECKING:
     from .server import Server
     from ._internal.bento import BentoStore
     from ._internal.yatai_client import YataiClient
+    from ._internal.bento.build_config import CondaOptions
+    from ._internal.bento.build_config import DockerOptions
+    from ._internal.bento.build_config import PythonOptions
 
 
 logger = logging.getLogger(__name__)
@@ -270,9 +273,9 @@ def build(
     description: str | None = None,
     include: t.List[str] | None = None,
     exclude: t.List[str] | None = None,
-    docker: dict[str, t.Any] | None = None,
-    python: dict[str, t.Any] | None = None,
-    conda: dict[str, t.Any] | None = None,
+    docker: DockerOptions | dict[str, t.Any] | None = None,
+    python: PythonOptions | dict[str, t.Any] | None = None,
+    conda: CondaOptions | dict[str, t.Any] | None = None,
     version: str | None = None,
     build_ctx: str | None = None,
     _bento_store: BentoStore = Provide[BentoMLContainer.bento_store],
@@ -369,7 +372,7 @@ def build(
         bentofile_path = os.path.join(os.path.dirname(f.name), f.name)
         build_args.extend(["--bentofile", bentofile_path])
         try:
-            output = subprocess.check_output(build_args)
+            output = subprocess.check_output(build_args, env=os.environ.copy())
         except subprocess.CalledProcessError as e:
             logger.error("Failed to build BentoService bundle: %s", e)
             raise
@@ -411,7 +414,7 @@ def build_bentofile(
     build_args.extend(["--bentofile", bentofile, "--output", "tag"])
 
     try:
-        output = subprocess.check_output(build_args)
+        output = subprocess.check_output(build_args, env=os.environ.copy())
     except subprocess.CalledProcessError as e:
         logger.error("Failed to build BentoService bundle: %s", e)
         raise


### PR DESCRIPTION
Currently, subprocess build doesn't respect current users environment. If custom
BENTOML_HOME is set, and in the service there is a import_model logics, it will
fail to find the model from the custom BENTOML_HOME and it will try to create a
default bentoml_home instead.

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
