### PR TITLE
docs: fix missing Multipart import in service.rst Composite Types section

### DIFF
--- a/docs/source/concepts/service.rst
+++ b/docs/source/concepts/service.rst
@@ -413,7 +413,7 @@ logic:
     import numpy as np
     from pydantic import BaseModel
 
-    from bentoml.io import NumpyNdarray, Json
+    from bentoml.io import Multipart, NumpyNdarray, Json
 
     class FooModel(BaseModel):
         field1: int


### PR DESCRIPTION
## What does this PR address?

Add missing Multipart import in documentation service.rst [Composite Types](https://docs.bentoml.org/en/latest/concepts/service.html#composite-types)

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [x] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
