### PR TITLE
docs: add note to Library Logging part to inform user about file rotate issue 

### DIFF
--- a/docs/source/guides/logging.rst
+++ b/docs/source/guides/logging.rst
@@ -132,6 +132,16 @@ When using BentoML as a library, BentoML does not configure any logs. By default
     bentoml_logger.addHandler(ch)
     bentoml_logger.setLevel(logging.DEBUG)
 
+.. note::
+    Important Notice: When using the BentoML serving API with the ``bentoml serve service.py:svc --production`` command,
+    please be aware that the execution of ``service.py`` takes place within a new forked child process.
+    It is crucial to avoid implementing any type of rotation FileHandler within service.py.
+
+    The Python logging module is thread-safe within a single process
+    However, when utilizing multiple processes, each process has its own instance of the logger, and they write to their respective log files independently.
+    The logging module does not provide synchronization mechanisms for sharing loggers or log files across different processes.
+
+    In this scenario, each process performs its own file rotation independently, which can result in overwritten archived log files.
 ----
 
 .. rubric:: Notes

--- a/docs/source/guides/logging.rst
+++ b/docs/source/guides/logging.rst
@@ -133,15 +133,8 @@ When using BentoML as a library, BentoML does not configure any logs. By default
     bentoml_logger.setLevel(logging.DEBUG)
 
 .. note::
-    Important Notice: When using the BentoML serving API with the ``bentoml serve service.py:svc --production`` command,
-    please be aware that the execution of ``service.py`` takes place within a new forked child process.
-    It is crucial to avoid implementing any type of rotation FileHandler within service.py.
 
-    The Python logging module is thread-safe within a single process
-    However, when utilizing multiple processes, each process has its own instance of the logger, and they write to their respective log files independently.
-    The logging module does not provide synchronization mechanisms for sharing loggers or log files across different processes.
-
-    In this scenario, each process performs its own file rotation independently, which can result in overwritten archived log files.
+    :bdg-info:`Important:` ``bentoml serve`` will fork the given `service.py` into the child process. This means any type of rotation FileHandler are not supported within the service definition. See `notes from Python logging module <https://docs.python.org/3/howto/logging-cookbook.html#logging-to-a-single-file-from-multiple-processes>`_ for more information.
 ----
 
 .. rubric:: Notes


### PR DESCRIPTION
Add the note to inform the user that initializing a custom logger in the `service.py` can not do file rotation properly, due to the logging module only support thread-safty in single process, but not for multiprocess. 

## What does this PR address?

<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->

Fixes #3851 

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [x] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
