### PR TITLE
docs: document bentoml.types

### DIFF
--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -17,3 +17,4 @@ BentoML APIs and learn about all the options they provide.
   batch
   exceptions
   container
+  types

--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -1,0 +1,8 @@
+=====
+Types
+=====
+
+Miscellaneous types for BentoML APIs
+
+.. autoclass:: bentoml.types.ModelSignature
+.. autoclass:: bentoml.types.ModelSignatureDict

--- a/src/bentoml/types.py
+++ b/src/bentoml/types.py
@@ -1,7 +1,4 @@
-from typing import TYPE_CHECKING
+from ._internal.models.model import ModelSignature
+from ._internal.models.model import ModelSignatureDict
 
-if TYPE_CHECKING:
-    from ._internal.models.model import ModelSignature
-    from ._internal.models.model import ModelSignatureDict
-
-    __all__ = ["ModelSignature", "ModelSignatureDict"]
+__all__ = ["ModelSignature", "ModelSignatureDict"]


### PR DESCRIPTION
At some point we should probably move these to `bentoml.models` or something, but that would be breaking.