### PR TITLE
improv: BentoServer can set its own timeout

### DIFF
--- a/src/bentoml/server.py
+++ b/src/bentoml/server.py
@@ -41,7 +41,6 @@ class Server(ABC):
     args: list[str]
 
     process: subprocess.Popen[bytes] | None = None
-    timeout: float = 10
     _client: Client | None = None
 
     def __init__(
@@ -57,6 +56,7 @@ class Server(ABC):
         api_workers: int | None,
         backlog: int,
         bento: str | Bento | Tag | Service | None = None,
+        timeout: float = 10,
     ):
         if bento is not None:
             if not servable:
@@ -119,6 +119,7 @@ class Server(ABC):
         self.args = args
         self.host = "127.0.0.1" if host == "0.0.0.0" else host
         self.port = port
+        self.timeout = timeout
 
     def start(
         self,
@@ -247,6 +248,7 @@ class HTTPServer(Server):
         env: t.Literal["conda"] | None = None,
         host: str = Provide[BentoMLContainer.http.host],
         port: int = Provide[BentoMLContainer.http.port],
+        timeout: float = 10,
         working_dir: str | None = None,
         api_workers: int | None = Provide[BentoMLContainer.api_server_workers],
         backlog: int = Provide[BentoMLContainer.api_server_config.backlog],
@@ -273,6 +275,7 @@ class HTTPServer(Server):
             working_dir,
             api_workers,
             backlog,
+            timeout=timeout,
         )
 
         ssl_args: dict[str, t.Any] = {
@@ -351,6 +354,7 @@ class GrpcServer(Server):
         env: t.Literal["conda"] | None = None,
         host: str = Provide[BentoMLContainer.grpc.host],
         port: int = Provide[BentoMLContainer.grpc.port],
+        timeout: float = 10,
         working_dir: str | None = None,
         api_workers: int | None = Provide[BentoMLContainer.api_server_workers],
         backlog: int = Provide[BentoMLContainer.api_server_config.backlog],
@@ -376,6 +380,7 @@ class GrpcServer(Server):
             working_dir,
             api_workers,
             backlog,
+            timeout=timeout,
         )
 
         ssl_args: dict[str, t.Any] = {


### PR DESCRIPTION
## What does this PR address?

BentoServer should be able to set timeout for different instance. Some types of server will just have longer timeout. Not sure if this pr is the best way to fix this. For example, another way is provide an argument for `Http/GrpcServer.get_client(timeout=10)`. This is open to discussion

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
