### PR TITLE
chore(cli): remove path from `bentoml list`

### DIFF
--- a/src/bentoml/_internal/utils/__init__.py
+++ b/src/bentoml/_internal/utils/__init__.py
@@ -58,7 +58,6 @@ __all__ = [
     "reserve_free_port",
     "LazyLoader",
     "validate_or_create_dir",
-    "display_path_under_home",
     "rich_console",
     "experimental",
     "compose",
@@ -160,16 +159,6 @@ def validate_or_create_dir(*path: PathType) -> None:
 
 def calc_dir_size(path: PathType) -> int:
     return sum(f.stat().st_size for f in Path(path).glob("**/*") if f.is_file())
-
-
-def display_path_under_home(path: str) -> str:
-    # Shorten path under home directory with leading `~`
-    # e.g. from `/Users/foo/bar` to just `~/bar`
-    try:
-        return str("~" / Path(path).relative_to(Path.home()))
-    except ValueError:
-        # when path is not under home directory, return original full path
-        return path
 
 
 def human_readable_size(size: t.Union[int, float], decimal_places: int = 2) -> str:

--- a/src/bentoml_cli/bentos.py
+++ b/src/bentoml_cli/bentos.py
@@ -55,7 +55,6 @@ def add_bento_management_commands(cli: Group):
     from bentoml._internal.utils import calc_dir_size
     from bentoml._internal.utils import human_readable_size
     from bentoml._internal.utils import resolve_user_filepath
-    from bentoml._internal.utils import display_path_under_home
     from bentoml._internal.bento.bento import Bento
     from bentoml._internal.bento.bento import DEFAULT_BENTO_BUILD_FILE
     from bentoml._internal.configuration import get_quiet_mode
@@ -114,7 +113,6 @@ def add_bento_management_commands(cli: Group):
         res = [
             {
                 "tag": str(bento.tag),
-                "path": display_path_under_home(bento.path),
                 "size": human_readable_size(calc_dir_size(bento.path)),
                 "creation_time": bento.info.creation_time.astimezone().strftime(
                     "%Y-%m-%d %H:%M:%S"
@@ -136,13 +134,11 @@ def add_bento_management_commands(cli: Group):
             table.add_column("Tag")
             table.add_column("Size")
             table.add_column("Creation Time")
-            table.add_column("Path")
             for bento in res:
                 table.add_row(
                     bento["tag"],
                     bento["size"],
                     bento["creation_time"],
-                    bento["path"],
                 )
             console.print(table)
 

--- a/src/bentoml_cli/models.py
+++ b/src/bentoml_cli/models.py
@@ -107,6 +107,7 @@ def add_model_management_commands(cli: Group) -> None:
                 "creation_time": model.info.creation_time.astimezone().strftime(
                     "%Y-%m-%d %H:%M:%S"
                 ),
+                "path": model.path,
             }
             for model in sorted(
                 models, key=lambda x: x.info.creation_time, reverse=True
@@ -124,12 +125,14 @@ def add_model_management_commands(cli: Group) -> None:
             table.add_column("Module")
             table.add_column("Size")
             table.add_column("Creation Time")
+            table.add_column("Path")
             for model in res:
                 table.add_row(
                     model["tag"],
                     model["module"],
                     model["size"],
                     model["creation_time"],
+                    model["path"],
                 )
             console.print(table)
 

--- a/src/bentoml_cli/models.py
+++ b/src/bentoml_cli/models.py
@@ -107,7 +107,6 @@ def add_model_management_commands(cli: Group) -> None:
                 "creation_time": model.info.creation_time.astimezone().strftime(
                     "%Y-%m-%d %H:%M:%S"
                 ),
-                "path": model.path,
             }
             for model in sorted(
                 models, key=lambda x: x.info.creation_time, reverse=True
@@ -125,14 +124,12 @@ def add_model_management_commands(cli: Group) -> None:
             table.add_column("Module")
             table.add_column("Size")
             table.add_column("Creation Time")
-            table.add_column("Path")
             for model in res:
                 table.add_row(
                     model["tag"],
                     model["module"],
                     model["size"],
                     model["creation_time"],
-                    model["path"],
                 )
             console.print(table)
 


### PR DESCRIPTION
this is a chore, but adding path for models when users do `bentoml models list`
is synonymous to when `bentoml list` also shows path

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
