### PR TITLE
chore(ci): disable windows e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,6 @@ jobs:
         server_type: ['http', 'grpc']
         exclude:
           - os: windows-latest
-            server_type: 'grpc'
           - os: macos-latest
             server_type: 'grpc'
             python-version: '3.10'


### PR DESCRIPTION
Disable windows CI until we have more bandwidth to learn how to fix it.

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
