### PR TITLE
fix: http request content length parsing

### DIFF
--- a/bentoml/types.py
+++ b/bentoml/types.py
@@ -231,7 +231,7 @@ class HTTPRequest:
             return None, None, {}
         environ = {
             "wsgi.input": io.BytesIO(self.body),
-            "CONTENT_LENGTH": len(self.body),
+            "CONTENT_LENGTH": str(len(self.body)),
             "CONTENT_TYPE": self.headers.get("content-type", ""),
             "REQUEST_METHOD": "POST",
         }


### PR DESCRIPTION
## Fix HTTPRequest content length parsing issue for 0.13 LTS 

`werkzeug` library expects to receive the content length header as a string and tries to parse that string with regex to get the integer. Passing an integer instead of a string directly resulted in `TypeError`. This fix converts `len(self.body)` to string

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?

