### PR TITLE
fix(metrics): make sure to return bento during build for telemetry

### DIFF
--- a/src/bentoml_cli/bentos.py
+++ b/src/bentoml_cli/bentos.py
@@ -326,6 +326,8 @@ def add_bento_management_commands(cli: Group):
             build_ctx=build_ctx,
         ).save(_bento_store)
 
+        # NOTE: Don't remove the return statement here, since we will need this
+        # for usage stats collection if users are opt-in.
         if output == "tag":
             click.echo(bento.tag)
             return bento

--- a/src/bentoml_cli/bentos.py
+++ b/src/bentoml_cli/bentos.py
@@ -328,7 +328,7 @@ def add_bento_management_commands(cli: Group):
 
         if output == "tag":
             click.echo(bento.tag)
-            return
+            return bento
 
         if not get_quiet_mode():
             click.echo(BENTOML_FIGLET)

--- a/src/bentoml_cli/bentos.py
+++ b/src/bentoml_cli/bentos.py
@@ -308,7 +308,7 @@ def add_bento_management_commands(cli: Group):
         version: str,
         output: t.Literal["tag", "default"],
         _bento_store: BentoStore = Provide[BentoMLContainer.bento_store],
-    ) -> None:
+    ):
         """Build a new Bento from current directory."""
         try:
             bentofile = resolve_user_filepath(bentofile, build_ctx)
@@ -342,3 +342,4 @@ def add_bento_management_commands(cli: Group):
                 f"\n * Push to BentoCloud with `bentoml push`:\n    $ bentoml push {bento.tag}",
                 fg="blue",
             )
+        return bento


### PR DESCRIPTION
There is a current bug (probably a regression when I wrote the subprocess build)
that CLI should return the Bento object for tracking purposes.

The events can be found under
bentoml/_internal/utils/analytics/cli_envets.py:_cli_bentoml_build_event

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
