### PR TITLE
fix: make sure to only save _framework for PreTrainedModel.

### DIFF
--- a/src/bentoml/_internal/frameworks/transformers.py
+++ b/src/bentoml/_internal/frameworks/transformers.py
@@ -864,9 +864,11 @@ def save_model(
         metadata.update(
             {
                 "_pretrained_class": pretrained.__class__.__name__,
-                "_framework": pretrained.framework,
             }
         )
+        if hasattr(pretrained, "framework"):
+            # NOTE: Only PreTrainedModel and variants has this, not tokenizer.
+            metadata["_framework"] = pretrained.framework
 
         with bentoml.models.create(
             name,

--- a/src/bentoml/_internal/frameworks/transformers.py
+++ b/src/bentoml/_internal/frameworks/transformers.py
@@ -866,7 +866,14 @@ def save_model(
                 "_pretrained_class": pretrained.__class__.__name__,
             }
         )
-        if hasattr(pretrained, "framework"):
+        if hasattr(pretrained, "framework") and isinstance(
+            pretrained,
+            (
+                transformers.PreTrainedModel,
+                transformers.TFPreTrainedModel,
+                transformers.FlaxPreTrainedModel,
+            ),
+        ):
             # NOTE: Only PreTrainedModel and variants has this, not tokenizer.
             metadata["_framework"] = pretrained.framework
 


### PR DESCRIPTION
Fix saving tokenizer metadata where `pretrained.framework` is only a PreTrainedModel | TFPreTrainedModel | FlaxPreTrainedModel attribute, not tokenizer

Signed-off-by: aarnphm-ec2-dev <29749331+aarnphm@users.noreply.github.com>
