### PR TITLE
fix(triton): default set embedded on Triton

### DIFF
--- a/src/bentoml/_internal/runner/runner.py
+++ b/src/bentoml/_internal/runner/runner.py
@@ -97,7 +97,12 @@ class AbstractRunner(ABC):
         """
 
     @abstractmethod
-    def init_client(self):
+    def init_client(
+        self,
+        handle_class: type[RunnerHandle] | None = None,
+        *args: t.Any,
+        **kwargs: t.Any,
+    ):
         """
         Initialize client for a remote runner instance. To be used within API server instance.
         """
@@ -132,7 +137,7 @@ class Runner(AbstractRunner):
     _runner_handle: RunnerHandle = attr.field(init=False, factory=DummyRunnerHandle)
 
     def _set_handle(
-        self, handle_class: type[RunnerHandle], *args: P.args, **kwargs: P.kwargs
+        self, handle_class: type[RunnerHandle], *args: t.Any, **kwargs: t.Any
     ) -> None:
         if not isinstance(self._runner_handle, DummyRunnerHandle):
             raise StateException("Runner already initialized")
@@ -309,8 +314,8 @@ class Runner(AbstractRunner):
     def init_client(
         self,
         handle_class: type[RunnerHandle] | None = None,
-        *args: P.args,
-        **kwargs: P.kwargs,
+        *args: t.Any,
+        **kwargs: t.Any,
     ):
         if handle_class is None:
             from .runner_handle.remote import RemoteRunnerClient


### PR DESCRIPTION
Fixes #3899. This is a regression from 1.0.19 when embedded is introduced.

embedded is apparently a breaking change, but since we never expose
AbstractRunner, I would assume that it won't break users custom Runner.

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
