### PR TITLE
feat(configuration): allow overwrite load_config with default override_config_dict

### DIFF
--- a/src/bentoml/_internal/configuration/__init__.py
+++ b/src/bentoml/_internal/configuration/__init__.py
@@ -134,7 +134,10 @@ def get_quiet_mode() -> bool:
     return False
 
 
-def load_config(bentoml_config_file: str | None = None):
+def load_config(
+    bentoml_config_file: str | None = None,
+    override_config: dict[str, t.Any] | None = None,
+):
     """Load global configuration of BentoML"""
 
     from .containers import BentoMLContainer
@@ -157,6 +160,7 @@ def load_config(bentoml_config_file: str | None = None):
         BentoMLConfiguration(
             override_config_file=bentoml_config_file,
             override_config_values=get_bentoml_override_config_from_env(),
+            override_config_dict=override_config,
         ).to_dict()
     )
 

--- a/src/bentoml/_internal/configuration/containers.py
+++ b/src/bentoml/_internal/configuration/containers.py
@@ -56,6 +56,7 @@ class BentoMLConfiguration:
         self,
         override_config_file: str | None = None,
         override_config_values: str | None = None,
+        override_config_dict: dict[str, t.Any] | None = None,
         *,
         validate_schema: bool = True,
         use_version: int = 1,
@@ -128,7 +129,23 @@ class BentoMLConfiguration:
                 ) from None
             config_merger.merge(self.config, override)
 
-        if override_config_file is not None or override_config_values is not None:
+        if override_config_dict is not None:
+            assert isinstance(
+                override_config_dict, dict
+            ), "override_config_dict must be a dict"
+            try:
+                override = unflatten(override_config_dict)
+            except ValueError as e:
+                raise BentoMLConfigException(
+                    f"Failed to unflatten the override_config_dict:\n{e}\n ** Note: You can just simply use a non flatten dict that follows the default BentoML configuration structure."
+                ) from None
+            config_merger.merge(self.config, override_config_dict)
+
+        if (
+            override_config_file is not None
+            or override_config_values is not None
+            or override_config_dict is not None
+        ):
             self._finalize()
 
         if validate_schema:

--- a/src/bentoml/_internal/configuration/containers.py
+++ b/src/bentoml/_internal/configuration/containers.py
@@ -65,6 +65,18 @@ class BentoMLConfiguration:
         self.config = get_default_config(version=use_version)
         spec_module = import_configuration_spec(version=use_version)
 
+        if override_config_dict is not None:
+            assert isinstance(
+                override_config_dict, dict
+            ), "override_config_dict must be a dict"
+            try:
+                override = unflatten(override_config_dict)
+            except ValueError as e:
+                raise BentoMLConfigException(
+                    f"Failed to unflatten the override_config_dict:\n{e}\n ** Note: You can just simply use a non flatten dict that follows the default BentoML configuration structure."
+                ) from None
+            config_merger.merge(self.config, override_config_dict)
+
         # User override configuration
         if override_config_file is not None:
             logger.info(
@@ -128,18 +140,6 @@ class BentoMLConfiguration:
                     f"Failed to parse config options from the env var:\n{e}.\n*** Note: You can use '\"' to quote the key if it contains special characters. ***"
                 ) from None
             config_merger.merge(self.config, override)
-
-        if override_config_dict is not None:
-            assert isinstance(
-                override_config_dict, dict
-            ), "override_config_dict must be a dict"
-            try:
-                override = unflatten(override_config_dict)
-            except ValueError as e:
-                raise BentoMLConfigException(
-                    f"Failed to unflatten the override_config_dict:\n{e}\n ** Note: You can just simply use a non flatten dict that follows the default BentoML configuration structure."
-                ) from None
-            config_merger.merge(self.config, override_config_dict)
 
         if (
             override_config_file is not None


### PR DESCRIPTION
This PR allows user to override the default configuration with given dict when
using `load_config`

Currently, we allow this behaviour via `BENTOML_CONFIG_OPTIONS`, which is still
the current behaviour

This PR add an additional enhancement via `load_config`:

```python
from bentoml import load_config

load_config(override_config={"api_server": {"timeout": 36000000}, "runners": {"llm-dolly-v2-runner": {'timeout': 36000000}}})
```

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
