### PR TITLE
fix(serialization): loads gpu torch tensor on cpu-only machine and revert DefaultContainer optimization

### DIFF
--- a/src/bentoml/_internal/runner/container.py
+++ b/src/bentoml/_internal/runner/container.py
@@ -10,6 +10,7 @@ from ..types import LazyType
 from ..utils import LazyLoader
 from ..utils.pickle import pep574_dumps
 from ..utils.pickle import pep574_loads
+from ..utils.pickle import fixed_torch_loads
 
 SingleType = t.TypeVar("SingleType")
 BatchType = t.TypeVar("BatchType")
@@ -478,42 +479,18 @@ class DefaultContainer(DataContainer[t.Any, t.List[t.Any]]):
         if isinstance(batch, t.Generator):  # Generators can't be pickled
             batch = list(t.cast(t.Generator[t.Any, t.Any, t.Any], batch))
 
-        meta: dict[str, bool | int | float | str | list[int]] = {"format": "pickle5"}
-
-        bs: bytes
-        concat_buffer_bs: bytes
-        indices: list[int]
-        bs, concat_buffer_bs, indices = pep574_dumps(batch)
-
-        if indices:
-            meta["with_buffer"] = True
-            data = concat_buffer_bs
-            meta["pickle_bytes_str"] = base64.b64encode(bs).decode("ascii")
-            meta["indices"] = indices
-        else:
-            meta["with_buffer"] = False
-            data = bs
+        data = pickle.dumps(batch)
 
         if isinstance(batch, list):
             batch_size = len(t.cast(t.List[t.Any], batch))
         else:
             batch_size = 1
 
-        return cls.create_payload(
-            data=data,
-            batch_size=batch_size,
-            meta=meta,
-        )
+        return cls.create_payload(data=data, batch_size=batch_size)
 
     @classmethod
     def from_payload(cls, payload: Payload) -> t.Any:
-        if payload.meta["with_buffer"]:
-            bs_str = t.cast(str, payload.meta["pickle_bytes_str"])
-            bs = base64.b64decode(bs_str)
-            indices = t.cast(t.List[int], payload.meta["indices"])
-            return pep574_loads(bs, payload.data, indices)
-        else:
-            return pep574_loads(payload.data, b"", [])
+        return fixed_torch_loads(payload.data)
 
     @classmethod
     def batch_to_payloads(

--- a/src/bentoml/_internal/utils/pickle.py
+++ b/src/bentoml/_internal/utils/pickle.py
@@ -38,7 +38,8 @@ def pep574_loads(
     main_bytes: bytes, concat_buffer_bytes: bytes, indices: list[int]
 ) -> t.Any:
     if not indices:
-        return loads_or_fix_torch(main_bytes)
+        # TODO: @larme monitor https://github.com/pytorch/pytorch/issues/102977 and may use this function later
+        return _fix_torch_loads(main_bytes)
 
     mem = memoryview(concat_buffer_bytes)
     partitions = zip(indices, indices[1:])

--- a/src/bentoml/_internal/utils/pickle.py
+++ b/src/bentoml/_internal/utils/pickle.py
@@ -48,7 +48,7 @@ def pep574_loads(
         buff = pickle.PickleBuffer(mem[slice(*partition)])
         recover_buffers.append(buff)
 
-    return pickle.loads(main_bytes, buffers=recover_buffers)
+    return _fix_torch_loads(main_bytes, buffers=recover_buffers)
 
 
 def _safe_torch_tensor_loads(bs: bytes) -> t.Any:
@@ -69,9 +69,9 @@ class FixTorchUnpickler(pickle.Unpickler):
             return super().find_class(module, name)
 
 
-def _fix_torch_loads(bs: bytes) -> t.Any:
+def _fix_torch_loads(bs: bytes, **kwargs: t.Any) -> t.Any:
     f = io.BytesIO(bs)
-    unpickler = FixTorchUnpickler(f)
+    unpickler = FixTorchUnpickler(f, **kwargs)
     return unpickler.load()
 
 

--- a/src/bentoml/_internal/utils/pickle.py
+++ b/src/bentoml/_internal/utils/pickle.py
@@ -52,7 +52,9 @@ def pep574_loads(
     main_bytes: bytes, concat_buffer_bytes: bytes, indices: list[int]
 ) -> t.Any:
     if not indices:
-        # TODO: @larme monitor https://github.com/pytorch/pytorch/issues/102977 and may use this function later
+        # TODO: @larme monitor
+        # https://github.com/pytorch/pytorch/issues/102977 and may change
+        # this function later
         return fixed_torch_loads(main_bytes)
 
     mem = memoryview(concat_buffer_bytes)

--- a/src/bentoml/_internal/utils/pickle.py
+++ b/src/bentoml/_internal/utils/pickle.py
@@ -10,8 +10,22 @@ else:
     import pickle
 
 
-# Pickle protocol 5 with out-of-band data
-# https://peps.python.org/pep-0574/
+# Pickle protocol 5 with out-of-band data. ref: https://peps.python.org/pep-0574/
+
+# This is originally intended for numpy ndarray/pandas dataframe
+# serialization.  In these situations the `main_bytes` part will only
+# contain some metadata. That's why putting these bytes in header will
+# not cause trouble. In the meantime the `concat_buffer_bytes`
+# contains out-of-band buffers that need no computation during
+# deserialization, which will save computation resource especially
+# when the payload is large. However DO NOT use this pair of functions
+# on `DefaultContainer`. Because `DefaultContainer` may be a
+# dictionary containing a large object that has no out-of-band buffer
+# (e.g. PIL Image or PyTorch tensor) and a small numpy ndarray. In
+# that case `concat_buffer_bytes` will be small and `main_bytes` may
+# be huge, hence we barely save any time while having a large header
+# (that may cause errors).
+
 def pep574_dumps(obj: t.Any) -> tuple[bytes, bytes, list[int]]:
     buffers: list[pickle.PickleBuffer] = []
     main_bytes: bytes = pickle.dumps(obj, protocol=5, buffer_callback=buffers.append)

--- a/src/bentoml/_internal/utils/pickle.py
+++ b/src/bentoml/_internal/utils/pickle.py
@@ -39,7 +39,7 @@ def pep574_loads(
 ) -> t.Any:
     if not indices:
         # TODO: @larme monitor https://github.com/pytorch/pytorch/issues/102977 and may use this function later
-        return _fix_torch_loads(main_bytes)
+        return fixed_torch_loads(main_bytes)
 
     mem = memoryview(concat_buffer_bytes)
     partitions = zip(indices, indices[1:])
@@ -48,7 +48,7 @@ def pep574_loads(
         buff = pickle.PickleBuffer(mem[slice(*partition)])
         recover_buffers.append(buff)
 
-    return _fix_torch_loads(main_bytes, buffers=recover_buffers)
+    return fixed_torch_loads(main_bytes, buffers=recover_buffers)
 
 
 def _safe_torch_tensor_loads(bs: bytes) -> t.Any:
@@ -69,7 +69,7 @@ class FixTorchUnpickler(pickle.Unpickler):
             return super().find_class(module, name)
 
 
-def _fix_torch_loads(bs: bytes, **kwargs: t.Any) -> t.Any:
+def fixed_torch_loads(bs: bytes, **kwargs: t.Any) -> t.Any:
     f = io.BytesIO(bs)
     unpickler = FixTorchUnpickler(f, **kwargs)
     return unpickler.load()
@@ -79,4 +79,4 @@ def loads_or_fix_torch(bs: bytes):
     try:
         return pickle.loads(bs)
     except RuntimeError:
-        return _fix_torch_loads(bs)
+        return fixed_torch_loads(bs)


### PR DESCRIPTION
## What does this PR address?

### fix cuda pytorch tensor unpickling in cpu-only enviornment
Try to fix the problem when unpickling a PyTorch tensor with its device set to "cuda" in a cpu-only environment (see this issue: https://github.com/pytorch/pytorch/issues/16797 for more information). This is crucial for BentoML's distribution runner because the distribution runner may run in a pod with GPU device while the api server run in cpu-only pods. Then when the runner pickle the tensor and send it to api server, the api server will meet unpickling errors.

The current strategy is to call normal unpickling function (`pickle.loads`) and only fallback to special torch tensor handling unpickler when a `RuntimeError` is raised. The other way is to call the special torch tensor handling unpickler everytime we need to unpickle bytes. The advantage of current strategy is it will handle torch tensor on device other than cuda better (the reason why https://github.com/pytorch/pytorch/pull/49920 is not accepted by PyTorch people), and it's faster than the second strategy when unpickling data other than torch tensor. The disadvantage of the current strategy is that if the `RuntimeError` is raised, catching the exception will have some performance cost. To measure the performance, I made some codes for benchmark. The repos is at https://github.com/larme/pytorch_unpickler_benchmark and a sample result is at https://docs.google.com/spreadsheets/d/17i4fXPpcamTIqzg_mMBRnyY7FzQIuXiQc7dTp_iRCkA/edit?usp=sharing

### revert `DefaultContainer` optimization

The `pep574_dumps` is originally intended for optimizing numpy ndarray/pandas dataframe serialization. In these situations the `main_bytes` part will only contain some metadata. That's why putting these bytes in header will not cause trouble. In the meantime the `concat_buffer_bytes` contains out-of-band buffers that need no computation during deserialization, which will save computation resource especially when the payload is large. 

However after optimizing ndarray/dataframe container I also want to use this pair of functions to optimize `DefaultContainer` because it may also contain large ndarray. However there's also the possiblity that `DefaultContainer` may be a dictionary/list containing a large object that has no out-of-band buffer (e.g. PIL Image or PyTorch tensor) and a small numpy ndarray. In that case `concat_buffer_bytes` will be small and `main_bytes` will be huge, hence we barely save any time while having a large header (that may cause errors).

Since `DefaultContainer` has so many possible combinations, I think we should just stick with plain pickle.dumps and pickle.loads (with pytorch cuda tensor fix) now.