### PR TITLE
ci: add isort to the ruff lint rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,8 @@ ci:
   autoupdate_schedule: monthly
 exclude: '.*\.(css|js|svg)$'
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.274'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 'v0.0.277'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/docs/source/frameworks/diffusers.rst
+++ b/docs/source/frameworks/diffusers.rst
@@ -18,7 +18,7 @@ You can import a pretrained diffusion model from huggingface hub or local direct
 	"sd2.1",  # model tag in BentoML model store
 	"stabilityai/stable-diffusion-2-1",  # huggingface model name
     )
-	      
+
 
 If you plan to use the model with a custom pipeline that has method other than :code:`__call__` (e.g. a :code:`StableDiffusionMegaPipeline`), you need to explicitly list them like this:
 

--- a/examples/custom_model_runner/locustfile.py
+++ b/examples/custom_model_runner/locustfile.py
@@ -1,6 +1,6 @@
-from locust import task
-from locust import between
 from locust import HttpUser
+from locust import between
+from locust import task
 
 
 class MnistTestUser(HttpUser):

--- a/examples/custom_model_runner/train.py
+++ b/examples/custom_model_runner/train.py
@@ -4,12 +4,12 @@ import argparse
 
 import net
 import torch
-import torch.optim as optim
 import torch.nn.functional as F
+import torch.optim as optim
+from torch.optim.lr_scheduler import StepLR
+from torch.utils.data import DataLoader
 from torchvision import datasets
 from torchvision import transforms
-from torch.utils.data import DataLoader
-from torch.optim.lr_scheduler import StepLR
 
 
 def train(args, model, device, train_loader, optimizer, epoch):

--- a/examples/custom_runner/nltk_pretrained_model/service.py
+++ b/examples/custom_runner/nltk_pretrained_model/service.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import time
 import typing as t
-from typing import TYPE_CHECKING
 from statistics import mean
+from typing import TYPE_CHECKING
 
 import nltk
 from nltk.sentiment import SentimentIntensityAnalyzer

--- a/examples/custom_web_serving/fastapi_example/train.py
+++ b/examples/custom_web_serving/fastapi_example/train.py
@@ -1,8 +1,8 @@
 import logging
 
 import pandas as pd
-from sklearn import svm
 from sklearn import datasets
+from sklearn import svm
 
 import bentoml
 

--- a/examples/custom_web_serving/flask_example/train.py
+++ b/examples/custom_web_serving/flask_example/train.py
@@ -1,7 +1,7 @@
 import logging
 
-from sklearn import svm
 from sklearn import datasets
+from sklearn import svm
 
 import bentoml
 

--- a/examples/flax/MNIST/tests/conftest.py
+++ b/examples/flax/MNIST/tests/conftest.py
@@ -1,26 +1,26 @@
 from __future__ import annotations
 
+import contextlib
 import os
+import subprocess
 import sys
 import typing as t
-import contextlib
-import subprocess
 from typing import TYPE_CHECKING
 
 import psutil
 import pytest
 
 import bentoml
-from bentoml.testing.server import host_bento
 from bentoml._internal.configuration.containers import BentoMLContainer
+from bentoml.testing.server import host_bento
 
 if TYPE_CHECKING:
     from contextlib import ExitStack
 
-    from _pytest.main import Session
-    from _pytest.nodes import Item
     from _pytest.config import Config
     from _pytest.fixtures import FixtureRequest as _PytestFixtureRequest
+    from _pytest.main import Session
+    from _pytest.nodes import Item
 
     class FixtureRequest(_PytestFixtureRequest):
         param: str

--- a/examples/flax/MNIST/tests/test_endpoints.py
+++ b/examples/flax/MNIST/tests/test_endpoints.py
@@ -7,8 +7,8 @@ import numpy as np
 import pytest
 
 import bentoml
-from bentoml.testing.grpc import create_channel
 from bentoml.testing.grpc import async_client_call
+from bentoml.testing.grpc import create_channel
 
 if t.TYPE_CHECKING:
     import jax.numpy as jnp

--- a/examples/flax/MNIST/train.py
+++ b/examples/flax/MNIST/train.py
@@ -1,17 +1,17 @@
 # modified from https://github.com/google/flax/blob/main/examples/mnist/README.md
 from __future__ import annotations
 
+import argparse
 import os
 import typing as t
-import argparse
 from typing import TYPE_CHECKING
 
-import jax
 import attrs
+import cattrs
+import jax
+import jax.numpy as jnp
 import numpy as np
 import optax
-import cattrs
-import jax.numpy as jnp
 import tensorflow_datasets as tfds
 from flax import linen as nn
 from flax import serialization

--- a/examples/fraud_detection/benchmark/fastapi_main_load_model.py
+++ b/examples/fraud_detection/benchmark/fastapi_main_load_model.py
@@ -2,9 +2,9 @@ import io
 
 import numpy as np
 import pandas as pd
-from sample import sample_input
 from fastapi import FastAPI
 from fastapi import Request
+from sample import sample_input
 
 import bentoml
 

--- a/examples/fraud_detection/benchmark/fastapi_main_local_runner.py
+++ b/examples/fraud_detection/benchmark/fastapi_main_local_runner.py
@@ -2,9 +2,9 @@ import io
 
 import numpy as np
 import pandas as pd
-from sample import sample_input
 from fastapi import FastAPI
 from fastapi import Request
+from sample import sample_input
 
 import bentoml
 

--- a/examples/fraud_detection/benchmark/locustfile.py
+++ b/examples/fraud_detection/benchmark/locustfile.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pandas as pd
-from locust import task
-from locust import between
 from locust import HttpUser
+from locust import between
+from locust import task
 
 NUM_OF_ROWS = 500
 test_transactions = pd.read_csv("../data/test_transaction.csv")[0:NUM_OF_ROWS]

--- a/examples/kfserving/train.py
+++ b/examples/kfserving/train.py
@@ -1,7 +1,7 @@
 import logging
 
-from sklearn import svm
 from sklearn import datasets
+from sklearn import svm
 
 import bentoml
 

--- a/examples/mlflow/keras/train.py
+++ b/examples/mlflow/keras/train.py
@@ -2,17 +2,16 @@
 on the Reuters newswire topic classification task.
 """
 # pylint: disable=no-name-in-module
-import numpy as np
-
 # The following import and function call are the only additions to code required
 # to automatically log metrics and parameters to MLflow.
 import mlflow.keras
+import numpy as np
 from tensorflow import keras
+from tensorflow.keras.datasets import reuters
+from tensorflow.keras.layers import Activation
 from tensorflow.keras.layers import Dense
 from tensorflow.keras.layers import Dropout
-from tensorflow.keras.layers import Activation
 from tensorflow.keras.models import Sequential
-from tensorflow.keras.datasets import reuters
 from tensorflow.keras.preprocessing.text import Tokenizer
 
 import bentoml

--- a/examples/mlflow/lightgbm/train.py
+++ b/examples/mlflow/lightgbm/train.py
@@ -1,12 +1,12 @@
 import argparse
 
-import mlflow
 import lightgbm as lgb
 import matplotlib as mpl
+import mlflow
 import mlflow.lightgbm
 from sklearn import datasets
-from sklearn.metrics import log_loss
 from sklearn.metrics import accuracy_score
+from sklearn.metrics import log_loss
 from sklearn.model_selection import train_test_split
 
 import bentoml

--- a/examples/mlflow/pytorch/mnist.py
+++ b/examples/mlflow/pytorch/mnist.py
@@ -11,15 +11,15 @@
 #
 # BentoML example is based on https://github.com/mlflow/mlflow/blob/master/examples/pytorch/mnist_tensorboard_artifact.py
 #
-import os
 import argparse
+import os
 
-import torch
 import mlflow
-import torch.nn as nn
-import torch.optim as optim
 import mlflow.pytorch
+import torch
+import torch.nn as nn
 import torch.nn.functional as F
+import torch.optim as optim
 from torchvision import datasets
 from torchvision import transforms
 

--- a/examples/mlflow/sklearn_autolog/grid_search_cv.py
+++ b/examples/mlflow/sklearn_autolog/grid_search_cv.py
@@ -2,10 +2,10 @@ from pprint import pprint
 
 import mlflow
 import pandas as pd
-from utils import fetch_logged_data
-from sklearn import svm
 from sklearn import datasets
+from sklearn import svm
 from sklearn.model_selection import GridSearchCV
+from utils import fetch_logged_data
 
 import bentoml
 

--- a/examples/mlflow/sklearn_autolog/linear_regression.py
+++ b/examples/mlflow/sklearn_autolog/linear_regression.py
@@ -1,9 +1,9 @@
 from pprint import pprint
 
-import numpy as np
 import mlflow
-from utils import fetch_logged_data
+import numpy as np
 from sklearn.linear_model import LinearRegression
+from utils import fetch_logged_data
 
 import bentoml
 

--- a/examples/mlflow/sklearn_autolog/pipeline.py
+++ b/examples/mlflow/sklearn_autolog/pipeline.py
@@ -1,11 +1,11 @@
 from pprint import pprint
 
-import numpy as np
 import mlflow
-from utils import fetch_logged_data
-from sklearn.pipeline import Pipeline
+import numpy as np
 from sklearn.linear_model import LinearRegression
+from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
+from utils import fetch_logged_data
 
 import bentoml
 

--- a/examples/mlflow/sklearn_logistic_regression/train.py
+++ b/examples/mlflow/sklearn_logistic_regression/train.py
@@ -1,6 +1,6 @@
-import numpy as np
 import mlflow
 import mlflow.sklearn
+import numpy as np
 from sklearn.linear_model import LogisticRegression
 
 import bentoml

--- a/examples/mlflow/torchscript/IrisClassification/iris_classification.py
+++ b/examples/mlflow/torchscript/IrisClassification/iris_classification.py
@@ -1,13 +1,13 @@
 # pylint: disable=abstract-method,redefined-outer-name
 import argparse
 
+import mlflow.pytorch
 import numpy as np
 import torch
 import torch.nn as nn
-import mlflow.pytorch
 import torch.nn.functional as F
-from sklearn.metrics import accuracy_score
 from sklearn.datasets import load_iris
+from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
 
 import bentoml

--- a/examples/mlflow/torchscript/MNIST/mnist_torchscript.py
+++ b/examples/mlflow/torchscript/MNIST/mnist_torchscript.py
@@ -2,16 +2,16 @@
 
 import argparse
 
+import mlflow
+import mlflow.pytorch
 import numpy as np
 import torch
-import mlflow
 import torch.nn as nn
-import torch.optim as optim
-import mlflow.pytorch
 import torch.nn.functional as F
+import torch.optim as optim
+from torch.optim.lr_scheduler import StepLR
 from torchvision import datasets
 from torchvision import transforms
-from torch.optim.lr_scheduler import StepLR
 
 import bentoml
 

--- a/examples/monitoring/task_classification/locustfile.py
+++ b/examples/monitoring/task_classification/locustfile.py
@@ -1,7 +1,7 @@
 import numpy as np
-from locust import task
-from locust import between
 from locust import HttpUser
+from locust import between
+from locust import task
 from sklearn import datasets
 
 test_data = datasets.load_iris().data

--- a/examples/monitoring/task_classification/service.py
+++ b/examples/monitoring/task_classification/service.py
@@ -5,8 +5,8 @@ import os
 import numpy as np
 
 import bentoml
-from bentoml.io import Text
 from bentoml.io import NumpyNdarray
+from bentoml.io import Text
 
 CLASS_NAMES = ["setosa", "versicolor", "virginica"]
 

--- a/examples/monitoring/task_classification/tests/conftest.py
+++ b/examples/monitoring/task_classification/tests/conftest.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import contextlib
 import os
+import subprocess
 import sys
 import typing as t
-import contextlib
-import subprocess
 from pathlib import Path
 
 import numpy as np
@@ -14,11 +14,11 @@ import bentoml
 from bentoml._internal.configuration.containers import BentoMLContainer
 
 if t.TYPE_CHECKING:
+    from _pytest.config import Config
+    from _pytest.fixtures import FixtureRequest
     from _pytest.main import Session
     from _pytest.nodes import Item
-    from _pytest.config import Config
     from _pytest.tmpdir import TempPathFactory
-    from _pytest.fixtures import FixtureRequest
 
 PROJECT_DIR = Path(__file__).parent.parent
 

--- a/examples/monitoring/task_classification/train.py
+++ b/examples/monitoring/task_classification/train.py
@@ -1,7 +1,7 @@
 import logging
 
-from sklearn import svm
 from sklearn import datasets
+from sklearn import svm
 
 import bentoml
 

--- a/examples/pydantic_validation/train.py
+++ b/examples/pydantic_validation/train.py
@@ -1,8 +1,8 @@
 import logging
 
 import pandas as pd
-from sklearn import svm
 from sklearn import datasets
+from sklearn import svm
 
 import bentoml
 

--- a/examples/pytorch_mnist/locustfile.py
+++ b/examples/pytorch_mnist/locustfile.py
@@ -1,6 +1,6 @@
-from locust import task
-from locust import between
 from locust import HttpUser
+from locust import between
+from locust import task
 
 with open("samples/1.png", "rb") as f:
     test_image_bytes = f.read()

--- a/examples/pytorch_mnist/tests/conftest.py
+++ b/examples/pytorch_mnist/tests/conftest.py
@@ -9,8 +9,8 @@ from bentoml.testing.server import host_bento
 
 def pytest_configure(config):  # pylint: disable=unused-argument
     import os
-    import sys
     import subprocess
+    import sys
 
     cmd = f"{sys.executable} {os.path.join(os.getcwd(), 'train.py')} --k-folds=0"
     subprocess.run(cmd, shell=True, check=True)

--- a/examples/pytorch_mnist/train.py
+++ b/examples/pytorch_mnist/train.py
@@ -1,15 +1,15 @@
 # pylint: disable=redefined-outer-name
+import argparse
 import os
 import random
-import argparse
 
 import model as models
 import numpy as np
 import torch
+from sklearn.model_selection import KFold
 from torch import nn
 from torchvision import transforms
 from torchvision.datasets import MNIST
-from sklearn.model_selection import KFold
 
 import bentoml
 

--- a/examples/quickstart/locustfile.py
+++ b/examples/quickstart/locustfile.py
@@ -2,10 +2,10 @@ import time
 
 import grpc
 import numpy as np
-from locust import task
+from locust import HttpUser
 from locust import User
 from locust import between
-from locust import HttpUser
+from locust import task
 from sklearn import datasets
 
 from bentoml.grpc.v1 import service_pb2 as pb

--- a/examples/quickstart/train.py
+++ b/examples/quickstart/train.py
@@ -1,7 +1,7 @@
 import logging
 
-from sklearn import svm
 from sklearn import datasets
+from sklearn import svm
 
 import bentoml
 

--- a/examples/sklearn/pipeline/train.py
+++ b/examples/sklearn/pipeline/train.py
@@ -1,13 +1,13 @@
 import logging
-from time import time
 from pprint import pprint
+from time import time
 
 from sklearn.datasets import fetch_20newsgroups
-from sklearn.pipeline import Pipeline
-from sklearn.linear_model import SGDClassifier
-from sklearn.model_selection import GridSearchCV
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.feature_extraction.text import TfidfTransformer
+from sklearn.linear_model import SGDClassifier
+from sklearn.model_selection import GridSearchCV
+from sklearn.pipeline import Pipeline
 
 import bentoml
 

--- a/examples/tensorflow2_keras/locustfile.py
+++ b/examples/tensorflow2_keras/locustfile.py
@@ -1,6 +1,6 @@
-from locust import task
-from locust import between
 from locust import HttpUser
+from locust import between
+from locust import task
 
 with open("samples/0.png", "rb") as f:
     test_image_bytes = f.read()

--- a/examples/tensorflow2_keras/tests/conftest.py
+++ b/examples/tensorflow2_keras/tests/conftest.py
@@ -1,8 +1,8 @@
 # pylint: disable=redefined-outer-name
 
-import typing as t
 import pathlib
 import subprocess
+import typing as t
 
 import pytest
 

--- a/examples/tensorflow2_keras/tests/test_prediction.py
+++ b/examples/tensorflow2_keras/tests/test_prediction.py
@@ -1,8 +1,8 @@
 # pylint: disable=redefined-outer-name
 # type: ignore[no-untyped-def]
 
-import json
 import asyncio
+import json
 
 import numpy as np
 import pytest

--- a/examples/tensorflow2_keras/train.py
+++ b/examples/tensorflow2_keras/train.py
@@ -1,8 +1,8 @@
 # pylint: disable=no-name-in-module,redefined-outer-name,abstract-method
 import tensorflow as tf
 from tensorflow.keras import Model
-from tensorflow.keras.layers import Dense
 from tensorflow.keras.layers import Conv2D
+from tensorflow.keras.layers import Dense
 from tensorflow.keras.layers import Flatten
 
 import bentoml

--- a/examples/tensorflow2_native/locustfile.py
+++ b/examples/tensorflow2_native/locustfile.py
@@ -1,6 +1,6 @@
-from locust import task
-from locust import between
 from locust import HttpUser
+from locust import between
+from locust import task
 
 with open("samples/0.png", "rb") as f:
     test_image_bytes = f.read()

--- a/examples/tensorflow2_native/tests/conftest.py
+++ b/examples/tensorflow2_native/tests/conftest.py
@@ -1,8 +1,8 @@
 # pylint: disable=redefined-outer-name
 
-import typing as t
 import pathlib
 import subprocess
+import typing as t
 
 import pytest
 

--- a/examples/tensorflow2_native/tests/test_prediction.py
+++ b/examples/tensorflow2_native/tests/test_prediction.py
@@ -1,8 +1,8 @@
 # pylint: disable=redefined-outer-name
 # type: ignore[no-untyped-def]
 
-import json
 import asyncio
+import json
 
 import numpy as np
 import pytest

--- a/examples/tensorflow2_native/train.py
+++ b/examples/tensorflow2_native/train.py
@@ -1,7 +1,7 @@
 # pylint: disable=no-name-in-module,redefined-outer-name,abstract-method
 import tensorflow as tf
-from tensorflow.keras.layers import Dense
 from tensorflow.keras.layers import Conv2D
+from tensorflow.keras.layers import Dense
 from tensorflow.keras.layers import Flatten
 
 import bentoml

--- a/examples/triton/onnx/build_bento.py
+++ b/examples/triton/onnx/build_bento.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
+import argparse
 import os
 import typing as t
-import argparse
 
 import attr
 import torch
 
 import bentoml
 from bentoml import Bento
-from bentoml._internal.utils import resolve_user_filepath
 from bentoml._internal.bento.build_config import BentoBuildConfig
 from bentoml._internal.configuration.containers import BentoMLContainer
+from bentoml._internal.utils import resolve_user_filepath
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/examples/triton/onnx/helpers.py
+++ b/examples/triton/onnx/helpers.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import os
 import json
+import os
 import time
 import typing as t
 from pathlib import Path
 
-import cv2
 import attr
+import cv2
 import numpy as np
 import torch
 import torchvision

--- a/examples/triton/onnx/locustfile.py
+++ b/examples/triton/onnx/locustfile.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from locust import task
-from locust import constant
 from locust import HttpUser
+from locust import constant
+from locust import task
 
 
 class TritonOnnxYolov5User(HttpUser):

--- a/examples/triton/onnx/serve_bento.py
+++ b/examples/triton/onnx/serve_bento.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 if __name__ == "__main__":
-    import time
     import argparse
+    import time
 
     import bentoml
 

--- a/examples/triton/onnx/service.py
+++ b/examples/triton/onnx/service.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import typing as t
 
-import torch
 import helpers
+import torch
 
 import bentoml
 

--- a/examples/triton/pytorch/build_bento.py
+++ b/examples/triton/pytorch/build_bento.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
+import argparse
 import os
 import typing as t
-import argparse
 
 import attr
 import torch
 
 import bentoml
 from bentoml import Bento
-from bentoml._internal.utils import resolve_user_filepath
 from bentoml._internal.bento.build_config import BentoBuildConfig
 from bentoml._internal.configuration.containers import BentoMLContainer
+from bentoml._internal.utils import resolve_user_filepath
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/examples/triton/pytorch/helpers.py
+++ b/examples/triton/pytorch/helpers.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import os
 import json
+import os
 import time
 import typing as t
 from pathlib import Path
 
-import cv2
 import attr
+import cv2
 import numpy as np
 import torch
 import torchvision

--- a/examples/triton/pytorch/locustfile.py
+++ b/examples/triton/pytorch/locustfile.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from locust import task
-from locust import constant
 from locust import HttpUser
+from locust import constant
+from locust import task
 
 
 class TritonTorchscriptYolov5User(HttpUser):

--- a/examples/triton/pytorch/serve_bento.py
+++ b/examples/triton/pytorch/serve_bento.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 if __name__ == "__main__":
-    import time
     import argparse
+    import time
 
     import bentoml
 

--- a/examples/triton/pytorch/service.py
+++ b/examples/triton/pytorch/service.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import typing as t
 
-import torch
 import helpers
+import torch
 
 import bentoml
 

--- a/examples/triton/tensorflow/build_bento.py
+++ b/examples/triton/tensorflow/build_bento.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
+import argparse
 import os
 import typing as t
-import argparse
 
 import attr
 import torch
 
 import bentoml
 from bentoml import Bento
-from bentoml._internal.utils import resolve_user_filepath
 from bentoml._internal.bento.build_config import BentoBuildConfig
 from bentoml._internal.configuration.containers import BentoMLContainer
+from bentoml._internal.utils import resolve_user_filepath
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/examples/triton/tensorflow/helpers.py
+++ b/examples/triton/tensorflow/helpers.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import os
 import json
+import os
 import time
 import typing as t
 from pathlib import Path
 
-import cv2
 import attr
+import cv2
 import numpy as np
 import torch
 import torchvision

--- a/examples/triton/tensorflow/locustfile.py
+++ b/examples/triton/tensorflow/locustfile.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from locust import task
-from locust import constant
 from locust import HttpUser
+from locust import constant
+from locust import task
 
 
 class TritonTensorflowYolov5User(HttpUser):

--- a/examples/triton/tensorflow/serve_bento.py
+++ b/examples/triton/tensorflow/serve_bento.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 if __name__ == "__main__":
-    import time
     import argparse
+    import time
 
     import bentoml
 

--- a/examples/triton/tensorflow/service.py
+++ b/examples/triton/tensorflow/service.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import typing as t
 
+import helpers
 import numpy as np
 import torch
-import helpers
 
 import bentoml
 

--- a/examples/tutorial/init_model.py
+++ b/examples/tutorial/init_model.py
@@ -1,5 +1,6 @@
-import bentoml
 import transformers
+
+import bentoml
 
 pipe = transformers.pipeline("text-classification")
 

--- a/examples/xgboost/locustfile.py
+++ b/examples/xgboost/locustfile.py
@@ -1,7 +1,7 @@
 import numpy as np
-from locust import task
-from locust import between
 from locust import HttpUser
+from locust import between
+from locust import task
 from sklearn.datasets import load_svmlight_file
 
 test_data = load_svmlight_file("data/agaricus.txt.train")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ testpaths = ["tests"]
 line-length = 88
 # We ignore E501 (line too long) here because we keep user-visible strings on one line.
 ignore = ["E501"]
+extend-select = ["I"]
 exclude = [
     "bazel-*/",
     "venv",

--- a/src/bentoml/__init__.py
+++ b/src/bentoml/__init__.py
@@ -17,71 +17,71 @@ And join us in the BentoML slack community: https://l.bentoml.com/join-slack
 
 from typing import TYPE_CHECKING
 
+from ._internal.configuration import BENTOML_VERSION as __version__
 from ._internal.configuration import load_config
 from ._internal.configuration import save_config
-from ._internal.configuration import BENTOML_VERSION as __version__
 from ._internal.configuration import set_serialization_strategy
 
 # Inject dependencies and configurations
 load_config()
 
+# BentoML built-in types
+from ._internal.bento import Bento
+from ._internal.cloud import YataiClient
+from ._internal.context import ServiceContext as Context
+from ._internal.models import Model
+from ._internal.monitoring import monitor
+from ._internal.runner import Runnable
+from ._internal.runner import Runner
+from ._internal.service import Service
+from ._internal.service.loader import load
+from ._internal.tag import Tag
+from ._internal.utils.http import Cookie
+
 # Bento management APIs
+from .bentos import delete
+from .bentos import export_bento
 from .bentos import get
+from .bentos import import_bento
 from .bentos import list  # pylint: disable=W0622
 from .bentos import pull
 from .bentos import push
 from .bentos import serve
-from .bentos import delete
-from .bentos import export_bento
-from .bentos import import_bento
 
 # server API
 from .server import GrpcServer
 from .server import HTTPServer
 
-# BentoML built-in types
-from ._internal.tag import Tag
-from ._internal.bento import Bento
-from ._internal.models import Model
-from ._internal.runner import Runner
-from ._internal.runner import Runnable
-from ._internal.context import ServiceContext as Context
-from ._internal.service import Service
-from ._internal.monitoring import monitor
-from ._internal.utils.http import Cookie
-from ._internal.cloud import YataiClient
-from ._internal.service.loader import load
-
 # Framework specific modules, model management and IO APIs are lazily loaded upon import.
 if TYPE_CHECKING:
-    from . import h2o
-    from . import ray
-    from . import flax
-    from . import onnx
-    from . import gluon
-    from . import keras
-    from . import spacy
-    from . import fastai
-    from . import mlflow
-    from . import paddle
-    from . import triton
-    from . import easyocr
-    from . import pycaret
-    from . import pytorch
-    from . import sklearn
-    from . import xgboost
     from . import catboost
-    from . import lightgbm
-    from . import onnxmlir
     from . import detectron
     from . import diffusers
-    from . import tensorflow
+    from . import easyocr
+    from . import fastai
+    from . import flax
+    from . import gluon
+    from . import h2o
+    from . import keras
+    from . import lightgbm
+    from . import mlflow
+    from . import onnx
+    from . import onnxmlir
+    from . import paddle
+    from . import picklable_model
+    from . import pycaret
+    from . import pytorch
+    from . import pytorch_lightning
+    from . import ray
+    from . import sklearn
+    from . import spacy
     from . import statsmodels
+    from . import tensorflow
+    from . import tensorflow_v1
     from . import torchscript
     from . import transformers
-    from . import tensorflow_v1
-    from . import picklable_model
-    from . import pytorch_lightning
+    from . import triton
+    from . import xgboost
 
     # isort: off
     from . import io

--- a/src/bentoml/_internal/batch/spark.py
+++ b/src/bentoml/_internal/batch/spark.py
@@ -1,22 +1,22 @@
 from __future__ import annotations
 
-import typing as t
 import logging
 import os.path
 import tempfile
+import typing as t
 from typing import TYPE_CHECKING
 
 from bentoml._internal.utils import reserve_free_port
 
-from ..tag import Tag
-from ..bento import Bento
-from ...bentos import serve
 from ...bentos import import_bento
+from ...bentos import serve
 from ...client import Client
 from ...client import HTTPClient
 from ...exceptions import BentoMLException
 from ...exceptions import MissingDependencyException
+from ..bento import Bento
 from ..service.loader import load_bento
+from ..tag import Tag
 
 try:
     from pyspark.files import SparkFiles
@@ -27,8 +27,8 @@ except ImportError:  # pragma: no cover (trivial error)
     )
 
 if TYPE_CHECKING:
-    import pyspark.sql.session
     import pyspark.sql.dataframe
+    import pyspark.sql.session
 
     RecordBatch: t.TypeAlias = t.Any  # pyarrow doesn't have type annotations
 

--- a/src/bentoml/_internal/bento/bento.py
+++ b/src/bentoml/_internal/bento/bento.py
@@ -1,45 +1,46 @@
 from __future__ import annotations
 
+import logging
 import os
 import typing as t
-import logging
-from typing import TYPE_CHECKING
 from datetime import datetime
 from datetime import timezone
+from typing import TYPE_CHECKING
 
-import fs
 import attr
-import yaml
-import fs.osfs
+import fs
 import fs.errors
 import fs.mirror
+import fs.osfs
 import fs.walk
-from fs.copy import copy_file
-from cattr.gen import override
+import yaml
 from cattr.gen import make_dict_structure_fn
 from cattr.gen import make_dict_unstructure_fn
-from simple_di import inject
+from cattr.gen import override
+from fs.copy import copy_file
 from simple_di import Provide
+from simple_di import inject
 
-from ..tag import Tag
-from ..store import Store
-from ..store import StoreItem
-from ..types import PathType
-from ..utils import bentoml_cattr
-from ..utils import encode_path_for_uri
-from ..utils import copy_file_to_fs_folder
-from ..utils import normalize_labels_value
-from ..models import ModelStore, copy_model
-from ..runner import Runner
-from ...exceptions import InvalidArgument
 from ...exceptions import BentoMLException
-from .build_config import CondaOptions
-from .build_config import BentoPathSpec
-from .build_config import DockerOptions
-from .build_config import PythonOptions
-from .build_config import BentoBuildConfig
+from ...exceptions import InvalidArgument
 from ..configuration import BENTOML_VERSION
 from ..configuration.containers import BentoMLContainer
+from ..models import ModelStore
+from ..models import copy_model
+from ..runner import Runner
+from ..store import Store
+from ..store import StoreItem
+from ..tag import Tag
+from ..types import PathType
+from ..utils import bentoml_cattr
+from ..utils import copy_file_to_fs_folder
+from ..utils import encode_path_for_uri
+from ..utils import normalize_labels_value
+from .build_config import BentoBuildConfig
+from .build_config import BentoPathSpec
+from .build_config import CondaOptions
+from .build_config import DockerOptions
+from .build_config import PythonOptions
 
 if TYPE_CHECKING:
     from fs.base import FS

--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -1,37 +1,37 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
+import subprocess
 import sys
 import typing as t
-import logging
-import subprocess
-from sys import version_info
 from shlex import quote
+from sys import version_info
 
-import fs
 import attr
-import yaml
-import psutil
+import fs
 import fs.copy
+import psutil
+import yaml
 from pathspec import PathSpec
 
-from ..utils import bentoml_cattr
-from ..utils import resolve_user_filepath
-from ..utils import copy_file_to_fs_folder
-from ..container import generate_containerfile
-from ...exceptions import InvalidArgument
 from ...exceptions import BentoMLException
-from ..utils.dotenv import parse_dotenv
+from ...exceptions import InvalidArgument
 from ..configuration import CLEAN_BENTOML_VERSION
-from ..container.generate import BENTO_PATH
-from .build_dev_bentoml_whl import build_bentoml_editable_wheel
+from ..container import generate_containerfile
+from ..container.frontend.dockerfile import ALLOWED_CUDA_VERSION_ARGS
+from ..container.frontend.dockerfile import CONTAINER_SUPPORTED_DISTROS
+from ..container.frontend.dockerfile import SUPPORTED_CUDA_VERSIONS
+from ..container.frontend.dockerfile import SUPPORTED_PYTHON_VERSIONS
 from ..container.frontend.dockerfile import DistroSpec
 from ..container.frontend.dockerfile import get_supported_spec
-from ..container.frontend.dockerfile import SUPPORTED_CUDA_VERSIONS
-from ..container.frontend.dockerfile import ALLOWED_CUDA_VERSION_ARGS
-from ..container.frontend.dockerfile import SUPPORTED_PYTHON_VERSIONS
-from ..container.frontend.dockerfile import CONTAINER_SUPPORTED_DISTROS
+from ..container.generate import BENTO_PATH
+from ..utils import bentoml_cattr
+from ..utils import copy_file_to_fs_folder
+from ..utils import resolve_user_filepath
+from ..utils.dotenv import parse_dotenv
+from .build_dev_bentoml_whl import build_bentoml_editable_wheel
 
 if t.TYPE_CHECKING:
     from attr import Attribute

--- a/src/bentoml/_internal/bento/build_dev_bentoml_whl.py
+++ b/src/bentoml/_internal/bento/build_dev_bentoml_whl.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import os
 import logging
+import os
 from pathlib import Path
 
-from ..utils.pkg import source_locations
 from ...exceptions import BentoMLException
 from ...exceptions import MissingDependencyException
 from ...grpc.utils import LATEST_PROTOCOL_VERSION
 from ..configuration import is_pypi_installed_bentoml
+from ..utils.pkg import source_locations
 
 logger = logging.getLogger(__name__)
 
@@ -35,9 +35,8 @@ def build_bentoml_editable_wheel(
         # different from build. However, isort sometimes
         # incorrectly re-order the imports order.
         # isort: off
-        from build.env import IsolatedEnvBuilder
-
         from build import ProjectBuilder
+        from build.env import IsolatedEnvBuilder
 
         # isort: on
     except ModuleNotFoundError as e:

--- a/src/bentoml/_internal/client/__init__.py
+++ b/src/bentoml/_internal/client/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import typing as t
 import asyncio
-import logging
 import functools
+import logging
+import typing as t
 from abc import ABC
 from abc import abstractmethod
 from http.client import BadStatusLine
@@ -16,9 +16,9 @@ logger = logging.getLogger(__name__)
 if t.TYPE_CHECKING:
     from types import TracebackType
 
+    from ..service import Service
     from .grpc import GrpcClient
     from .http import HTTPClient
-    from ..service import Service
 
 
 class Client(ABC):

--- a/src/bentoml/_internal/client/grpc.py
+++ b/src/bentoml/_internal/client/grpc.py
@@ -1,24 +1,24 @@
 from __future__ import annotations
 
+import functools
+import logging
 import time
 import typing as t
-import logging
-import functools
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 from packaging.version import parse
 
-from . import Client
-from .. import io_descriptors
-from ..utils import LazyLoader
-from functools import cached_property
-from ..service import Service
 from ...exceptions import BentoMLException
+from ...grpc.utils import LATEST_PROTOCOL_VERSION
+from ...grpc.utils import import_generated_stubs
 from ...grpc.utils import import_grpc
 from ...grpc.utils import load_from_file
-from ...grpc.utils import import_generated_stubs
-from ...grpc.utils import LATEST_PROTOCOL_VERSION
+from .. import io_descriptors
+from ..service import Service
 from ..service.inference_api import InferenceAPI
+from ..utils import LazyLoader
+from . import Client
 
 logger = logging.getLogger(__name__)
 
@@ -27,14 +27,14 @@ REFLECTION_EXC_MESSAGE = "'grpcio-reflection' is required to use gRPC Client. In
 
 if TYPE_CHECKING:
     import grpc
+    from google.protobuf import json_format as _json_format
     from grpc import aio
     from grpc._channel import Channel as GrpcSyncChannel
     from grpc_health.v1 import health_pb2 as pb_health
-    from google.protobuf import json_format as _json_format
 
-    from ..types import PathType
     from ...grpc.v1.service_pb2 import Response
     from ...grpc.v1.service_pb2 import ServiceMetadataResponse
+    from ..types import PathType
 
     class ClientCredentials(t.TypedDict):
         root_certificates: t.NotRequired[PathType | bytes]

--- a/src/bentoml/_internal/client/http.py
+++ b/src/bentoml/_internal/client/http.py
@@ -1,27 +1,27 @@
 from __future__ import annotations
 
-import json
-import time
-import socket
-import typing as t
 import asyncio
+import json
 import logging
+import socket
+import time
+import typing as t
 import urllib.error
 import urllib.request
 from http.client import HTTPConnection
 from urllib.parse import urlparse
 
 import aiohttp
-import starlette.requests
 import starlette.datastructures
+import starlette.requests
 
-from . import Client
-from .. import io_descriptors as io
-from ..service import Service
-from ...exceptions import RemoteException
 from ...exceptions import BentoMLException
+from ...exceptions import RemoteException
+from .. import io_descriptors as io
 from ..configuration import get_debug_mode
+from ..service import Service
 from ..service.inference_api import InferenceAPI
+from . import Client
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/cloud/__init__.py
+++ b/src/bentoml/_internal/cloud/__init__.py
@@ -1,4 +1,4 @@
 from .base import CloudClient as CloudClient
 from .bentocloud import BentoCloudClient as BentoCloudClient
-from .yatai import YataiClient as YataiClient
 from .deployment import Resource as Resource
+from .yatai import YataiClient as YataiClient

--- a/src/bentoml/_internal/cloud/base.py
+++ b/src/bentoml/_internal/cloud/base.py
@@ -3,25 +3,25 @@ from __future__ import annotations
 import typing as t
 from abc import ABC
 from abc import abstractmethod
-from functools import wraps
 from contextlib import contextmanager
+from functools import wraps
 
-from rich.panel import Panel
 from rich.console import Group
-from rich.progress import Progress
+from rich.panel import Panel
 from rich.progress import BarColumn
-from rich.progress import TextColumn
-from rich.progress import SpinnerColumn
 from rich.progress import DownloadColumn
+from rich.progress import Progress
+from rich.progress import SpinnerColumn
+from rich.progress import TextColumn
 from rich.progress import TimeElapsedColumn
 from rich.progress import TimeRemainingColumn
 from rich.progress import TransferSpeedColumn
 
-from ..tag import Tag
 from ..bento import Bento
 from ..bento import BentoStore
 from ..models import Model
 from ..models import ModelStore
+from ..tag import Tag
 
 FILE_CHUNK_SIZE = 100 * 1024 * 1024  # 100Mb
 

--- a/src/bentoml/_internal/cloud/bentocloud.py
+++ b/src/bentoml/_internal/cloud/bentocloud.py
@@ -1,55 +1,55 @@
 from __future__ import annotations
 
 import io
-import typing as t
 import tarfile
 import tempfile
-import warnings
 import threading
+import typing as t
+import warnings
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from concurrent.futures import ThreadPoolExecutor
 
 import fs
 import requests
 from rich.live import Live
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
-from ..tag import Tag
+from ...exceptions import BentoMLException
+from ...exceptions import NotFound
 from ..bento import Bento
 from ..bento import BentoStore
-from ..utils import calc_dir_size
-from .config import get_rest_api_client
+from ..configuration.containers import BentoMLContainer
 from ..models import Model
-from ..models import copy_model
 from ..models import ModelStore
-from .schemas import BentoApiSchema
-from .schemas import LabelItemSchema
-from .schemas import BentoRunnerSchema
-from .schemas import BentoUploadStatus
-from .schemas import CreateBentoSchema
-from .schemas import CreateModelSchema
-from .schemas import ModelUploadStatus
-from .schemas import UpdateBentoSchema
-from .schemas import CompletePartSchema
-from .schemas import BentoManifestSchema
-from .schemas import ModelManifestSchema
-from .schemas import TransmissionStrategy
-from .schemas import FinishUploadBentoSchema
-from .schemas import FinishUploadModelSchema
-from .schemas import BentoRunnerResourceSchema
-from .schemas import CreateBentoRepositorySchema
-from .schemas import CreateModelRepositorySchema
-from .schemas import CompleteMultipartUploadSchema
-from .schemas import PreSignMultipartUploadUrlSchema
-from .base import CloudClient
+from ..models import copy_model
+from ..tag import Tag
+from ..utils import calc_dir_size
 from .base import FILE_CHUNK_SIZE
 from .base import CallbackIOWrapper
+from .base import CloudClient
+from .config import get_rest_api_client
 from .deployment import Deployment
-from ...exceptions import NotFound
-from ...exceptions import BentoMLException
-from ..configuration.containers import BentoMLContainer
+from .schemas import BentoApiSchema
+from .schemas import BentoManifestSchema
+from .schemas import BentoRunnerResourceSchema
+from .schemas import BentoRunnerSchema
+from .schemas import BentoUploadStatus
+from .schemas import CompleteMultipartUploadSchema
+from .schemas import CompletePartSchema
+from .schemas import CreateBentoRepositorySchema
+from .schemas import CreateBentoSchema
+from .schemas import CreateModelRepositorySchema
+from .schemas import CreateModelSchema
+from .schemas import FinishUploadBentoSchema
+from .schemas import FinishUploadModelSchema
+from .schemas import LabelItemSchema
+from .schemas import ModelManifestSchema
+from .schemas import ModelUploadStatus
+from .schemas import PreSignMultipartUploadUrlSchema
+from .schemas import TransmissionStrategy
+from .schemas import UpdateBentoSchema
 
 if t.TYPE_CHECKING:
     from concurrent.futures import Future

--- a/src/bentoml/_internal/cloud/client.py
+++ b/src/bentoml/_internal/cloud/client.py
@@ -6,33 +6,34 @@ from urllib.parse import urljoin
 
 import requests
 
-from .schemas import UserSchema, schema_from_object
-from .schemas import BentoSchema
-from .schemas import ModelSchema
-from .schemas import schema_to_json
-from .schemas import DeploymentSchema
-from .schemas import schema_from_json
-from .schemas import CreateBentoSchema
-from .schemas import CreateModelSchema
-from .schemas import UpdateBentoSchema
-from .schemas import OrganizationSchema
-from .schemas import DeploymentListSchema
-from .schemas import BentoRepositorySchema
-from .schemas import ModelRepositorySchema
-from .schemas import CreateDeploymentSchema
-from .schemas import UpdateDeploymentSchema
-from .schemas import FinishUploadBentoSchema
-from .schemas import FinishUploadModelSchema
-from .schemas import CreateBentoRepositorySchema
-from .schemas import CreateModelRepositorySchema
-from .schemas import BentoWithRepositoryListSchema
-from .schemas import CompleteMultipartUploadSchema
-from .schemas import ModelWithRepositoryListSchema
-from .schemas import PreSignMultipartUploadUrlSchema
-from .schemas import ClusterListSchema
-from .schemas import ClusterFullSchema
 from ...exceptions import CloudRESTApiClientError
 from ..configuration import BENTOML_VERSION
+from .schemas import BentoRepositorySchema
+from .schemas import BentoSchema
+from .schemas import BentoWithRepositoryListSchema
+from .schemas import ClusterFullSchema
+from .schemas import ClusterListSchema
+from .schemas import CompleteMultipartUploadSchema
+from .schemas import CreateBentoRepositorySchema
+from .schemas import CreateBentoSchema
+from .schemas import CreateDeploymentSchema
+from .schemas import CreateModelRepositorySchema
+from .schemas import CreateModelSchema
+from .schemas import DeploymentListSchema
+from .schemas import DeploymentSchema
+from .schemas import FinishUploadBentoSchema
+from .schemas import FinishUploadModelSchema
+from .schemas import ModelRepositorySchema
+from .schemas import ModelSchema
+from .schemas import ModelWithRepositoryListSchema
+from .schemas import OrganizationSchema
+from .schemas import PreSignMultipartUploadUrlSchema
+from .schemas import UpdateBentoSchema
+from .schemas import UpdateDeploymentSchema
+from .schemas import UserSchema
+from .schemas import schema_from_json
+from .schemas import schema_from_object
+from .schemas import schema_to_json
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/cloud/config.py
+++ b/src/bentoml/_internal/cloud/config.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 
 import attr
 import yaml
-from ..utils import bentoml_cattr
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
-from .client import RestApiClient
 from ...exceptions import CloudRESTApiClientError
 from ..configuration.containers import BentoMLContainer
+from ..utils import bentoml_cattr
+from .client import RestApiClient
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/cloud/deployment.py
+++ b/src/bentoml/_internal/cloud/deployment.py
@@ -1,29 +1,29 @@
 from __future__ import annotations
 
 import json
-import typing as t
 import logging
+import typing as t
 
 import attr
+from deepmerge.merger import Merger
 
+from ...exceptions import BentoMLException
 from ..tag import Tag
 from ..utils import bentoml_cattr
+from ..utils import first_not_none
 from ..utils import resolve_user_filepath
 from .config import get_rest_api_client
+from .schemas import CreateDeploymentSchema
+from .schemas import DeploymentListSchema
 from .schemas import DeploymentMode
 from .schemas import DeploymentSchema
-from .schemas import DeploymentListSchema
+from .schemas import DeploymentTargetCanaryRule
+from .schemas import DeploymentTargetConfig
+from .schemas import DeploymentTargetHPAConf
+from .schemas import DeploymentTargetRunnerConfig
 from .schemas import DeploymentTargetType
 from .schemas import FullDeploymentSchema
-from .schemas import CreateDeploymentSchema
-from .schemas import DeploymentTargetConfig
 from .schemas import UpdateDeploymentSchema
-from .schemas import DeploymentTargetHPAConf
-from .schemas import DeploymentTargetCanaryRule
-from .schemas import DeploymentTargetRunnerConfig
-from deepmerge.merger import Merger
-from ..utils import first_not_none
-from ...exceptions import BentoMLException
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/cloud/schemas.py
+++ b/src/bentoml/_internal/cloud/schemas.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import json
 import typing as t
+from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
-from datetime import datetime
+
 import attr
 import cattr
 from dateutil.parser import parse

--- a/src/bentoml/_internal/cloud/yatai.py
+++ b/src/bentoml/_internal/cloud/yatai.py
@@ -1,54 +1,54 @@
 from __future__ import annotations
 
 import io
-import typing as t
 import tarfile
 import tempfile
-import warnings
 import threading
+import typing as t
+import warnings
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from concurrent.futures import ThreadPoolExecutor
 
 import fs
 import requests
 from rich.live import Live
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
-from ..tag import Tag
+from ...exceptions import BentoMLException
+from ...exceptions import NotFound
 from ..bento import Bento
 from ..bento import BentoStore
-from ..utils import calc_dir_size
-from .config import get_rest_api_client
+from ..configuration.containers import BentoMLContainer
 from ..models import Model
-from ..models import copy_model
 from ..models import ModelStore
-from .schemas import BentoApiSchema
-from .schemas import LabelItemSchema
-from .schemas import BentoRunnerSchema
-from .schemas import BentoUploadStatus
-from .schemas import CreateBentoSchema
-from .schemas import CreateModelSchema
-from .schemas import ModelUploadStatus
-from .schemas import UpdateBentoSchema
-from .schemas import CompletePartSchema
-from .schemas import BentoManifestSchema
-from .schemas import ModelManifestSchema
-from .schemas import TransmissionStrategy
-from .schemas import FinishUploadBentoSchema
-from .schemas import FinishUploadModelSchema
-from .schemas import BentoRunnerResourceSchema
-from .schemas import CreateBentoRepositorySchema
-from .schemas import CreateModelRepositorySchema
-from .schemas import CompleteMultipartUploadSchema
-from .schemas import PreSignMultipartUploadUrlSchema
-from .base import CloudClient
+from ..models import copy_model
+from ..tag import Tag
+from ..utils import calc_dir_size
 from .base import FILE_CHUNK_SIZE
 from .base import CallbackIOWrapper
-from ...exceptions import NotFound
-from ...exceptions import BentoMLException
-from ..configuration.containers import BentoMLContainer
+from .base import CloudClient
+from .config import get_rest_api_client
+from .schemas import BentoApiSchema
+from .schemas import BentoManifestSchema
+from .schemas import BentoRunnerResourceSchema
+from .schemas import BentoRunnerSchema
+from .schemas import BentoUploadStatus
+from .schemas import CompleteMultipartUploadSchema
+from .schemas import CompletePartSchema
+from .schemas import CreateBentoRepositorySchema
+from .schemas import CreateBentoSchema
+from .schemas import CreateModelRepositorySchema
+from .schemas import CreateModelSchema
+from .schemas import FinishUploadBentoSchema
+from .schemas import FinishUploadModelSchema
+from .schemas import LabelItemSchema
+from .schemas import ModelManifestSchema
+from .schemas import ModelUploadStatus
+from .schemas import PreSignMultipartUploadUrlSchema
+from .schemas import TransmissionStrategy
+from .schemas import UpdateBentoSchema
 
 if t.TYPE_CHECKING:
     from concurrent.futures import Future

--- a/src/bentoml/_internal/configuration/__init__.py
+++ b/src/bentoml/_internal/configuration/__init__.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
 import typing as t
-import logging
-from typing import TYPE_CHECKING
 from functools import lru_cache
+from typing import TYPE_CHECKING
 
-from ...exceptions import BentoMLException
 from ...exceptions import BentoMLConfigException
+from ...exceptions import BentoMLException
 
 try:
     from ..._version import __version__
@@ -137,8 +137,8 @@ def get_quiet_mode() -> bool:
 def load_config(bentoml_config_file: str | None = None):
     """Load global configuration of BentoML"""
 
-    from .containers import BentoMLContainer
     from .containers import BentoMLConfiguration
+    from .containers import BentoMLContainer
 
     if not bentoml_config_file:
         bentoml_config_file = get_bentoml_config_file_from_env()

--- a/src/bentoml/_internal/configuration/containers.py
+++ b/src/bentoml/_internal/configuration/containers.py
@@ -1,34 +1,34 @@
 from __future__ import annotations
 
-import os
-import math
-from pathlib import Path
-import uuid
-import typing as t
 import logging
+import math
+import os
+import typing as t
+import uuid
 from copy import deepcopy
-from typing import TYPE_CHECKING
 from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
 
-import yaml
 import schema as s
+import yaml
+from deepmerge.merger import Merger
 from simple_di import Provide
 from simple_di import providers
-from deepmerge.merger import Merger
 
-from . import expand_env_var
-from ..utils import split_with_quotes
-from ..utils import validate_or_create_dir
-from .helpers import flatten_dict
-from .helpers import load_config_file
-from .helpers import get_default_config
-from .helpers import import_configuration_spec
-from ..context import trace_context
+from ...exceptions import BentoMLConfigException
 from ..context import component_context
+from ..context import trace_context
 from ..resource import CpuResource
 from ..resource import system_resources
-from ...exceptions import BentoMLConfigException
+from ..utils import split_with_quotes
+from ..utils import validate_or_create_dir
 from ..utils.unflatten import unflatten
+from . import expand_env_var
+from .helpers import flatten_dict
+from .helpers import get_default_config
+from .helpers import import_configuration_spec
+from .helpers import load_config_file
 
 if TYPE_CHECKING:
     from fs.base import FS
@@ -36,8 +36,8 @@ if TYPE_CHECKING:
     from .. import external_typing as ext
     from ..bento import BentoStore
     from ..models import ModelStore
-    from ..utils.analytics import ServeInfo
     from ..server.metrics.prometheus import PrometheusClient
+    from ..utils.analytics import ServeInfo
 
     SerializationStrategy = t.Literal["EXPORT_BENTO", "LOCAL_BENTO", "REMOTE_BENTO"]
 
@@ -358,13 +358,13 @@ class _BentoMLContainerClass:
         jaeger: dict[str, t.Any] = Provide[tracing.jaeger],
         otlp: dict[str, t.Any] = Provide[tracing.otlp],
     ):
-        from opentelemetry.sdk.trace import TracerProvider
-        from opentelemetry.sdk.resources import Resource
-        from opentelemetry.sdk.resources import SERVICE_NAME
-        from opentelemetry.sdk.resources import SERVICE_VERSION
-        from opentelemetry.sdk.resources import SERVICE_NAMESPACE
         from opentelemetry.sdk.resources import SERVICE_INSTANCE_ID
+        from opentelemetry.sdk.resources import SERVICE_NAME
+        from opentelemetry.sdk.resources import SERVICE_NAMESPACE
+        from opentelemetry.sdk.resources import SERVICE_VERSION
         from opentelemetry.sdk.resources import OTELResourceDetector
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
         from ...exceptions import InvalidArgument

--- a/src/bentoml/_internal/configuration/helpers.py
+++ b/src/bentoml/_internal/configuration/helpers.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
+import logging
 import os
 import socket
 import typing as t
-import logging
-from typing import TYPE_CHECKING
 from functools import singledispatch
+from typing import TYPE_CHECKING
 
-import yaml
 import schema as s
+import yaml
 
-from ..utils import LazyLoader
 from ...exceptions import BentoMLConfigException
+from ..utils import LazyLoader
 
 if TYPE_CHECKING:
     from types import ModuleType

--- a/src/bentoml/_internal/configuration/v1/__init__.py
+++ b/src/bentoml/_internal/configuration/v1/__init__.py
@@ -5,17 +5,17 @@ import typing as t
 
 import schema as s
 
-from ..helpers import depth
-from ..helpers import ensure_range
-from ..helpers import rename_fields
-from ..helpers import ensure_larger_than
-from ..helpers import is_valid_ip_address
-from ..helpers import ensure_iterable_type
-from ..helpers import validate_tracing_type
-from ..helpers import validate_otlp_protocol
-from ..helpers import ensure_larger_than_zero
 from ...utils.metrics import DEFAULT_BUCKET
 from ...utils.unflatten import unflatten
+from ..helpers import depth
+from ..helpers import ensure_iterable_type
+from ..helpers import ensure_larger_than
+from ..helpers import ensure_larger_than_zero
+from ..helpers import ensure_range
+from ..helpers import is_valid_ip_address
+from ..helpers import rename_fields
+from ..helpers import validate_otlp_protocol
+from ..helpers import validate_tracing_type
 
 __all__ = ["SCHEMA", "migration"]
 

--- a/src/bentoml/_internal/container/base.py
+++ b/src/bentoml/_internal/container/base.py
@@ -1,22 +1,20 @@
 from __future__ import annotations
 
-import os
-import typing as t
 import logging
+import os
 import subprocess
+import typing as t
 from abc import abstractmethod
-from queue import Queue
-from typing import TYPE_CHECKING
+from functools import singledispatchmethod
 from itertools import chain
+from queue import Queue
 from threading import Thread
+from typing import TYPE_CHECKING
 
 import attr
 
-from ..utils import resolve_user_filepath
 from ...exceptions import BentoMLException
-
-from functools import singledispatchmethod
-
+from ..utils import resolve_user_filepath
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/src/bentoml/_internal/container/buildah.py
+++ b/src/bentoml/_internal/container/buildah.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
+import logging
 import shutil
 import typing as t
-import logging
 from typing import TYPE_CHECKING
 
 from .base import Arguments
 
 if TYPE_CHECKING:
-    from .base import ArgType
     from ..types import PathType
+    from .base import ArgType
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/container/buildctl.py
+++ b/src/bentoml/_internal/container/buildctl.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
 import shutil
 import typing as t
-import logging
 from typing import TYPE_CHECKING
 
 import psutil
@@ -12,8 +12,8 @@ import psutil
 from .base import Arguments
 
 if TYPE_CHECKING:
-    from .base import ArgType
     from ..types import PathType
+    from .base import ArgType
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/container/buildx.py
+++ b/src/bentoml/_internal/container/buildx.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
-import typing as t
 import logging
 import subprocess
+import typing as t
 from typing import TYPE_CHECKING
 
 from .base import Arguments
 from .docker import ENV
-from .docker import health as _docker_health
 from .docker import find_binary
+from .docker import health as _docker_health
 
 if TYPE_CHECKING:
-    from .base import ArgType
     from ..types import PathType
+    from .base import ArgType
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/container/docker.py
+++ b/src/bentoml/_internal/container/docker.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
 import shutil
-import typing as t
-import logging
 import subprocess
+import typing as t
 from typing import TYPE_CHECKING
 
 import psutil
@@ -14,8 +14,8 @@ from packaging.version import parse
 from .base import Arguments
 
 if TYPE_CHECKING:
-    from .base import ArgType
     from ..types import PathType
+    from .base import ArgType
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/container/frontend/dockerfile/__init__.py
+++ b/src/bentoml/_internal/container/frontend/dockerfile/__init__.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
 import attr
 
-from .....exceptions import InvalidArgument
 from .....exceptions import BentoMLException
+from .....exceptions import InvalidArgument
 
 if TYPE_CHECKING:
     P = t.ParamSpec("P")

--- a/src/bentoml/_internal/container/generate.py
+++ b/src/bentoml/_internal/container/generate.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
+import logging
 import os
 import typing as t
-import logging
 from typing import TYPE_CHECKING
 
 from jinja2 import Environment
 from jinja2.loaders import FileSystemLoader
 
+from ..configuration.containers import BentoMLContainer
 from ..utils import resolve_user_filepath
 from .frontend.dockerfile import DistroSpec
-from ..configuration.containers import BentoMLContainer
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/container/nerdctl.py
+++ b/src/bentoml/_internal/container/nerdctl.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import typing as t
-import logging
 from typing import TYPE_CHECKING
 
 import psutil
@@ -11,8 +11,8 @@ import psutil
 from .base import Arguments
 
 if TYPE_CHECKING:
-    from .base import ArgType
     from ..types import PathType
+    from .base import ArgType
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/container/podman.py
+++ b/src/bentoml/_internal/container/podman.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import shutil
-import typing as t
 import logging
+import shutil
 import subprocess
+import typing as t
 from typing import TYPE_CHECKING
 
 import psutil
@@ -12,8 +12,8 @@ from .base import Arguments
 from .buildah import ENV
 
 if TYPE_CHECKING:
-    from .base import ArgType
     from ..types import PathType
+    from .base import ArgType
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/env_manager/envs.py
+++ b/src/bentoml/_internal/env_manager/envs.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import os
-import typing as t
 import logging
+import os
 import subprocess
+import typing as t
 from abc import ABC
 from abc import abstractmethod
 from shutil import which

--- a/src/bentoml/_internal/env_manager/manager.py
+++ b/src/bentoml/_internal/env_manager/manager.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 
 import fs
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
-from .envs import Conda
 from ..bento.bento import Bento
 from ..bento.bento import BentoInfo
 from ..configuration.containers import BentoMLContainer
+from .envs import Conda
 
 if t.TYPE_CHECKING:
     from fs.base import FS

--- a/src/bentoml/_internal/exportable.py
+++ b/src/bentoml/_internal/exportable.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
 import typing as t
-import logging
 import urllib.parse
 from abc import ABC
 from abc import abstractmethod
@@ -13,8 +13,8 @@ import fs.copy
 import fs.errors
 import fs.mirror
 import fs.opener
-import fs.tempfs
 import fs.opener.errors
+import fs.tempfs
 from fs import open_fs
 from fs.base import FS
 

--- a/src/bentoml/_internal/frameworks/catboost.py
+++ b/src/bentoml/_internal/frameworks/catboost.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import logging
 import os
 import typing as t
-import logging
 from types import ModuleType
 from typing import TYPE_CHECKING
 
@@ -11,14 +11,14 @@ import numpy as np
 
 import bentoml
 from bentoml import Tag
-from bentoml.models import ModelOptions
-from bentoml.exceptions import NotFound
-from bentoml.exceptions import InvalidArgument
 from bentoml.exceptions import BentoMLException
+from bentoml.exceptions import InvalidArgument
 from bentoml.exceptions import MissingDependencyException
+from bentoml.exceptions import NotFound
+from bentoml.models import ModelOptions
 
-from ..utils.pkg import get_pkg_version
 from ..models.model import ModelContext
+from ..utils.pkg import get_pkg_version
 
 if TYPE_CHECKING:
     from bentoml.types import ModelSignature

--- a/src/bentoml/_internal/frameworks/common/jax.py
+++ b/src/bentoml/_internal/frameworks/common/jax.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
+import itertools
 import pickle
 import typing as t
-import itertools
 from typing import TYPE_CHECKING
 
 from simple_di import inject
 
-from ...types import LazyType
-from ...utils import LazyLoader
 from ....exceptions import MissingDependencyException
-from ...runner.container import Payload
 from ...runner.container import DataContainer
 from ...runner.container import DataContainerRegistry
+from ...runner.container import Payload
+from ...types import LazyType
+from ...utils import LazyLoader
 
 try:
     import jaxlib as jaxlib

--- a/src/bentoml/_internal/frameworks/common/pytorch.py
+++ b/src/bentoml/_internal/frameworks/common/pytorch.py
@@ -1,25 +1,25 @@
 from __future__ import annotations
 
-import pickle
-import typing as t
-import logging
 import functools
 import itertools
+import logging
+import pickle
+import typing as t
 from typing import TYPE_CHECKING
 
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
 import bentoml
 
-from ...types import LazyType
 from ....exceptions import MissingDependencyException
+from ...configuration.containers import BentoMLContainer
 from ...models.model import Model
-from ...runner.utils import Params
-from ...runner.container import Payload
 from ...runner.container import DataContainer
 from ...runner.container import DataContainerRegistry
-from ...configuration.containers import BentoMLContainer
+from ...runner.container import Payload
+from ...runner.utils import Params
+from ...types import LazyType
 
 try:
     import torch

--- a/src/bentoml/_internal/frameworks/detectron.py
+++ b/src/bentoml/_internal/frameworks/detectron.py
@@ -1,31 +1,31 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from types import ModuleType
 
 import bentoml
 
-from ..tag import Tag
-from ..types import LazyType
-from ..utils import LazyLoader
-from ..utils.pkg import get_pkg_version
-from ...exceptions import NotFound
 from ...exceptions import MissingDependencyException
+from ...exceptions import NotFound
 from ..models.model import Model
 from ..models.model import ModelContext
 from ..models.model import ModelSignature
 from ..models.model import PartialKwargsModelOptions as ModelOptions
 from ..runner.utils import Params
-from .common.pytorch import torch
-from .common.pytorch import inference_mode_ctx
+from ..tag import Tag
+from ..types import LazyType
+from ..utils import LazyLoader
+from ..utils.pkg import get_pkg_version
 from .common.pytorch import PyTorchTensorContainer  # noqa # type: ignore
+from .common.pytorch import inference_mode_ctx
+from .common.pytorch import torch
 
 try:
+    import detectron2.checkpoint as Checkpoint
     import detectron2.config as Config
     import detectron2.engine as Engine
     import detectron2.modeling as Modeling
-    import detectron2.checkpoint as Checkpoint
 except ImportError:  # pragma: no cover
     raise MissingDependencyException(
         "'detectron2' is required in order to use module 'bentoml.detectron'. Install detectron2 with 'pip install 'git+https://github.com/facebookresearch/detectron2.git''."

--- a/src/bentoml/_internal/frameworks/diffusers.py
+++ b/src/bentoml/_internal/frameworks/diffusers.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import re
+import logging
 import os
+import re
 import shutil
 import typing as t
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -12,10 +12,10 @@ import attr
 
 import bentoml
 from bentoml import Tag
-from bentoml.models import ModelContext
-from bentoml.exceptions import NotFound
 from bentoml.exceptions import BentoMLException
 from bentoml.exceptions import MissingDependencyException
+from bentoml.exceptions import NotFound
+from bentoml.models import ModelContext
 
 from ..models.model import PartialKwargsModelOptions
 
@@ -27,11 +27,11 @@ if TYPE_CHECKING:
 
 
 try:
-    import torch
     import diffusers
+    import torch
+    from diffusers.utils.import_utils import is_accelerate_available
     from diffusers.utils.import_utils import is_torch_version
     from diffusers.utils.import_utils import is_xformers_available
-    from diffusers.utils.import_utils import is_accelerate_available
 except ImportError:  # pragma: no cover
     raise MissingDependencyException(
         "'diffusers' and 'transformers' is required in order to use module 'bentoml.diffusers', install diffusers and its dependencies with 'pip install --upgrade diffusers transformers accelerate'. For more information, refer to https://github.com/huggingface/diffusers",

--- a/src/bentoml/_internal/frameworks/easyocr.py
+++ b/src/bentoml/_internal/frameworks/easyocr.py
@@ -1,21 +1,21 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from types import ModuleType
 
 import cloudpickle
 
 import bentoml
 
-from ..tag import Tag
-from ..utils.pkg import get_pkg_version
-from ...exceptions import NotFound
 from ...exceptions import MissingDependencyException
+from ...exceptions import NotFound
 from ..models.model import Model
 from ..models.model import ModelContext
 from ..models.model import ModelOptions
 from ..models.model import ModelSignature
+from ..tag import Tag
+from ..utils.pkg import get_pkg_version
 from .common.pytorch import PyTorchTensorContainer  # noqa # type: ignore
 
 try:

--- a/src/bentoml/_internal/frameworks/fastai.py
+++ b/src/bentoml/_internal/frameworks/fastai.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-import typing as t
-import logging
 import contextlib
+import logging
+import typing as t
 from types import ModuleType
 from typing import TYPE_CHECKING
 
 import bentoml
 
-from ..utils.pkg import get_pkg_version
-from ...exceptions import NotFound
-from ...exceptions import InvalidArgument
 from ...exceptions import BentoMLException
+from ...exceptions import InvalidArgument
 from ...exceptions import MissingDependencyException
+from ...exceptions import NotFound
 from ..models.model import ModelContext
+from ..utils.pkg import get_pkg_version
 
 # register PyTorchTensorContainer as import side effect.
 from .common.pytorch import PyTorchTensorContainer
@@ -26,10 +26,10 @@ logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    from .. import external_typing as ext
-    from ..tag import Tag
     from ...types import ModelSignature
+    from .. import external_typing as ext
     from ..models.model import ModelSignaturesType
+    from ..tag import Tag
 
 try:
     import torch

--- a/src/bentoml/_internal/frameworks/flax.py
+++ b/src/bentoml/_internal/frameworks/flax.py
@@ -1,39 +1,39 @@
 from __future__ import annotations
 
-import typing as t
-import logging
 import functools
-from types import ModuleType
+import logging
+import typing as t
 from pickle import UnpicklingError
+from types import ModuleType
 from typing import TYPE_CHECKING
 
 import msgpack.exceptions
 
 import bentoml
 
-from ..types import LazyType
-from ..utils import LazyLoader
-from ..utils.pkg import get_pkg_version
-from .common.jax import jax
-from .common.jax import jnp
-from .common.jax import JaxArrayContainer
-from ...exceptions import NotFound
 from ...exceptions import BentoMLException
 from ...exceptions import MissingDependencyException
+from ...exceptions import NotFound
 from ..models.model import ModelContext
 from ..models.model import PartialKwargsModelOptions as ModelOptions
 from ..runner.utils import Params
+from ..types import LazyType
+from ..utils import LazyLoader
+from ..utils.pkg import get_pkg_version
+from .common.jax import JaxArrayContainer
+from .common.jax import jax
+from .common.jax import jnp
 
 if TYPE_CHECKING:
     from flax import struct
-    from jax.lib import xla_bridge
     from flax.core import FrozenDict
     from jax._src.lib.xla_bridge import XlaBackend
+    from jax.lib import xla_bridge
 
-    from .. import external_typing as ext
-    from ..tag import Tag
     from ...types import ModelSignature
+    from .. import external_typing as ext
     from ..models.model import ModelSignaturesType
+    from ..tag import Tag
 else:
     xla_bridge = LazyLoader("xla_bridge", globals(), "jax.lib.xla_bridge")
 

--- a/src/bentoml/_internal/frameworks/keras.py
+++ b/src/bentoml/_internal/frameworks/keras.py
@@ -1,32 +1,32 @@
 from __future__ import annotations
 
-import typing as t
-import logging
 import functools
+import logging
+import typing as t
 from types import ModuleType
 from typing import TYPE_CHECKING
 
 import attr
 
 import bentoml
-from bentoml import Tag
 from bentoml import Runnable
-from bentoml.models import ModelContext
-from bentoml.exceptions import NotFound
+from bentoml import Tag
 from bentoml.exceptions import MissingDependencyException
+from bentoml.exceptions import NotFound
+from bentoml.models import ModelContext
 
-from ..types import LazyType
 from ..models.model import ModelSignature
 from ..models.model import PartialKwargsModelOptions
 from ..runner.utils import Params
+from ..types import LazyType
 from .utils.tensorflow import get_tf_version
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover
     from .. import external_typing as ext
-    from ..models.model import ModelSignatureDict
     from ..external_typing import tensorflow as tf_ext
+    from ..models.model import ModelSignatureDict
 
     KerasArgType = t.Union[t.List[t.Union[int, float]], ext.NpNDArray, tf_ext.Tensor]
 

--- a/src/bentoml/_internal/frameworks/lightgbm.py
+++ b/src/bentoml/_internal/frameworks/lightgbm.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from types import ModuleType
 from typing import TYPE_CHECKING
 
@@ -9,12 +9,12 @@ import numpy as np
 
 import bentoml
 from bentoml import Tag
-from bentoml.exceptions import NotFound
 from bentoml.exceptions import InvalidArgument
 from bentoml.exceptions import MissingDependencyException
+from bentoml.exceptions import NotFound
 
-from ..utils.pkg import get_pkg_version
 from ..models.model import ModelContext
+from ..utils.pkg import get_pkg_version
 
 if TYPE_CHECKING:
     from bentoml.types import ModelSignature

--- a/src/bentoml/_internal/frameworks/mlflow.py
+++ b/src/bentoml/_internal/frameworks/mlflow.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
+import logging
 import os
 import shutil
-import typing as t
-import logging
 import tempfile
+import typing as t
 from typing import TYPE_CHECKING
 
 import bentoml
 from bentoml import Tag
-from bentoml.models import ModelContext
-from bentoml.exceptions import NotFound
 from bentoml.exceptions import BentoMLException
 from bentoml.exceptions import MissingDependencyException
+from bentoml.exceptions import NotFound
+from bentoml.models import ModelContext
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -183,8 +183,8 @@ def import_model(
         context=context,
     ) as bento_model:
         from mlflow.models import Model as MLflowModel
-        from mlflow.pyfunc import FLAVOR_NAME as PYFUNC_FLAVOR_NAME
         from mlflow.models.model import MLMODEL_FILE_NAME
+        from mlflow.pyfunc import FLAVOR_NAME as PYFUNC_FLAVOR_NAME
 
         # Explicitly provide a destination dir to mlflow so that we don't
         # accidentially download into the root of the bento model temp dir

--- a/src/bentoml/_internal/frameworks/onnx.py
+++ b/src/bentoml/_internal/frameworks/onnx.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import logging
 import os
 import typing as t
-import logging
 from types import ModuleType
 from typing import TYPE_CHECKING
 
@@ -10,21 +10,21 @@ import attr
 
 import bentoml
 from bentoml import Tag
-from bentoml.models import ModelContext
-from bentoml.models import ModelOptions
-from bentoml.exceptions import NotFound
 from bentoml.exceptions import BentoMLException
 from bentoml.exceptions import MissingDependencyException
+from bentoml.exceptions import NotFound
+from bentoml.models import ModelContext
+from bentoml.models import ModelOptions
 
-from ..utils.pkg import get_pkg_version
 from ..utils.pkg import PackageNotFoundError
+from ..utils.pkg import get_pkg_version
 
 if TYPE_CHECKING:
     from bentoml.types import ModelSignature
     from bentoml.types import ModelSignatureDict
 
-    from .utils.onnx import ONNXArgType
     from .utils.onnx import ONNXArgCastedType
+    from .utils.onnx import ONNXArgType
 
     ProvidersType = list[str | tuple[str, dict[str, t.Any]]]
 

--- a/src/bentoml/_internal/frameworks/picklable.py
+++ b/src/bentoml/_internal/frameworks/picklable.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from types import ModuleType
 from typing import TYPE_CHECKING
 
@@ -9,9 +9,9 @@ import cloudpickle
 
 import bentoml
 from bentoml import Tag
+from bentoml.exceptions import NotFound
 from bentoml.models import Model
 from bentoml.models import ModelContext
-from bentoml.exceptions import NotFound
 
 from ..models import PKL_EXT
 from ..models import SAVE_NAMESPACE

--- a/src/bentoml/_internal/frameworks/pytorch.py
+++ b/src/bentoml/_internal/frameworks/pytorch.py
@@ -1,24 +1,24 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
+from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING
-from pathlib import Path
 
 import cloudpickle
 
 import bentoml
 from bentoml import Tag
 
-from ..types import LazyType
-from ..models import Model
-from ..utils.pkg import get_pkg_version
 from ...exceptions import NotFound
+from ..models import Model
 from ..models.model import ModelContext
 from ..models.model import PartialKwargsModelOptions as ModelOptions
-from .common.pytorch import torch
+from ..types import LazyType
+from ..utils.pkg import get_pkg_version
 from .common.pytorch import PyTorchTensorContainer
+from .common.pytorch import torch
 
 __all__ = ["load_model", "save_model", "get_runnable", "get", "PyTorchTensorContainer"]
 
@@ -191,9 +191,9 @@ def get_runnable(bento_model: Model):
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
-    from .common.pytorch import partial_class
     from .common.pytorch import PytorchModelRunnable
     from .common.pytorch import make_pytorch_runnable_method
+    from .common.pytorch import partial_class
 
     partial_kwargs: t.Dict[str, t.Any] = bento_model.info.options.partial_kwargs  # type: ignore
 

--- a/src/bentoml/_internal/frameworks/pytorch_lightning.py
+++ b/src/bentoml/_internal/frameworks/pytorch_lightning.py
@@ -7,12 +7,12 @@ from typing import TYPE_CHECKING
 import bentoml
 from bentoml import Tag
 
-from .torchscript import save_model as script_save_model
-from .torchscript import MODEL_FILENAME
-from ...exceptions import NotFound
 from ...exceptions import MissingDependencyException
+from ...exceptions import NotFound
 from ..models.model import Model
 from .common.pytorch import torch
+from .torchscript import MODEL_FILENAME
+from .torchscript import save_model as script_save_model
 
 if TYPE_CHECKING:
     from ..models.model import ModelSignaturesType
@@ -184,9 +184,9 @@ def get_runnable(bento_model: Model):
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
-    from .common.pytorch import partial_class
     from .common.pytorch import PytorchModelRunnable
     from .common.pytorch import make_pytorch_runnable_method
+    from .common.pytorch import partial_class
 
     for method_name, options in bento_model.info.signatures.items():
         PytorchModelRunnable.add_method(

--- a/src/bentoml/_internal/frameworks/sklearn.py
+++ b/src/bentoml/_internal/frameworks/sklearn.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from types import ModuleType
 from typing import TYPE_CHECKING
 
 import bentoml
 from bentoml import Tag
+from bentoml.exceptions import MissingDependencyException
+from bentoml.exceptions import NotFound
 from bentoml.models import Model
 from bentoml.models import ModelContext
-from bentoml.exceptions import NotFound
-from bentoml.exceptions import MissingDependencyException
 
 from ..types import LazyType
 from ..utils.pkg import get_pkg_version

--- a/src/bentoml/_internal/frameworks/tensorflow_v2.py
+++ b/src/bentoml/_internal/frameworks/tensorflow_v2.py
@@ -1,36 +1,36 @@
 from __future__ import annotations
 
+import contextlib
+import itertools
+import logging
 import pickle
 import typing as t
-import logging
-import itertools
-import contextlib
 from types import ModuleType
 from typing import TYPE_CHECKING
 
 import bentoml
-from bentoml import Tag
 from bentoml import Runnable
-from bentoml.models import ModelContext
-from bentoml.exceptions import NotFound
+from bentoml import Tag
 from bentoml.exceptions import MissingDependencyException
+from bentoml.exceptions import NotFound
+from bentoml.models import ModelContext
 
-from ..types import LazyType
 from ..models.model import ModelSignature
 from ..models.model import PartialKwargsModelOptions as ModelOptions
-from .utils.tensorflow import get_tf_version
+from ..runner.container import DataContainer
+from ..runner.container import DataContainerRegistry
+from ..runner.container import Payload
+from ..types import LazyType
+from .utils.tensorflow import cast_py_args_to_tf_function_args
 from .utils.tensorflow import get_input_signatures_v2
 from .utils.tensorflow import get_output_signatures_v2
 from .utils.tensorflow import get_restorable_functions
-from .utils.tensorflow import cast_py_args_to_tf_function_args
-from ..runner.container import Payload
-from ..runner.container import DataContainer
-from ..runner.container import DataContainerRegistry
+from .utils.tensorflow import get_tf_version
 
 if TYPE_CHECKING:
     from .. import external_typing as ext
-    from ..models.model import ModelSignatureDict
     from ..external_typing import tensorflow as tf_ext
+    from ..models.model import ModelSignatureDict
 
     TFArgType = t.Union[t.List[t.Union[int, float]], ext.NpNDArray, tf_ext.Tensor]
     TFModelOutputType = tf_ext.EagerTensor | tuple[tf_ext.EagerTensor]

--- a/src/bentoml/_internal/frameworks/torchscript.py
+++ b/src/bentoml/_internal/frameworks/torchscript.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from types import ModuleType
 from typing import TYPE_CHECKING
 
 import bentoml
 from bentoml import Tag
 
-from ..utils.pkg import get_pkg_version
 from ...exceptions import NotFound
 from ..models.model import Model
 from ..models.model import ModelContext
 from ..models.model import PartialKwargsModelOptions as ModelOptions
+from ..utils.pkg import get_pkg_version
 from .common.pytorch import torch
 
 if TYPE_CHECKING:
@@ -172,9 +172,9 @@ def get_runnable(bento_model: Model):
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
-    from .common.pytorch import partial_class
     from .common.pytorch import PytorchModelRunnable
     from .common.pytorch import make_pytorch_runnable_method
+    from .common.pytorch import partial_class
 
     partial_kwargs: t.Dict[str, t.Any] = bento_model.info.options.partial_kwargs  # type: ignore
     model_runnable_class = partial_class(

--- a/src/bentoml/_internal/frameworks/transformers.py
+++ b/src/bentoml/_internal/frameworks/transformers.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import os
-import typing as t
 import logging
+import os
 import platform
+import typing as t
 import warnings
 from types import ModuleType
 
@@ -11,23 +11,23 @@ import attr
 
 import bentoml
 
+from ...exceptions import BentoMLException
+from ...exceptions import MissingDependencyException
+from ...exceptions import NotFound
+from ..models.model import Model
+from ..models.model import ModelContext
+from ..models.model import ModelOptions
+from ..models.model import ModelSignature
 from ..tag import Tag
 from ..types import LazyType
 from ..utils import LazyLoader
 from ..utils.pkg import get_pkg_version
 from ..utils.pkg import pkg_version_info
-from ...exceptions import NotFound
-from ...exceptions import BentoMLException
-from ...exceptions import MissingDependencyException
-from ..models.model import Model
-from ..models.model import ModelContext
-from ..models.model import ModelOptions
-from ..models.model import ModelSignature
 
 if t.TYPE_CHECKING:
-    import torch
-    import tensorflow as tf
     import cloudpickle
+    import tensorflow as tf
+    import torch
     from transformers.models.auto.auto_factory import (
         _BaseAutoModelClass as BaseAutoModelClass,
     )
@@ -696,12 +696,12 @@ def save_model(
 
     # The below API are introduced since 4.18
     if pkg_version_info("transformers")[:2] >= (4, 18):
-        from transformers.utils import is_tf_available
         from transformers.utils import is_flax_available
+        from transformers.utils import is_tf_available
         from transformers.utils import is_torch_available
     else:
-        from .utils.transformers import is_tf_available
         from .utils.transformers import is_flax_available
+        from .utils.transformers import is_tf_available
         from .utils.transformers import is_torch_available
 
     framework_versions = {"transformers": get_pkg_version("transformers")}

--- a/src/bentoml/_internal/frameworks/utils/onnx.py
+++ b/src/bentoml/_internal/frameworks/utils/onnx.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
-from ...types import LazyType
 from ....exceptions import BentoMLException
+from ...types import LazyType
 from ...utils.lazy_loader import LazyLoader
 
 if TYPE_CHECKING:

--- a/src/bentoml/_internal/frameworks/utils/tensorflow.py
+++ b/src/bentoml/_internal/frameworks/utils/tensorflow.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
-import typing as t
-import logging
+import importlib.metadata
 import importlib.util
+import logging
+import typing as t
 from typing import TYPE_CHECKING
 
 from bentoml.exceptions import BentoMLException
 
 from ...types import LazyType
 from ...utils.lazy_loader import LazyLoader
-
-import importlib.metadata
 
 if TYPE_CHECKING:
     import tensorflow as tf

--- a/src/bentoml/_internal/frameworks/utils/transformers.py
+++ b/src/bentoml/_internal/frameworks/utils/transformers.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import logging
+import importlib.metadata
 import importlib.util
+import logging
 
 from packaging import version
-
-import importlib.metadata
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/frameworks/xgboost.py
+++ b/src/bentoml/_internal/frameworks/xgboost.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import logging
 import os
 import typing as t
-import logging
 from types import ModuleType
 from typing import TYPE_CHECKING
 
@@ -11,14 +11,14 @@ import numpy as np
 
 import bentoml
 from bentoml import Tag
-from bentoml.models import ModelOptions
-from bentoml.exceptions import NotFound
-from bentoml.exceptions import InvalidArgument
 from bentoml.exceptions import BentoMLException
+from bentoml.exceptions import InvalidArgument
 from bentoml.exceptions import MissingDependencyException
+from bentoml.exceptions import NotFound
+from bentoml.models import ModelOptions
 
-from ..utils.pkg import get_pkg_version
 from ..models.model import ModelContext
+from ..utils.pkg import get_pkg_version
 
 if TYPE_CHECKING:
     from bentoml.types import ModelSignature

--- a/src/bentoml/_internal/io_descriptors/__init__.py
+++ b/src/bentoml/_internal/io_descriptors/__init__.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
-from .base import from_spec
-from .base import IODescriptor
 from .base import IO_DESCRIPTOR_REGISTRY
+from .base import IODescriptor
+from .base import from_spec
 from .file import File
-from .json import JSON
-from .text import Text
 from .image import Image
-from .numpy import NumpyNdarray
-from .pandas import PandasSeries
-from .pandas import PandasDataFrame
+from .json import JSON
 from .multipart import Multipart
+from .numpy import NumpyNdarray
+from .pandas import PandasDataFrame
+from .pandas import PandasSeries
+from .text import Text
 
 __all__ = [
     "IO_DESCRIPTOR_REGISTRY",

--- a/src/bentoml/_internal/io_descriptors/base.py
+++ b/src/bentoml/_internal/io_descriptors/base.py
@@ -17,10 +17,10 @@ if t.TYPE_CHECKING:
 
     from bentoml.grpc.types import ProtoField
 
-    from ..types import LazyType
     from ..context import ServiceContext as Context
-    from ..service.openapi.specification import Schema
     from ..service.openapi.specification import Reference
+    from ..service.openapi.specification import Schema
+    from ..types import LazyType
 
     InputType = (
         UnionType

--- a/src/bentoml/_internal/io_descriptors/file.py
+++ b/src/bentoml/_internal/io_descriptors/file.py
@@ -1,28 +1,28 @@
 from __future__ import annotations
 
 import io
+import logging
 import os
 import typing as t
-import logging
 from functools import lru_cache
 
-from starlette.requests import Request
 from multipart.multipart import parse_options_header
-from starlette.responses import Response
 from starlette.datastructures import UploadFile
+from starlette.requests import Request
+from starlette.responses import Response
 
-from .base import IODescriptor
-from ..types import FileLike
-from ..utils import resolve_user_filepath
-from ..utils.http import set_cookies
 from ...exceptions import BadInput
-from ...exceptions import InvalidArgument
 from ...exceptions import BentoMLException
+from ...exceptions import InvalidArgument
 from ...exceptions import MissingDependencyException
 from ...grpc.utils import import_generated_stubs
 from ..service.openapi import SUCCESS_DESCRIPTION
-from ..service.openapi.specification import Schema
 from ..service.openapi.specification import MediaType
+from ..service.openapi.specification import Schema
+from ..types import FileLike
+from ..utils import resolve_user_filepath
+from ..utils.http import set_cookies
+from .base import IODescriptor
 
 logger = logging.getLogger(__name__)
 
@@ -30,8 +30,8 @@ if t.TYPE_CHECKING:
     from bentoml.grpc.v1 import service_pb2 as pb
     from bentoml.grpc.v1alpha1 import service_pb2 as pb_v1alpha1
 
-    from .base import OpenAPIResponse
     from ..context import ServiceContext as Context
+    from .base import OpenAPIResponse
 
     FileKind: t.TypeAlias = t.Literal["binaryio", "textio"]
 else:

--- a/src/bentoml/_internal/io_descriptors/image.py
+++ b/src/bentoml/_internal/io_descriptors/image.py
@@ -1,28 +1,28 @@
 from __future__ import annotations
 
+import functools
 import io
 import typing as t
-import functools
 from urllib.parse import quote
 
-from starlette.requests import Request
 from multipart.multipart import parse_options_header
-from starlette.responses import Response
 from starlette.datastructures import UploadFile
+from starlette.requests import Request
+from starlette.responses import Response
 
-from .base import IODescriptor
+from ...exceptions import BadInput
+from ...exceptions import InternalServerError
+from ...exceptions import InvalidArgument
+from ...exceptions import MissingDependencyException
+from ...grpc.utils import import_generated_stubs
+from ..service.openapi import SUCCESS_DESCRIPTION
+from ..service.openapi.specification import MediaType
+from ..service.openapi.specification import Schema
 from ..types import LazyType
 from ..utils import LazyLoader
 from ..utils import resolve_user_filepath
 from ..utils.http import set_cookies
-from ...exceptions import BadInput
-from ...exceptions import InvalidArgument
-from ...exceptions import InternalServerError
-from ...exceptions import MissingDependencyException
-from ...grpc.utils import import_generated_stubs
-from ..service.openapi import SUCCESS_DESCRIPTION
-from ..service.openapi.specification import Schema
-from ..service.openapi.specification import MediaType
+from .base import IODescriptor
 
 PIL_EXC_MSG = "'Pillow' is required to use the Image IO descriptor. Install with 'pip install bentoml[io-image]'."
 
@@ -32,11 +32,11 @@ if t.TYPE_CHECKING:
     import PIL
     import PIL.Image
 
-    from .. import external_typing as ext
-    from .base import OpenAPIResponse
-    from ..context import ServiceContext as Context
     from ...grpc.v1 import service_pb2 as pb
     from ...grpc.v1alpha1 import service_pb2 as pb_v1alpha1
+    from .. import external_typing as ext
+    from ..context import ServiceContext as Context
+    from .base import OpenAPIResponse
 
     _Mode = t.Literal[
         "1", "CMYK", "F", "HSV", "I", "L", "LAB", "P", "RGB", "RGBA", "RGBX", "YCbCr"

--- a/src/bentoml/_internal/io_descriptors/json.py
+++ b/src/bentoml/_internal/io_descriptors/json.py
@@ -1,26 +1,26 @@
 from __future__ import annotations
 
-import json
-import typing as t
-import logging
 import dataclasses
+import json
+import logging
+import typing as t
 
 import attr
 from starlette.requests import Request
 from starlette.responses import Response
 
-from .base import IODescriptor
-from ..types import LazyType
-from ..utils import LazyLoader
-from ..utils import bentoml_cattr
-from ..utils.pkg import pkg_version_info
-from ..utils.http import set_cookies
 from ...exceptions import BadInput
 from ...exceptions import InvalidArgument
 from ..service.openapi import REF_PREFIX
 from ..service.openapi import SUCCESS_DESCRIPTION
-from ..service.openapi.specification import Schema
 from ..service.openapi.specification import MediaType
+from ..service.openapi.specification import Schema
+from ..types import LazyType
+from ..utils import LazyLoader
+from ..utils import bentoml_cattr
+from ..utils.http import set_cookies
+from ..utils.pkg import pkg_version_info
+from .base import IODescriptor
 
 EXC_MSG = "'pydantic' must be installed to use 'pydantic_model'. Install with 'pip install bentoml[io-json]'."
 
@@ -37,8 +37,8 @@ if t.TYPE_CHECKING:
     from google.protobuf import struct_pb2
     from typing_extensions import Self
 
-    from .base import OpenAPIResponse
     from ..context import ServiceContext as Context
+    from .base import OpenAPIResponse
 
 else:
     pydantic = LazyLoader("pydantic", globals(), "pydantic", exc_msg=EXC_MSG)

--- a/src/bentoml/_internal/io_descriptors/multipart.py
+++ b/src/bentoml/_internal/io_descriptors/multipart.py
@@ -1,22 +1,22 @@
 from __future__ import annotations
 
-import typing as t
 import asyncio
+import typing as t
 
-from starlette.requests import Request
 from multipart.multipart import parse_options_header
+from starlette.requests import Request
 from starlette.responses import Response
 
-from . import from_spec as io_descriptor_from_spec
-from .base import IODescriptor
-from ...exceptions import InvalidArgument
 from ...exceptions import BentoMLException
+from ...exceptions import InvalidArgument
 from ...grpc.utils import import_generated_stubs
 from ..service.openapi import SUCCESS_DESCRIPTION
-from ..utils.formparser import populate_multipart_requests
-from ..utils.formparser import concat_to_multipart_response
-from ..service.openapi.specification import Schema
 from ..service.openapi.specification import MediaType
+from ..service.openapi.specification import Schema
+from ..utils.formparser import concat_to_multipart_response
+from ..utils.formparser import populate_multipart_requests
+from . import from_spec as io_descriptor_from_spec
+from .base import IODescriptor
 
 if t.TYPE_CHECKING:
     from types import UnionType
@@ -26,9 +26,9 @@ if t.TYPE_CHECKING:
     from bentoml.grpc.v1 import service_pb2 as pb
     from bentoml.grpc.v1alpha1 import service_pb2 as pb_v1alpha1
 
-    from .base import OpenAPIResponse
-    from ..types import LazyType
     from ..context import ServiceContext as Context
+    from ..types import LazyType
+    from .base import OpenAPIResponse
 else:
     pb, _ = import_generated_stubs("v1")
     pb_v1alpha1, _ = import_generated_stubs("v1alpha1")

--- a/src/bentoml/_internal/io_descriptors/numpy.py
+++ b/src/bentoml/_internal/io_descriptors/numpy.py
@@ -1,25 +1,25 @@
 from __future__ import annotations
 
 import json
-import typing as t
 import logging
+import typing as t
 from functools import lru_cache
 
 from starlette.requests import Request
 from starlette.responses import Response
 
-from .base import IODescriptor
-from ..types import LazyType
-from ..utils import LazyLoader
-from ..utils.http import set_cookies
 from ...exceptions import BadInput
 from ...exceptions import InvalidArgument
 from ...exceptions import UnprocessableEntity
-from ...grpc.utils import import_generated_stubs
 from ...grpc.utils import LATEST_PROTOCOL_VERSION
+from ...grpc.utils import import_generated_stubs
 from ..service.openapi import SUCCESS_DESCRIPTION
-from ..service.openapi.specification import Schema
 from ..service.openapi.specification import MediaType
+from ..service.openapi.specification import Schema
+from ..types import LazyType
+from ..utils import LazyLoader
+from ..utils.http import set_cookies
+from .base import IODescriptor
 
 if t.TYPE_CHECKING:
     import numpy as np
@@ -31,8 +31,8 @@ if t.TYPE_CHECKING:
     from bentoml.grpc.v1alpha1 import service_pb2 as pb_v1alpha1
 
     from .. import external_typing as ext
-    from .base import OpenAPIResponse
     from ..context import ServiceContext as Context
+    from .base import OpenAPIResponse
 else:
     pb, _ = import_generated_stubs("v1")
     pb_v1alpha1, _ = import_generated_stubs("v1alpha1")
@@ -646,9 +646,9 @@ class NumpyNdarray(
         return pyarrow.RecordBatch.from_arrays([pyarrow.array(arr)], names=["output"])
 
     def spark_schema(self) -> pyspark.sql.types.StructType:
-        from pyspark.sql.types import StructType
-        from pyspark.sql.types import StructField
         from pyspark.pandas.typedef import as_spark_type
+        from pyspark.sql.types import StructField
+        from pyspark.sql.types import StructType
 
         if self._dtype is None:
             raise InvalidArgument(

--- a/src/bentoml/_internal/io_descriptors/pandas.py
+++ b/src/bentoml/_internal/io_descriptors/pandas.py
@@ -1,29 +1,29 @@
 from __future__ import annotations
 
+import functools
 import io
+import logging
 import os
 import typing as t
-import logging
-import functools
-from enum import Enum
 from concurrent.futures import ThreadPoolExecutor
+from enum import Enum
 
 from starlette.requests import Request
 from starlette.responses import Response
 
-from .base import IODescriptor
-from ..types import LazyType
-from ..utils.pkg import find_spec
-from ..utils.http import set_cookies
 from ...exceptions import BadInput
 from ...exceptions import InvalidArgument
-from ...exceptions import UnprocessableEntity
 from ...exceptions import MissingDependencyException
+from ...exceptions import UnprocessableEntity
 from ...grpc.utils import import_generated_stubs
 from ..service.openapi import SUCCESS_DESCRIPTION
-from ..utils.lazy_loader import LazyLoader
-from ..service.openapi.specification import Schema
 from ..service.openapi.specification import MediaType
+from ..service.openapi.specification import Schema
+from ..types import LazyType
+from ..utils.http import set_cookies
+from ..utils.lazy_loader import LazyLoader
+from ..utils.pkg import find_spec
+from .base import IODescriptor
 
 EXC_MSG = "pandas' is required to use PandasDataFrame or PandasSeries. Install with 'pip install bentoml[io-pandas]'"
 
@@ -38,8 +38,8 @@ if t.TYPE_CHECKING:
     from bentoml.grpc.v1alpha1 import service_pb2 as pb_v1alpha1
 
     from .. import external_typing as ext
-    from .base import OpenAPIResponse
     from ..context import ServiceContext as Context
+    from .base import OpenAPIResponse
 
 else:
     pb, _ = import_generated_stubs("v1")
@@ -751,9 +751,9 @@ class PandasDataFrame(
         return pyarrow.RecordBatch.from_pandas(df)
 
     def spark_schema(self) -> pyspark.sql.types.StructType:
-        from pyspark.sql.types import StructType
-        from pyspark.sql.types import StructField
         from pyspark.pandas.typedef import as_spark_type
+        from pyspark.sql.types import StructField
+        from pyspark.sql.types import StructType
 
         if self._dtype is None or self._dtype:
             raise InvalidArgument(
@@ -1211,9 +1211,9 @@ class PandasSeries(
         return pyarrow.RecordBatch.from_pandas(df)
 
     def spark_schema(self) -> pyspark.sql.types.StructType:
-        from pyspark.sql.types import StructType
-        from pyspark.sql.types import StructField
         from pyspark.pandas.typedef import as_spark_type
+        from pyspark.sql.types import StructField
+        from pyspark.sql.types import StructType
 
         if self._dtype is None or self._dtype is True:
             raise InvalidArgument(

--- a/src/bentoml/_internal/io_descriptors/text.py
+++ b/src/bentoml/_internal/io_descriptors/text.py
@@ -5,20 +5,20 @@ import typing as t
 from starlette.requests import Request
 from starlette.responses import Response
 
-from .base import IODescriptor
-from ..utils.http import set_cookies
 from ...exceptions import BentoMLException
 from ..service.openapi import SUCCESS_DESCRIPTION
-from ..utils.lazy_loader import LazyLoader
-from ..service.openapi.specification import Schema
 from ..service.openapi.specification import MediaType
+from ..service.openapi.specification import Schema
+from ..utils.http import set_cookies
+from ..utils.lazy_loader import LazyLoader
+from .base import IODescriptor
 
 if t.TYPE_CHECKING:
     from google.protobuf import wrappers_pb2
     from typing_extensions import Self
 
-    from .base import OpenAPIResponse
     from ..context import ServiceContext as Context
+    from .base import OpenAPIResponse
 else:
     wrappers_pb2 = LazyLoader("wrappers_pb2", globals(), "google.protobuf.wrappers_pb2")
 

--- a/src/bentoml/_internal/log.py
+++ b/src/bentoml/_internal/log.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import typing as t
 import logging
 import logging.config
+import typing as t
 from functools import lru_cache
 
-from .context import trace_context
-from .context import component_context
 from .configuration import get_debug_mode
 from .configuration import get_quiet_mode
+from .context import component_context
+from .context import trace_context
 
 default_factory = logging.getLogRecordFactory()
 

--- a/src/bentoml/_internal/marshal/dispatcher.py
+++ b/src/bentoml/_internal/marshal/dispatcher.py
@@ -1,25 +1,25 @@
 from __future__ import annotations
 
-import time
-import typing as t
 import asyncio
-import logging
-import functools
-import traceback
 import collections
+import functools
+import logging
+import time
+import traceback
+import typing as t
+from functools import cached_property
 
 import attr
 import numpy as np
 
-from functools import cached_property
 from ..utils.alg import TokenBucket
 
 logger = logging.getLogger(__name__)
 
 
 if t.TYPE_CHECKING:
-    from ..runner.utils import Params
     from ..runner.container import Payload
+    from ..runner.utils import Params
 
 
 class NonBlockSema:

--- a/src/bentoml/_internal/models/__init__.py
+++ b/src/bentoml/_internal/models/__init__.py
@@ -1,8 +1,8 @@
 from .model import Model
-from .model import copy_model
-from .model import ModelStore
 from .model import ModelContext
 from .model import ModelOptions
+from .model import ModelStore
+from .model import copy_model
 
 # Deprecated. Use framework module local constants and name the saved files with API
 # Version in mind. E.g.:

--- a/src/bentoml/_internal/models/model.py
+++ b/src/bentoml/_internal/models/model.py
@@ -1,49 +1,49 @@
 from __future__ import annotations
 
+import importlib
 import io
+import logging
 import os
 import typing as t
-import logging
-import importlib
-from sys import version_info as pyver
-from types import ModuleType
-from typing import overload
-from typing import TYPE_CHECKING
 from datetime import datetime
 from datetime import timezone
+from sys import version_info as pyver
+from types import ModuleType
+from typing import TYPE_CHECKING
+from typing import overload
 
-import fs
 import attr
-import yaml
+import cloudpickle  # type: ignore (no cloudpickle types)
+import fs
 import fs.errors
 import fs.mirror
-import cloudpickle  # type: ignore (no cloudpickle types)
-from fs.base import FS
-from cattr.gen import override
+import yaml
 from cattr.gen import make_dict_structure_fn
 from cattr.gen import make_dict_unstructure_fn
-from simple_di import inject
+from cattr.gen import override
+from fs.base import FS
 from simple_di import Provide
+from simple_di import inject
 
-from ..tag import Tag
+from ...exceptions import BentoMLException
+from ...exceptions import NotFound
+from ..configuration import BENTOML_VERSION
+from ..configuration.containers import BentoMLContainer
 from ..store import Store
 from ..store import StoreItem
+from ..tag import Tag
 from ..types import MetadataDict
+from ..types import ModelSignatureDict
 from ..utils import bentoml_cattr
 from ..utils import label_validator
 from ..utils import metadata_validator
 from ..utils import normalize_labels_value
-from ...exceptions import NotFound
-from ...exceptions import BentoMLException
-from ..configuration import BENTOML_VERSION
-from ..configuration.containers import BentoMLContainer
-from ..types import ModelSignatureDict
 
 if t.TYPE_CHECKING:
-    from ..types import PathType
-    from ..runner import Runner
     from ..runner import Runnable
+    from ..runner import Runner
     from ..runner.strategy import Strategy
+    from ..types import PathType
 
 
 T = t.TypeVar("T")

--- a/src/bentoml/_internal/monitoring/__init__.py
+++ b/src/bentoml/_internal/monitoring/__init__.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import typing as t
-import logging
 import importlib
+import logging
+import typing as t
 
+from ...exceptions import MissingDependencyException
 from .api import monitor
 from .base import MonitorBase
 from .base import NoOpMonitor
 from .default import DefaultMonitor
-from ...exceptions import MissingDependencyException
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/monitoring/api.py
+++ b/src/bentoml/_internal/monitoring/api.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-import typing as t
-import logging
 import contextlib
+import logging
 import logging.config
+import typing as t
 
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
+from ..configuration.containers import BentoMLContainer
+from ..types import LazyType
 from .base import MT
 from .base import MonitorBase
 from .base import NoOpMonitor
-from ..types import LazyType
 from .default import DefaultMonitor
-from ..configuration.containers import BentoMLContainer
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/monitoring/base.py
+++ b/src/bentoml/_internal/monitoring/base.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import typing as t
-import logging
 import collections
 import contextvars
+import logging
+import typing as t
 
 MON_COLUMN_VAR: contextvars.ContextVar[
     "dict[str, dict[str, str]] | None"

--- a/src/bentoml/_internal/monitoring/default.py
+++ b/src/bentoml/_internal/monitoring/default.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-import typing as t
-import logging
-import datetime
 import collections
+import datetime
+import logging
 import logging.config
+import typing as t
 from pathlib import Path
 
 import yaml
 
-from .base import MonitorBase
-from ..context import trace_context
 from ..context import component_context
+from ..context import trace_context
+from .base import MonitorBase
 
 if t.TYPE_CHECKING:
     from ..types import JSONSerializable

--- a/src/bentoml/_internal/monitoring/otlp.py
+++ b/src/bentoml/_internal/monitoring/otlp.py
@@ -1,30 +1,30 @@
 from __future__ import annotations
 
+import collections
+import datetime
+import logging
+import logging.config
 import os
 import random
 import typing as t
-import logging
-import datetime
-import collections
-import logging.config
 
 # NOTE: AFAIK, they move this function from opentelemetry.sdk.logs to opentelemetry._logs
 from opentelemetry._logs import set_logger_provider
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs import LoggingHandler
-from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
-from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_HEADERS
-from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_TIMEOUT
-from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_ENDPOINT
-from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_INSECURE
 from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_CERTIFICATE
 from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_COMPRESSION
+from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_ENDPOINT
+from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_HEADERS
+from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_INSECURE
+from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_TIMEOUT
+from opentelemetry.sdk.resources import Resource
 
-from .base import MonitorBase
-from ..context import trace_context
-from ..context import component_context
 from ...exceptions import MissingDependencyException
+from ..context import component_context
+from ..context import trace_context
+from .base import MonitorBase
 
 try:
     from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
@@ -135,8 +135,8 @@ class OTLPMonitor(MonitorBase["JSONSerializable"]):
         self._will_export_schema = False
 
     def _init_logger(self) -> None:
-        from opentelemetry.sdk.resources import SERVICE_NAME
         from opentelemetry.sdk.resources import SERVICE_INSTANCE_ID
+        from opentelemetry.sdk.resources import SERVICE_NAME
         from opentelemetry.sdk.resources import OTELResourceDetector
 
         # User can optionally configure the resource with the following environment variables. Only

--- a/src/bentoml/_internal/ray/__init__.py
+++ b/src/bentoml/_internal/ray/__init__.py
@@ -10,9 +10,9 @@ import bentoml
 from bentoml import Tag
 
 from ...exceptions import MissingDependencyException
+from ..runner.container import AutoContainer
 from ..runner.utils import Params
 from .runner_handle import RayRunnerHandle
-from ..runner.container import AutoContainer
 
 try:
     from ray import serve

--- a/src/bentoml/_internal/ray/runner_handle.py
+++ b/src/bentoml/_internal/ray/runner_handle.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import typing as t
 import functools
+import typing as t
 
-from ..runner import Runner
 from ...exceptions import MissingDependencyException
+from ..runner import Runner
 from ..runner.runner import RunnerMethod
 from ..runner.runner_handle import RunnerHandle
 

--- a/src/bentoml/_internal/resource.py
+++ b/src/bentoml/_internal/resource.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import functools
+import logging
+import math
 import os
 import re
-import math
 import typing as t
-import logging
-import functools
 from abc import ABC
 from abc import abstractmethod
 

--- a/src/bentoml/_internal/runner/__init__.py
+++ b/src/bentoml/_internal/runner/__init__.py
@@ -1,4 +1,4 @@
-from .runner import Runner
 from .runnable import Runnable
+from .runner import Runner
 
 __all__ = ["Runner", "Runnable"]

--- a/src/bentoml/_internal/runner/container.py
+++ b/src/bentoml/_internal/runner/container.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import abc
 import base64
+import itertools
 import pickle
 import typing as t
-import itertools
 
 from ..types import LazyType
 from ..utils import LazyLoader
+from ..utils.pickle import fixed_torch_loads
 from ..utils.pickle import pep574_dumps
 from ..utils.pickle import pep574_loads
-from ..utils.pickle import fixed_torch_loads
 
 SingleType = t.TypeVar("SingleType")
 BatchType = t.TypeVar("BatchType")

--- a/src/bentoml/_internal/runner/runnable.py
+++ b/src/bentoml/_internal/runner/runnable.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import typing as t
 import logging
-from typing import overload
+import typing as t
 from typing import TYPE_CHECKING
+from typing import overload
 
 import attr
 
-from ..types import LazyType
 from ...exceptions import BentoMLException
+from ..types import LazyType
 
 if TYPE_CHECKING:
     from ..types import AnyType

--- a/src/bentoml/_internal/runner/runner.py
+++ b/src/bentoml/_internal/runner/runner.py
@@ -1,24 +1,24 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from abc import ABC
 from abc import abstractmethod
 
 import attr
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
+from ...exceptions import StateException
+from ..configuration.containers import BentoMLContainer
+from ..models.model import Model
 from ..tag import validate_tag_str
 from ..utils import first_not_none
 from .runnable import Runnable
-from .strategy import Strategy
-from .strategy import DefaultStrategy
-from ...exceptions import StateException
-from ..models.model import Model
-from .runner_handle import RunnerHandle
 from .runner_handle import DummyRunnerHandle
-from ..configuration.containers import BentoMLContainer
+from .runner_handle import RunnerHandle
+from .strategy import DefaultStrategy
+from .strategy import Strategy
 
 if t.TYPE_CHECKING:
     from ...triton import Runner as TritonRunner

--- a/src/bentoml/_internal/runner/runner_handle/__init__.py
+++ b/src/bentoml/_internal/runner/runner_handle/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from abc import ABC
 from abc import abstractmethod
 from typing import TYPE_CHECKING
@@ -9,9 +9,9 @@ from typing import TYPE_CHECKING
 from ....exceptions import StateException
 
 if TYPE_CHECKING:
+    from ..runner import AbstractRunner
     from ..runner import Runner
     from ..runner import RunnerMethod
-    from ..runner import AbstractRunner
 
     R = t.TypeVar("R")
     P = t.ParamSpec("P")

--- a/src/bentoml/_internal/runner/runner_handle/local.py
+++ b/src/bentoml/_internal/runner/runner_handle/local.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-import typing as t
 import functools
+import typing as t
 from typing import TYPE_CHECKING
 
 import anyio
 
-from . import RunnerHandle
-from ..utils import Params
-from ..container import Payload
 from ..container import AutoContainer
+from ..container import Payload
+from ..utils import Params
+from . import RunnerHandle
 
 if TYPE_CHECKING:
     from ..runner import Runner

--- a/src/bentoml/_internal/runner/runner_handle/remote.py
+++ b/src/bentoml/_internal/runner/runner_handle/remote.py
@@ -1,40 +1,40 @@
 from __future__ import annotations
 
-import os
-import json
-import time
-import pickle
-import typing as t
 import asyncio
-import logging
 import functools
+import json
+import logging
+import os
+import pickle
+import time
 import traceback
+import typing as t
 from json.decoder import JSONDecodeError
 from urllib.parse import urlparse
 
-from . import RunnerHandle
-from ..utils import Params
-from ..utils import PAYLOAD_META_HEADER
-from ...utils import LazyLoader
-from ...context import component_context
-from ..container import Payload
-from ...utils.uri import uri_to_path
 from ....exceptions import RemoteException
 from ....exceptions import ServiceUnavailable
 from ...configuration.containers import BentoMLContainer
+from ...context import component_context
+from ...utils import LazyLoader
+from ...utils.uri import uri_to_path
+from ..container import Payload
+from ..utils import PAYLOAD_META_HEADER
+from ..utils import Params
+from . import RunnerHandle
 
 TRITON_EXC_MSG = "tritonclient is required to use triton with BentoML. Install with 'pip install \"tritonclient[all]>=2.29.0\"'."
 
 if t.TYPE_CHECKING:
-    import yarl
     import tritonclient.grpc.aio as tritongrpcclient
     import tritonclient.http.aio as tritonhttpclient
+    import yarl
     from aiohttp import BaseConnector
     from aiohttp.client import ClientSession
 
+    from ....triton import Runner as TritonRunner
     from ..runner import Runner
     from ..runner import RunnerMethod
-    from ....triton import Runner as TritonRunner
 
     P = t.ParamSpec("P")
     R = t.TypeVar("R")

--- a/src/bentoml/_internal/runner/strategy.py
+++ b/src/bentoml/_internal/runner/strategy.py
@@ -5,7 +5,8 @@ import logging
 import math
 import typing as t
 
-from ..resource import get_resource, system_resources
+from ..resource import get_resource
+from ..resource import system_resources
 from .runnable import Runnable
 
 logger = logging.getLogger(__name__)

--- a/src/bentoml/_internal/runner/utils.py
+++ b/src/bentoml/_internal/runner/utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import typing as t
-import logging
 import itertools
+import logging
+import typing as t
 from typing import TYPE_CHECKING
 
 from bentoml.exceptions import InvalidArgument

--- a/src/bentoml/_internal/server/grpc_app.py
+++ b/src/bentoml/_internal/server/grpc_app.py
@@ -7,6 +7,7 @@ import os
 import sys
 import typing as t
 from concurrent.futures import ThreadPoolExecutor
+from functools import cached_property
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -20,8 +21,6 @@ from ...grpc.utils import load_from_file
 from ..configuration.containers import BentoMLContainer
 from ..context import ServiceContext as Context
 from ..utils import LazyLoader
-from functools import cached_property
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/server/http/access.py
+++ b/src/bentoml/_internal/server/http/access.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
+from contextvars import ContextVar
 from timeit import default_timer
 from typing import TYPE_CHECKING
-from contextvars import ContextVar
 
 if TYPE_CHECKING:
     from ... import external_typing as ext

--- a/src/bentoml/_internal/server/http/instruments.py
+++ b/src/bentoml/_internal/server/http/instruments.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-import logging
 import contextvars
+import logging
 from timeit import default_timer
 from typing import TYPE_CHECKING
 
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
-from ...context import component_context
 from ...configuration.containers import BentoMLContainer
+from ...context import component_context
 
 if TYPE_CHECKING:
     from ... import external_typing as ext

--- a/src/bentoml/_internal/server/metrics/prometheus.py
+++ b/src/bentoml/_internal/server/metrics/prometheus.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import typing as t
-import logging
-from typing import TYPE_CHECKING
 from functools import partial
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ... import external_typing as ext
@@ -60,11 +60,11 @@ class PrometheusClient:
 
         # step 2:
         import prometheus_client
-        import prometheus_client.parser
-        import prometheus_client.metrics
         import prometheus_client.exposition
+        import prometheus_client.metrics
         import prometheus_client.metrics_core
         import prometheus_client.multiprocess
+        import prometheus_client.parser
 
         self._imported = True
         return prometheus_client

--- a/src/bentoml/_internal/service/inference_api.py
+++ b/src/bentoml/_internal/service/inference_api.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
+import inspect
 import re
 import typing as t
-import inspect
 from typing import Optional
 
 import yaml
 
-from ..types import is_compatible_type
-from ..context import ServiceContext as Context
 from ...exceptions import InvalidArgument
+from ..context import ServiceContext as Context
 from ..io_descriptors import IODescriptor
+from ..types import is_compatible_type
 
 RESERVED_API_NAMES = [
     "index",

--- a/src/bentoml/_internal/service/loader.py
+++ b/src/bentoml/_internal/service/loader.py
@@ -1,29 +1,29 @@
 from __future__ import annotations
 
+import importlib
+import logging
 import os
 import sys
 import typing as t
-import logging
-import importlib
 from typing import TYPE_CHECKING
 
 import fs
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
-from ..tag import Tag
-from ..bento import Bento
-from ..models import ModelStore
-from .service import on_load_bento
-from ...exceptions import NotFound
 from ...exceptions import BentoMLException
 from ...exceptions import ImportServiceError
-from ..bento.bento import BENTO_YAML_FILENAME
+from ...exceptions import NotFound
+from ..bento import Bento
 from ..bento.bento import BENTO_PROJECT_DIR_NAME
+from ..bento.bento import BENTO_YAML_FILENAME
 from ..bento.bento import DEFAULT_BENTO_BUILD_FILE
-from ..configuration import BENTOML_VERSION
 from ..bento.build_config import BentoBuildConfig
+from ..configuration import BENTOML_VERSION
 from ..configuration.containers import BentoMLContainer
+from ..models import ModelStore
+from ..tag import Tag
+from .service import on_load_bento
 
 if TYPE_CHECKING:
     from ..bento import BentoStore

--- a/src/bentoml/_internal/service/openapi/__init__.py
+++ b/src/bentoml/_internal/service/openapi/__init__.py
@@ -1,31 +1,31 @@
 from __future__ import annotations
 
 import typing as t
+from functools import lru_cache
 from http import HTTPStatus
 from typing import TYPE_CHECKING
-from functools import lru_cache
 
 from deepmerge.merger import Merger
 
-from bentoml.exceptions import NotFound
-from bentoml.exceptions import InvalidArgument
 from bentoml.exceptions import InternalServerError
+from bentoml.exceptions import InvalidArgument
+from bentoml.exceptions import NotFound
 
-from .utils import REF_PREFIX
-from .utils import exception_schema
-from .utils import exception_components_schema
 from ...types import LazyType
 from ...utils import bentoml_cattr
-from .specification import Tag
-from .specification import Info
-from .specification import Contact
-from .specification import PathItem
-from .specification import Response
-from .specification import MediaType
-from .specification import Operation
-from .specification import Reference
 from .specification import Components
+from .specification import Contact
+from .specification import Info
+from .specification import MediaType
 from .specification import OpenAPISpecification
+from .specification import Operation
+from .specification import PathItem
+from .specification import Reference
+from .specification import Response
+from .specification import Tag
+from .utils import REF_PREFIX
+from .utils import exception_components_schema
+from .utils import exception_schema
 
 if TYPE_CHECKING:
     from .. import Service

--- a/src/bentoml/_internal/service/openapi/specification.py
+++ b/src/bentoml/_internal/service/openapi/specification.py
@@ -10,14 +10,14 @@ webhooks, securities, etc. are yet to be implemented/exposed to user.
 """
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 
 import attr
-import yaml
 import cattr.errors
-from cattr.gen import override
+import yaml
 from cattr.gen import make_dict_unstructure_fn
+from cattr.gen import override
 
 from ...utils import bentoml_cattr
 

--- a/src/bentoml/_internal/service/openapi/utils.py
+++ b/src/bentoml/_internal/service/openapi/utils.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import typing as t
-from typing import TYPE_CHECKING
 from functools import lru_cache
+from typing import TYPE_CHECKING
 
-from bentoml.exceptions import NotFound
-from bentoml.exceptions import InvalidArgument
 from bentoml.exceptions import InternalServerError
+from bentoml.exceptions import InvalidArgument
+from bentoml.exceptions import NotFound
 
 from ...utils import LazyLoader
 from ...utils.pkg import pkg_version_info

--- a/src/bentoml/_internal/store.py
+++ b/src/bentoml/_internal/store.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import datetime
 import os
 import typing as t
-import datetime
 from abc import ABC
 from abc import abstractmethod
 from contextlib import contextmanager
@@ -11,11 +11,11 @@ import fs
 import fs.errors
 from fs.base import FS
 
+from ..exceptions import BentoMLException
+from ..exceptions import NotFound
+from .exportable import Exportable
 from .tag import Tag
 from .types import PathType
-from .exportable import Exportable
-from ..exceptions import NotFound
-from ..exceptions import BentoMLException
 
 T = t.TypeVar("T")
 

--- a/src/bentoml/_internal/tag.py
+++ b/src/bentoml/_internal/tag.py
@@ -1,14 +1,14 @@
-import re
-import uuid
 import base64
-import typing as t
 import logging
+import re
+import typing as t
+import uuid
 
-import fs
 import attr
+import fs
 
-from .utils import bentoml_cattr
 from ..exceptions import BentoMLException
+from .utils import bentoml_cattr
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/utils/analytics/__init__.py
+++ b/src/bentoml/_internal/utils/analytics/__init__.py
@@ -1,13 +1,13 @@
+from .cli_events import cli_events_map
+from .schemas import BentoBuildEvent
 from .schemas import CliEvent
 from .schemas import ModelSaveEvent
-from .schemas import BentoBuildEvent
 from .schemas import ServeUpdateEvent
-from .cli_events import cli_events_map
-from .usage_stats import track
-from .usage_stats import ServeInfo
-from .usage_stats import track_serve
-from .usage_stats import get_serve_info
 from .usage_stats import BENTOML_DO_NOT_TRACK
+from .usage_stats import ServeInfo
+from .usage_stats import get_serve_info
+from .usage_stats import track
+from .usage_stats import track_serve
 
 __all__ = [
     "track",

--- a/src/bentoml/_internal/utils/analytics/schemas.py
+++ b/src/bentoml/_internal/utils/analytics/schemas.py
@@ -1,26 +1,27 @@
 from __future__ import annotations
+
 import os
 import re
-import uuid
 import typing as t
+import uuid
 from abc import ABC
 from datetime import datetime
 from datetime import timezone
+from functools import lru_cache
 from platform import platform
 from platform import python_version
-from functools import lru_cache
 
 import attr
-import yaml
-import psutil
 import attr.converters
-from simple_di import inject
+import psutil
+import yaml
 from simple_di import Provide
+from simple_di import inject
 
-from ...utils import bentoml_cattr
 from ...cloud.config import CloudClientConfig
 from ...configuration import BENTOML_VERSION
 from ...configuration.containers import BentoMLContainer
+from ...utils import bentoml_cattr
 
 if t.TYPE_CHECKING:
     from pathlib import Path

--- a/src/bentoml/_internal/utils/analytics/usage_stats.py
+++ b/src/bentoml/_internal/utils/analytics/usage_stats.py
@@ -1,30 +1,30 @@
 from __future__ import annotations
 
-import os
-import typing as t
+import contextlib
 import logging
+import os
 import secrets
 import threading
-import contextlib
-from typing import TYPE_CHECKING
+import typing as t
 from datetime import datetime
 from datetime import timezone
-from functools import wraps
 from functools import lru_cache
+from functools import wraps
+from typing import TYPE_CHECKING
 
 import attr
 import requests
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
-from ...utils import compose
-from .schemas import EventMeta
-from .schemas import ServeInitEvent
-from .schemas import TrackingPayload
-from .schemas import CommonProperties
-from .schemas import ServeUpdateEvent
 from ...configuration import get_debug_mode
 from ...configuration.containers import BentoMLContainer
+from ...utils import compose
+from .schemas import CommonProperties
+from .schemas import EventMeta
+from .schemas import ServeInitEvent
+from .schemas import ServeUpdateEvent
+from .schemas import TrackingPayload
 
 if TYPE_CHECKING:
     P = t.ParamSpec("P")

--- a/src/bentoml/_internal/utils/benchmark.py
+++ b/src/bentoml/_internal/utils/benchmark.py
@@ -1,6 +1,6 @@
+import asyncio
 import math
 import time
-import asyncio
 from collections import defaultdict
 
 from tabulate import tabulate

--- a/src/bentoml/_internal/utils/buildx.py
+++ b/src/bentoml/_internal/utils/buildx.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 import typing as t
 import warnings
 
-from ..container import health as _internal_container_health
 from ..container import get_backend
+from ..container import health as _internal_container_health
 
 __all__ = ["build", "health"]
 

--- a/src/bentoml/_internal/utils/circus/watchfilesplugin.py
+++ b/src/bentoml/_internal/utils/circus/watchfilesplugin.py
@@ -1,23 +1,23 @@
 from __future__ import annotations
 
+import logging
 import os
 import typing as t
-import logging
-from typing import TYPE_CHECKING
 from pathlib import Path
 from threading import Event
 from threading import Thread
+from typing import TYPE_CHECKING
 
 import fs
-from watchfiles import watch
 from circus.plugins import CircusPlugin
+from watchfiles import watch
 
-from ...log import configure_server_logging
-from ...context import component_context
-from ...utils.pkg import source_locations
-from ...configuration import is_pypi_installed_bentoml
-from ...bento.build_config import BentoPathSpec
 from ...bento.build_config import BentoBuildConfig
+from ...bento.build_config import BentoPathSpec
+from ...configuration import is_pypi_installed_bentoml
+from ...context import component_context
+from ...log import configure_server_logging
+from ...utils.pkg import source_locations
 
 if TYPE_CHECKING:
     from watchfiles.main import FileChange

--- a/src/bentoml/_internal/utils/dotenv.py
+++ b/src/bentoml/_internal/utils/dotenv.py
@@ -25,10 +25,10 @@ for original implementation
 """
 from __future__ import annotations
 
+import logging
 import os
 import re
 import typing as t
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/_internal/utils/formparser.py
+++ b/src/bentoml/_internal/utils/formparser.py
@@ -1,24 +1,24 @@
 from __future__ import annotations
 
 import io
-import uuid
 import typing as t
+import uuid
+from dataclasses import dataclass
+from dataclasses import field
 from enum import Enum
 from tempfile import SpooledTemporaryFile
-from dataclasses import field
-from dataclasses import dataclass
 from urllib.parse import unquote_plus
 
 import multipart.multipart as multipart
+from starlette.datastructures import FormData
+from starlette.datastructures import Headers
+from starlette.datastructures import MutableHeaders
+from starlette.datastructures import UploadFile
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.datastructures import Headers
-from starlette.datastructures import FormData
-from starlette.datastructures import UploadFile
-from starlette.datastructures import MutableHeaders
 
-from .http import set_cookies
 from ...exceptions import BentoMLException
+from .http import set_cookies
 
 if t.TYPE_CHECKING:
     from ..context import ServiceContext as Context

--- a/src/bentoml/_internal/utils/lazy_loader.py
+++ b/src/bentoml/_internal/utils/lazy_loader.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import importlib
+import logging
 import sys
 import types
 import typing as t
-import logging
-import importlib
 
 from ...exceptions import MissingDependencyException
 

--- a/src/bentoml/_internal/utils/pickle.py
+++ b/src/bentoml/_internal/utils/pickle.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import io
-import typing as t
-
 import pickle
-
+import typing as t
 
 # Pickle protocol 5 with out-of-band data. ref: https://peps.python.org/pep-0574/
 

--- a/src/bentoml/_internal/utils/pkg.py
+++ b/src/bentoml/_internal/utils/pkg.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
+import importlib.metadata
+import importlib.util
+from importlib.metadata import PackageNotFoundError
 from types import ModuleType
 from typing import cast
-
-import importlib.metadata
-from importlib.metadata import PackageNotFoundError
-import importlib.util
 
 from packaging.version import Version
 

--- a/src/bentoml/_internal/utils/telemetry.py
+++ b/src/bentoml/_internal/utils/telemetry.py
@@ -2,17 +2,17 @@
 import typing as t
 from typing import TYPE_CHECKING
 
-from opentelemetry.trace import get_current_span
-from opentelemetry.sdk.trace.sampling import Decision
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
+from opentelemetry.sdk.trace.sampling import Decision
 from opentelemetry.sdk.trace.sampling import ParentBased
-from opentelemetry.sdk.trace.sampling import StaticSampler
 from opentelemetry.sdk.trace.sampling import SamplingResult
+from opentelemetry.sdk.trace.sampling import StaticSampler
 from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+from opentelemetry.trace import get_current_span
 
 if TYPE_CHECKING:
-    from opentelemetry.trace import Link
     from opentelemetry.trace import Context
+    from opentelemetry.trace import Link
     from opentelemetry.trace import SpanKind
     from opentelemetry.trace import TraceState
     from opentelemetry.util.types import Attributes

--- a/src/bentoml/_internal/utils/unflatten.py
+++ b/src/bentoml/_internal/utils/unflatten.py
@@ -35,8 +35,8 @@ IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 """
-from __future__ import annotations
 from __future__ import absolute_import
+from __future__ import annotations
 
 import re
 import sys

--- a/src/bentoml/bentos.py
+++ b/src/bentoml/bentos.py
@@ -4,34 +4,34 @@ User facing python APIs for managing local bentos and build new bentos.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
-import typing as t
-import logging
-import tempfile
 import subprocess
+import tempfile
+import typing as t
 
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
-from .exceptions import BadInput
-from .exceptions import InvalidArgument
-from .exceptions import BentoMLException
-from ._internal.tag import Tag
 from ._internal.bento import Bento
-from ._internal.utils import resolve_user_filepath
 from ._internal.bento.build_config import BentoBuildConfig
 from ._internal.configuration.containers import BentoMLContainer
+from ._internal.tag import Tag
+from ._internal.utils import resolve_user_filepath
 from ._internal.utils.analytics.usage_stats import _usage_event_debugging
+from .exceptions import BadInput
+from .exceptions import BentoMLException
+from .exceptions import InvalidArgument
 
 if t.TYPE_CHECKING:
-    from .server import Server
     from ._internal.bento import BentoStore
-    from ._internal.cloud import BentoCloudClient
     from ._internal.bento.build_config import CondaOptions
     from ._internal.bento.build_config import DockerOptions
-    from ._internal.bento.build_config import PythonOptions
     from ._internal.bento.build_config import ModelSpec
+    from ._internal.bento.build_config import PythonOptions
+    from ._internal.cloud import BentoCloudClient
+    from .server import Server
 
 
 logger = logging.getLogger(__name__)

--- a/src/bentoml/catboost.py
+++ b/src/bentoml/catboost.py
@@ -1,7 +1,9 @@
+from ._internal.frameworks.catboost import (
+    CatBoostOptions as ModelOptions,  # type: ignore # noqa
+)
 from ._internal.frameworks.catboost import get
+from ._internal.frameworks.catboost import get_runnable
 from ._internal.frameworks.catboost import load_model
 from ._internal.frameworks.catboost import save_model
-from ._internal.frameworks.catboost import get_runnable
-from ._internal.frameworks.catboost import CatBoostOptions as ModelOptions  # type: ignore # noqa
 
 __all__ = ["load_model", "save_model", "get", "get_runnable"]

--- a/src/bentoml/cloud.py
+++ b/src/bentoml/cloud.py
@@ -1,3 +1,3 @@
-from ._internal.cloud import YataiClient as YataiClient
 from ._internal.cloud import BentoCloudClient as BentoCloudClient
 from ._internal.cloud import Resource as Resource
+from ._internal.cloud import YataiClient as YataiClient

--- a/src/bentoml/container.py
+++ b/src/bentoml/container.py
@@ -4,31 +4,31 @@ User facing python APIs for building a OCI-complicant image.
 
 from __future__ import annotations
 
-import os
-import sys
-import shutil
-import typing as t
 import logging
+import os
+import shutil
+import sys
+import typing as t
 from typing import TYPE_CHECKING
 
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
-from .exceptions import BentoMLException
+from ._internal.configuration.containers import BentoMLContainer
 from ._internal.container import build as _internal_build
-from ._internal.container import health
-from ._internal.container import get_backend
-from ._internal.container import register_backend
 from ._internal.container import (
     construct_containerfile as _internal_construct_containerfile,
 )
-from ._internal.configuration.containers import BentoMLContainer
+from ._internal.container import get_backend
+from ._internal.container import health
+from ._internal.container import register_backend
+from .exceptions import BentoMLException
 
 if TYPE_CHECKING:
-    from ._internal.tag import Tag
     from ._internal.bento import BentoStore
-    from ._internal.types import PathType
     from ._internal.container.base import ArgType
+    from ._internal.tag import Tag
+    from ._internal.types import PathType
 
 logger = logging.getLogger(__name__)
 

--- a/src/bentoml/detectron.py
+++ b/src/bentoml/detectron.py
@@ -1,7 +1,7 @@
+from ._internal.frameworks.detectron import ModelOptions
 from ._internal.frameworks.detectron import get
+from ._internal.frameworks.detectron import get_runnable
 from ._internal.frameworks.detectron import load_model
 from ._internal.frameworks.detectron import save_model
-from ._internal.frameworks.detectron import get_runnable
-from ._internal.frameworks.detectron import ModelOptions
 
 __all__ = ["load_model", "save_model", "get", "get_runnable", "ModelOptions"]

--- a/src/bentoml/diffusers.py
+++ b/src/bentoml/diffusers.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+from ._internal.frameworks.diffusers import DiffusersOptions as ModelOptions
 from ._internal.frameworks.diffusers import get
-from ._internal.frameworks.diffusers import load_model
-from ._internal.frameworks.diffusers import save_model
 from ._internal.frameworks.diffusers import get_runnable
 from ._internal.frameworks.diffusers import import_model
-from ._internal.frameworks.diffusers import DiffusersOptions as ModelOptions
+from ._internal.frameworks.diffusers import load_model
+from ._internal.frameworks.diffusers import save_model
 
 __all__ = [
     "get",

--- a/src/bentoml/easyocr.py
+++ b/src/bentoml/easyocr.py
@@ -1,6 +1,6 @@
 from ._internal.frameworks.easyocr import get
+from ._internal.frameworks.easyocr import get_runnable
 from ._internal.frameworks.easyocr import load_model
 from ._internal.frameworks.easyocr import save_model
-from ._internal.frameworks.easyocr import get_runnable
 
 __all__ = ["load_model", "save_model", "get", "get_runnable"]

--- a/src/bentoml/fastai.py
+++ b/src/bentoml/fastai.py
@@ -1,6 +1,6 @@
 from ._internal.frameworks.fastai import get
+from ._internal.frameworks.fastai import get_runnable
 from ._internal.frameworks.fastai import load_model
 from ._internal.frameworks.fastai import save_model
-from ._internal.frameworks.fastai import get_runnable
 
 __all__ = ["load_model", "save_model", "get", "get_runnable"]

--- a/src/bentoml/flax.py
+++ b/src/bentoml/flax.py
@@ -1,7 +1,7 @@
+from ._internal.frameworks.flax import ModelOptions
 from ._internal.frameworks.flax import get
+from ._internal.frameworks.flax import get_runnable
 from ._internal.frameworks.flax import load_model
 from ._internal.frameworks.flax import save_model
-from ._internal.frameworks.flax import get_runnable
-from ._internal.frameworks.flax import ModelOptions
 
 __all__ = ["load_model", "save_model", "get", "get_runnable", "ModelOptions"]

--- a/src/bentoml/grpc/interceptors/access.py
+++ b/src/bentoml/grpc/interceptors/access.py
@@ -1,29 +1,29 @@
 from __future__ import annotations
 
-import typing as t
-import logging
 import functools
+import logging
+import typing as t
 from timeit import default_timer
 from typing import TYPE_CHECKING
 
+from bentoml.grpc.utils import GRPC_CONTENT_TYPE
+from bentoml.grpc.utils import import_generated_stubs
 from bentoml.grpc.utils import import_grpc
 from bentoml.grpc.utils import to_http_status
 from bentoml.grpc.utils import wrap_rpc_handler
-from bentoml.grpc.utils import GRPC_CONTENT_TYPE
-from bentoml.grpc.utils import import_generated_stubs
 
 if TYPE_CHECKING:
     import grpc
     from grpc import aio
     from grpc.aio._typing import MetadataType  # pylint: disable=unused-import
 
-    from bentoml.grpc.v1 import service_pb2 as pb
+    from bentoml.grpc.types import AsyncHandlerMethod
+    from bentoml.grpc.types import BentoServicerContext
+    from bentoml.grpc.types import HandlerCallDetails
     from bentoml.grpc.types import Request
     from bentoml.grpc.types import Response
     from bentoml.grpc.types import RpcMethodHandler
-    from bentoml.grpc.types import AsyncHandlerMethod
-    from bentoml.grpc.types import HandlerCallDetails
-    from bentoml.grpc.types import BentoServicerContext
+    from bentoml.grpc.v1 import service_pb2 as pb
 else:
     pb, _ = import_generated_stubs()
     grpc, aio = import_grpc()

--- a/src/bentoml/grpc/interceptors/opentelemetry.py
+++ b/src/bentoml/grpc/interceptors/opentelemetry.py
@@ -1,27 +1,27 @@
 from __future__ import annotations
 
-import typing as t
-import logging
 import functools
-from typing import TYPE_CHECKING
+import logging
+import typing as t
 from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 
-from simple_di import inject
-from simple_di import Provide
 from opentelemetry import trace
 from opentelemetry.context import attach
 from opentelemetry.context import detach
 from opentelemetry.propagate import extract
+from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace.status import Status
 from opentelemetry.trace.status import StatusCode
-from opentelemetry.semconv.trace import SpanAttributes
+from simple_di import Provide
+from simple_di import inject
 
-from bentoml.grpc.utils import import_grpc
-from bentoml.grpc.utils import wrap_rpc_handler
-from bentoml.grpc.utils import GRPC_CONTENT_TYPE
-from bentoml.grpc.utils import parse_method_name
-from bentoml._internal.utils.pkg import get_pkg_version
 from bentoml._internal.configuration.containers import BentoMLContainer
+from bentoml._internal.utils.pkg import get_pkg_version
+from bentoml.grpc.utils import GRPC_CONTENT_TYPE
+from bentoml.grpc.utils import import_grpc
+from bentoml.grpc.utils import parse_method_name
+from bentoml.grpc.utils import wrap_rpc_handler
 
 if TYPE_CHECKING:
     import grpc
@@ -29,15 +29,15 @@ if TYPE_CHECKING:
     from grpc.aio._typing import MetadataKey
     from grpc.aio._typing import MetadataType
     from grpc.aio._typing import MetadataValue
-    from opentelemetry.trace import Span
     from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.trace import Span
 
+    from bentoml.grpc.types import AsyncHandlerMethod
+    from bentoml.grpc.types import BentoServicerContext
+    from bentoml.grpc.types import HandlerCallDetails
     from bentoml.grpc.types import Request
     from bentoml.grpc.types import Response
     from bentoml.grpc.types import RpcMethodHandler
-    from bentoml.grpc.types import AsyncHandlerMethod
-    from bentoml.grpc.types import HandlerCallDetails
-    from bentoml.grpc.types import BentoServicerContext
 else:
     grpc, aio = import_grpc()
 

--- a/src/bentoml/grpc/interceptors/prometheus.py
+++ b/src/bentoml/grpc/interceptors/prometheus.py
@@ -1,21 +1,21 @@
 from __future__ import annotations
 
-import typing as t
-import logging
-import functools
 import contextvars
+import functools
+import logging
+import typing as t
 from timeit import default_timer
 from typing import TYPE_CHECKING
 
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
+from bentoml._internal.configuration.containers import BentoMLContainer
+from bentoml._internal.context import component_context
+from bentoml.grpc.utils import import_generated_stubs
 from bentoml.grpc.utils import import_grpc
 from bentoml.grpc.utils import to_http_status
 from bentoml.grpc.utils import wrap_rpc_handler
-from bentoml.grpc.utils import import_generated_stubs
-from bentoml._internal.context import component_context
-from bentoml._internal.configuration.containers import BentoMLContainer
 
 START_TIME_VAR: contextvars.ContextVar[float] = contextvars.ContextVar("START_TIME_VAR")
 
@@ -23,14 +23,14 @@ if TYPE_CHECKING:
     import grpc
     from grpc import aio
 
-    from bentoml.grpc.v1 import service_pb2 as pb
+    from bentoml._internal.server.metrics.prometheus import PrometheusClient
+    from bentoml.grpc.types import AsyncHandlerMethod
+    from bentoml.grpc.types import BentoServicerContext
+    from bentoml.grpc.types import HandlerCallDetails
     from bentoml.grpc.types import Request
     from bentoml.grpc.types import Response
     from bentoml.grpc.types import RpcMethodHandler
-    from bentoml.grpc.types import AsyncHandlerMethod
-    from bentoml.grpc.types import HandlerCallDetails
-    from bentoml.grpc.types import BentoServicerContext
-    from bentoml._internal.server.metrics.prometheus import PrometheusClient
+    from bentoml.grpc.v1 import service_pb2 as pb
 else:
     pb, _ = import_generated_stubs()
     grpc, aio = import_grpc()

--- a/src/bentoml/grpc/utils/__init__.py
+++ b/src/bentoml/grpc/utils/__init__.py
@@ -1,29 +1,29 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
+from dataclasses import dataclass
+from functools import lru_cache
 from http import HTTPStatus
 from typing import TYPE_CHECKING
-from functools import lru_cache
-from dataclasses import dataclass
 
-from ...exceptions import InvalidArgument
-from ._import_hook import import_grpc
-from ._import_hook import import_generated_stubs
-from ._import_hook import LATEST_PROTOCOL_VERSION
 from ..._internal.utils import resolve_user_filepath
+from ...exceptions import InvalidArgument
+from ._import_hook import LATEST_PROTOCOL_VERSION
+from ._import_hook import import_generated_stubs
+from ._import_hook import import_grpc
 
 if TYPE_CHECKING:
     from enum import Enum
 
     import grpc
 
-    from ..v1 import service_pb2 as pb
+    from ..._internal.io_descriptors import IODescriptor
+    from ...exceptions import BentoMLException
+    from ..types import BentoServicerContext
     from ..types import ProtoField
     from ..types import RpcMethodHandler
-    from ..types import BentoServicerContext
-    from ...exceptions import BentoMLException
-    from ..._internal.io_descriptors import IODescriptor
+    from ..v1 import service_pb2 as pb
 
 else:
     pb, _ = import_generated_stubs()

--- a/src/bentoml/io.py
+++ b/src/bentoml/io.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from ._internal.io_descriptors import from_spec
 from ._internal.io_descriptors.base import IODescriptor
 from ._internal.io_descriptors.file import File
-from ._internal.io_descriptors.json import JSON
-from ._internal.io_descriptors.text import Text
 from ._internal.io_descriptors.image import Image
-from ._internal.io_descriptors.numpy import NumpyNdarray
-from ._internal.io_descriptors.pandas import PandasSeries
-from ._internal.io_descriptors.pandas import PandasDataFrame
+from ._internal.io_descriptors.json import JSON
 from ._internal.io_descriptors.multipart import Multipart
+from ._internal.io_descriptors.numpy import NumpyNdarray
+from ._internal.io_descriptors.pandas import PandasDataFrame
+from ._internal.io_descriptors.pandas import PandasSeries
+from ._internal.io_descriptors.text import Text
 
 __all__ = [
     "File",

--- a/src/bentoml/keras.py
+++ b/src/bentoml/keras.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
+from ._internal.frameworks.keras import KerasOptions as ModelOptions
 from ._internal.frameworks.keras import get
+from ._internal.frameworks.keras import get_runnable
 from ._internal.frameworks.keras import load_model
 from ._internal.frameworks.keras import save_model
-from ._internal.frameworks.keras import get_runnable
-from ._internal.frameworks.keras import KerasOptions as ModelOptions
 
 if TYPE_CHECKING:
     from ._internal.tag import Tag

--- a/src/bentoml/lightgbm.py
+++ b/src/bentoml/lightgbm.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
 from ._internal.frameworks.lightgbm import get
+from ._internal.frameworks.lightgbm import get_runnable
 from ._internal.frameworks.lightgbm import load_model
 from ._internal.frameworks.lightgbm import save_model
-from ._internal.frameworks.lightgbm import get_runnable
 
 if TYPE_CHECKING:
     from ._internal.tag import Tag

--- a/src/bentoml/metrics.py
+++ b/src/bentoml/metrics.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
 from ._internal.configuration.containers import BentoMLContainer
 

--- a/src/bentoml/mlflow.py
+++ b/src/bentoml/mlflow.py
@@ -1,9 +1,9 @@
+from ._internal.frameworks.mlflow import MLFLOW_MODEL_FOLDER
 from ._internal.frameworks.mlflow import get
-from ._internal.frameworks.mlflow import load_model
+from ._internal.frameworks.mlflow import get_mlflow_model
 from ._internal.frameworks.mlflow import get_runnable
 from ._internal.frameworks.mlflow import import_model
-from ._internal.frameworks.mlflow import get_mlflow_model
-from ._internal.frameworks.mlflow import MLFLOW_MODEL_FOLDER
+from ._internal.frameworks.mlflow import load_model
 
 __all__ = [
     "load_model",

--- a/src/bentoml/models.py
+++ b/src/bentoml/models.py
@@ -1,27 +1,27 @@
 from __future__ import annotations
 
 import typing as t
+from contextlib import contextmanager
 from types import ModuleType
 from typing import TYPE_CHECKING
-from contextlib import contextmanager
 
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
-from .exceptions import BentoMLException
-from ._internal.tag import Tag
-from ._internal.utils import calc_dir_size
+from ._internal.configuration.containers import BentoMLContainer
 from ._internal.models import Model
 from ._internal.models import ModelContext
 from ._internal.models import ModelOptions
-from ._internal.utils.analytics import track
+from ._internal.tag import Tag
+from ._internal.utils import calc_dir_size
 from ._internal.utils.analytics import ModelSaveEvent
-from ._internal.configuration.containers import BentoMLContainer
+from ._internal.utils.analytics import track
+from .exceptions import BentoMLException
 
 if TYPE_CHECKING:
+    from ._internal.cloud import BentoCloudClient
     from ._internal.models import ModelStore
     from ._internal.models.model import ModelSignaturesType
-    from ._internal.cloud import BentoCloudClient
 
 
 @inject

--- a/src/bentoml/monitoring.py
+++ b/src/bentoml/monitoring.py
@@ -1,5 +1,5 @@
-from ._internal.monitoring import monitor
-from ._internal.monitoring import MonitorBase
 from ._internal.monitoring import DefaultMonitor
+from ._internal.monitoring import MonitorBase
+from ._internal.monitoring import monitor
 
 __all__ = ["MonitorBase", "monitor", "DefaultMonitor"]

--- a/src/bentoml/onnx.py
+++ b/src/bentoml/onnx.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
+from ._internal.frameworks.onnx import (
+    ONNXOptions as ModelOptions,  # type: ignore # noqa
+)
 from ._internal.frameworks.onnx import get
+from ._internal.frameworks.onnx import get_runnable
 from ._internal.frameworks.onnx import load_model
 from ._internal.frameworks.onnx import save_model
-from ._internal.frameworks.onnx import ONNXOptions as ModelOptions  # type: ignore # noqa
-from ._internal.frameworks.onnx import get_runnable
 
 if TYPE_CHECKING:
     from ._internal.tag import Tag

--- a/src/bentoml/picklable_model.py
+++ b/src/bentoml/picklable_model.py
@@ -1,7 +1,7 @@
+from ._internal.frameworks.picklable import ModelOptions
 from ._internal.frameworks.picklable import get
+from ._internal.frameworks.picklable import get_runnable
 from ._internal.frameworks.picklable import load_model
 from ._internal.frameworks.picklable import save_model
-from ._internal.frameworks.picklable import get_runnable
-from ._internal.frameworks.picklable import ModelOptions
 
 __all__ = ["load_model", "get_runnable", "save_model", "get", "ModelOptions"]

--- a/src/bentoml/pytorch.py
+++ b/src/bentoml/pytorch.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
+from ._internal.frameworks.pytorch import ModelOptions
 from ._internal.frameworks.pytorch import get
+from ._internal.frameworks.pytorch import get_runnable
 from ._internal.frameworks.pytorch import load_model
 from ._internal.frameworks.pytorch import save_model
-from ._internal.frameworks.pytorch import get_runnable
-from ._internal.frameworks.pytorch import ModelOptions
 
 if TYPE_CHECKING:
     from ._internal.tag import Tag

--- a/src/bentoml/pytorch_lightning.py
+++ b/src/bentoml/pytorch_lightning.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
 from ._internal.frameworks.pytorch_lightning import get
+from ._internal.frameworks.pytorch_lightning import get_runnable
 from ._internal.frameworks.pytorch_lightning import load_model
 from ._internal.frameworks.pytorch_lightning import save_model
-from ._internal.frameworks.pytorch_lightning import get_runnable
 
 if TYPE_CHECKING:
     from ._internal.tag import Tag

--- a/src/bentoml/server.py
+++ b/src/bentoml/server.py
@@ -1,25 +1,25 @@
 from __future__ import annotations
 
-import os
-import sys
-import signal
-import typing as t
 import logging
-import textwrap
+import os
+import signal
 import subprocess
+import sys
+import textwrap
+import typing as t
 from abc import ABC
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
-from .exceptions import BentoMLException
-from ._internal.tag import Tag
 from ._internal.bento import Bento
-from ._internal.service import Service
 from ._internal.configuration.containers import BentoMLContainer
+from ._internal.service import Service
+from ._internal.tag import Tag
 from ._internal.utils.analytics.usage_stats import BENTOML_SERVE_FROM_SERVER_API
+from .exceptions import BentoMLException
 
 if TYPE_CHECKING:
     from types import TracebackType

--- a/src/bentoml/sklearn.py
+++ b/src/bentoml/sklearn.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
 from ._internal.frameworks.sklearn import get
+from ._internal.frameworks.sklearn import get_runnable
 from ._internal.frameworks.sklearn import load_model
 from ._internal.frameworks.sklearn import save_model
-from ._internal.frameworks.sklearn import get_runnable
 
 if TYPE_CHECKING:
     from ._internal.tag import Tag

--- a/src/bentoml/start.py
+++ b/src/bentoml/start.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
-import os
+import contextlib
 import json
 import logging
-import contextlib
+import os
 
-from simple_di import inject
 from simple_di import Provide
+from simple_di import inject
 
-from .grpc.utils import LATEST_PROTOCOL_VERSION
-from ._internal.runner.runner import Runner
 from ._internal.configuration.containers import BentoMLContainer
+from ._internal.runner.runner import Runner
+from .grpc.utils import LATEST_PROTOCOL_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -40,11 +40,11 @@ def start_runner_server(
     prometheus_dir = ensure_prometheus_dir()
 
     from . import load
+    from ._internal.utils import reserve_free_port
+    from ._internal.utils.analytics import track_serve
+    from ._internal.utils.circus import create_standalone_arbiter
     from .serve import create_watcher
     from .serve import find_triton_binary
-    from ._internal.utils import reserve_free_port
-    from ._internal.utils.circus import create_standalone_arbiter
-    from ._internal.utils.analytics import track_serve
 
     working_dir = os.path.realpath(os.path.expanduser(working_dir))
     svc = load(bento_identifier, working_dir=working_dir, standalone_load=True)
@@ -160,12 +160,12 @@ def start_http_server(
     from circus.watcher import Watcher
 
     from . import load
-    from .serve import create_watcher
-    from .serve import API_SERVER_NAME
-    from .serve import construct_ssl_args
-    from .serve import PROMETHEUS_MESSAGE
-    from ._internal.utils.circus import create_standalone_arbiter
     from ._internal.utils.analytics import track_serve
+    from ._internal.utils.circus import create_standalone_arbiter
+    from .serve import API_SERVER_NAME
+    from .serve import PROMETHEUS_MESSAGE
+    from .serve import construct_ssl_args
+    from .serve import create_watcher
 
     working_dir = os.path.realpath(os.path.expanduser(working_dir))
     svc = load(bento_identifier, working_dir=working_dir, standalone_load=True)
@@ -270,13 +270,13 @@ def start_grpc_server(
 
     from bentoml import load
 
-    from .serve import create_watcher
-    from .serve import construct_ssl_args
+    from ._internal.utils import reserve_free_port
+    from ._internal.utils.analytics import track_serve
+    from ._internal.utils.circus import create_standalone_arbiter
     from .serve import PROMETHEUS_MESSAGE
     from .serve import PROMETHEUS_SERVER_NAME
-    from ._internal.utils import reserve_free_port
-    from ._internal.utils.circus import create_standalone_arbiter
-    from ._internal.utils.analytics import track_serve
+    from .serve import construct_ssl_args
+    from .serve import create_watcher
 
     working_dir = os.path.realpath(os.path.expanduser(working_dir))
     svc = load(bento_identifier, working_dir=working_dir, standalone_load=True)

--- a/src/bentoml/tensorflow.py
+++ b/src/bentoml/tensorflow.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
+from ._internal.frameworks.tensorflow_v2 import ModelOptions
 from ._internal.frameworks.tensorflow_v2 import get
+from ._internal.frameworks.tensorflow_v2 import get_runnable
 from ._internal.frameworks.tensorflow_v2 import load_model
 from ._internal.frameworks.tensorflow_v2 import save_model
-from ._internal.frameworks.tensorflow_v2 import get_runnable
-from ._internal.frameworks.tensorflow_v2 import ModelOptions
 
 if TYPE_CHECKING:
     from ._internal.tag import Tag

--- a/src/bentoml/testing/grpc/__init__.py
+++ b/src/bentoml/testing/grpc/__init__.py
@@ -1,31 +1,31 @@
 from __future__ import annotations
 
-import typing as t
 import importlib
 import traceback
-from typing import TYPE_CHECKING
+import typing as t
 from contextlib import ExitStack
 from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 
-from ...exceptions import BentoMLException
-from ...grpc.utils import import_grpc
-from ...grpc.utils import import_generated_stubs
-from ...grpc.utils import LATEST_PROTOCOL_VERSION
 from ..._internal.utils import LazyLoader
-from ..._internal.utils import reserve_free_port
-from ..._internal.utils import cached_contextmanager
 from ..._internal.utils import add_experimental_docstring
+from ..._internal.utils import cached_contextmanager
+from ..._internal.utils import reserve_free_port
+from ...exceptions import BentoMLException
+from ...grpc.utils import LATEST_PROTOCOL_VERSION
+from ...grpc.utils import import_generated_stubs
+from ...grpc.utils import import_grpc
 
 if TYPE_CHECKING:
     import grpc
     import numpy as np
-    from grpc import aio
-    from numpy.typing import NDArray
-    from grpc.aio._channel import Channel
     from google.protobuf.message import Message
+    from grpc import aio
+    from grpc.aio._channel import Channel
+    from numpy.typing import NDArray
 
-    from ...grpc.v1 import service_pb2 as pb
     from ..._internal.service import Service
+    from ...grpc.v1 import service_pb2 as pb
 else:
     grpc, aio = import_grpc()  # pylint: disable=E1111
     np = LazyLoader("np", globals(), "numpy")

--- a/src/bentoml/testing/pytest/plugin.py
+++ b/src/bentoml/testing/pytest/plugin.py
@@ -1,10 +1,10 @@
 # pylint: disable=unused-argument
 from __future__ import annotations
 
-import os
-import typing as t
-import tempfile
 import contextlib
+import os
+import tempfile
+import typing as t
 from typing import TYPE_CHECKING
 
 import psutil
@@ -12,21 +12,21 @@ import pytest
 from pytest import MonkeyPatch
 
 import bentoml
-from bentoml._internal.utils import LazyLoader
-from bentoml._internal.utils import validate_or_create_dir
-from bentoml._internal.models import ModelContext
 from bentoml._internal.configuration import CLEAN_BENTOML_VERSION
 from bentoml._internal.configuration.containers import BentoMLContainer
+from bentoml._internal.models import ModelContext
+from bentoml._internal.utils import LazyLoader
+from bentoml._internal.utils import validate_or_create_dir
 
 if TYPE_CHECKING:
     import numpy as np
-    from _pytest.main import Session
-    from _pytest.nodes import Item
     from _pytest.config import Config
     from _pytest.config import ExitCode
-    from _pytest.python import Metafunc
-    from _pytest.fixtures import FixtureRequest
     from _pytest.config.argparsing import Parser
+    from _pytest.fixtures import FixtureRequest
+    from _pytest.main import Session
+    from _pytest.nodes import Item
+    from _pytest.python import Metafunc
 
     from bentoml._internal.server.metrics.prometheus import PrometheusClient
 

--- a/src/bentoml/testing/server.py
+++ b/src/bentoml/testing/server.py
@@ -1,37 +1,37 @@
 # pylint: disable=redefined-outer-name,not-context-manager
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import itertools
+import multiprocessing
 import os
+import socket
+import subprocess
 import sys
 import time
-import socket
 import typing as t
 import urllib
-import asyncio
-import itertools
-import contextlib
-import subprocess
 import urllib.error
 import urllib.request
-import multiprocessing
-from typing import TYPE_CHECKING
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 import psutil
 
-from bentoml.grpc.utils import import_grpc
 from bentoml._internal.tag import Tag
 from bentoml._internal.utils import LazyLoader
-from bentoml._internal.utils import reserve_free_port
 from bentoml._internal.utils import cached_contextmanager
+from bentoml._internal.utils import reserve_free_port
+from bentoml.grpc.utils import import_grpc
 
 from ..grpc.utils import LATEST_PROTOCOL_VERSION
 
 if TYPE_CHECKING:
     from grpc import aio
     from grpc_health.v1 import health_pb2 as pb_health
-    from starlette.datastructures import Headers
     from starlette.datastructures import FormData
+    from starlette.datastructures import Headers
 
     from bentoml._internal.bento.bento import Bento
 

--- a/src/bentoml/testing/utils.py
+++ b/src/bentoml/testing/utils.py
@@ -7,12 +7,12 @@ import aiohttp
 import multidict
 
 if TYPE_CHECKING:
-    from starlette.types import Send
-    from starlette.types import Scope
-    from starlette.types import Receive
     from aiohttp.typedefs import LooseHeaders
-    from starlette.datastructures import Headers
     from starlette.datastructures import FormData
+    from starlette.datastructures import Headers
+    from starlette.types import Receive
+    from starlette.types import Scope
+    from starlette.types import Send
 
 
 async def parse_multipart_form(headers: "Headers", body: bytes) -> "FormData":

--- a/src/bentoml/torchscript.py
+++ b/src/bentoml/torchscript.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
+from ._internal.frameworks.torchscript import ModelOptions
 from ._internal.frameworks.torchscript import get
+from ._internal.frameworks.torchscript import get_runnable
 from ._internal.frameworks.torchscript import load_model
 from ._internal.frameworks.torchscript import save_model
-from ._internal.frameworks.torchscript import get_runnable
-from ._internal.frameworks.torchscript import ModelOptions
 
 if TYPE_CHECKING:
     from ._internal.tag import Tag

--- a/src/bentoml/transformers.py
+++ b/src/bentoml/transformers.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 
+from ._internal.frameworks.transformers import TransformersOptions as ModelOptions
 from ._internal.frameworks.transformers import get
+from ._internal.frameworks.transformers import get_runnable
 from ._internal.frameworks.transformers import load_model
 from ._internal.frameworks.transformers import save_model
-from ._internal.frameworks.transformers import get_runnable
-from ._internal.frameworks.transformers import TransformersOptions as ModelOptions
 
 if t.TYPE_CHECKING:
     from ._internal.tag import Tag

--- a/src/bentoml/triton.py
+++ b/src/bentoml/triton.py
@@ -1,27 +1,25 @@
 from __future__ import annotations
 
-import typing as t
 import logging
-
-import attr
-
+import typing as t
 from functools import cached_property
 
-from simple_di import inject as _inject
+import attr
 from simple_di import Provide as _Provide
+from simple_di import inject as _inject
 
-from ._internal.utils import LazyLoader as _LazyLoader
 from ._internal.configuration import get_debug_mode as _get_debug_mode
-from ._internal.runner.runner import RunnerMethod as _RunnerMethod
-from ._internal.runner.runner import AbstractRunner as _AbstractRunner
-from ._internal.runner.runner import object_setattr as _object_setattr
-from ._internal.runner.runnable import RunnableMethodConfig as _RunnableMethodConfig
-from ._internal.runner.runner_handle import DummyRunnerHandle as _DummyRunnerHandle
 from ._internal.configuration.containers import BentoMLContainer as _BentoMLContainer
+from ._internal.runner.runnable import RunnableMethodConfig as _RunnableMethodConfig
+from ._internal.runner.runner import AbstractRunner as _AbstractRunner
+from ._internal.runner.runner import RunnerMethod as _RunnerMethod
+from ._internal.runner.runner import object_setattr as _object_setattr
+from ._internal.runner.runner_handle import DummyRunnerHandle as _DummyRunnerHandle
 from ._internal.runner.runner_handle.remote import TRITON_EXC_MSG as _TRITON_EXC_MSG
 from ._internal.runner.runner_handle.remote import (
     handle_triton_exception as _handle_triton_exception,
 )
+from ._internal.utils import LazyLoader as _LazyLoader
 
 if t.TYPE_CHECKING:
     import tritonclient.grpc.aio as _tritongrpcclient

--- a/src/bentoml/xgboost.py
+++ b/src/bentoml/xgboost.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
+from ._internal.frameworks.xgboost import XGBoostOptions as ModelOptions
 from ._internal.frameworks.xgboost import get
+from ._internal.frameworks.xgboost import get_runnable
 from ._internal.frameworks.xgboost import load_model
 from ._internal.frameworks.xgboost import save_model
-from ._internal.frameworks.xgboost import get_runnable
-from ._internal.frameworks.xgboost import XGBoostOptions as ModelOptions
 
 if TYPE_CHECKING:
     from ._internal.tag import Tag

--- a/src/bentoml_cli/bentos.py
+++ b/src/bentoml_cli/bentos.py
@@ -3,19 +3,19 @@ from __future__ import annotations
 import json
 import typing as t
 
-import yaml
 import click
-from simple_di import inject
-from simple_di import Provide
-from rich.table import Table
+import yaml
 from rich.syntax import Syntax
+from rich.table import Table
+from simple_di import Provide
+from simple_di import inject
 
-from bentoml_cli.utils import is_valid_bento_tag
 from bentoml_cli.utils import is_valid_bento_name
+from bentoml_cli.utils import is_valid_bento_tag
 
 if t.TYPE_CHECKING:
-    from click import Group
     from click import Context
+    from click import Group
     from click import Parameter
 
     from bentoml._internal.bento import BentoStore
@@ -54,17 +54,17 @@ def parse_delete_targets_argument_callback(
 def add_bento_management_commands(cli: Group):
     import bentoml
     from bentoml import Tag
-    from bentoml.bentos import import_bento
-    from bentoml._internal.utils import rich_console as console
+    from bentoml._internal.bento.bento import DEFAULT_BENTO_BUILD_FILE
+    from bentoml._internal.bento.bento import Bento
+    from bentoml._internal.bento.build_config import BentoBuildConfig
+    from bentoml._internal.configuration import get_quiet_mode
+    from bentoml._internal.configuration.containers import BentoMLContainer
     from bentoml._internal.utils import calc_dir_size
     from bentoml._internal.utils import human_readable_size
     from bentoml._internal.utils import resolve_user_filepath
-    from bentoml._internal.bento.bento import Bento
-    from bentoml._internal.bento.bento import DEFAULT_BENTO_BUILD_FILE
-    from bentoml._internal.configuration import get_quiet_mode
-    from bentoml._internal.bento.build_config import BentoBuildConfig
-    from bentoml._internal.configuration.containers import BentoMLContainer
+    from bentoml._internal.utils import rich_console as console
     from bentoml._internal.utils.analytics.usage_stats import _usage_event_debugging
+    from bentoml.bentos import import_bento
 
     bento_store = BentoMLContainer.bento_store.get()
     cloud_client = BentoMLContainer.bentocloud_client.get()
@@ -318,7 +318,6 @@ def add_bento_management_commands(cli: Group):
         """Build a new Bento from current directory."""
         if output == "tag":
             from bentoml._internal.configuration import set_quiet_mode
-
             from bentoml._internal.log import configure_logging
 
             set_quiet_mode(True)

--- a/src/bentoml_cli/cli.py
+++ b/src/bentoml_cli/cli.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 import click
 import psutil
 
+from bentoml_cli.bentos import add_bento_management_commands
+from bentoml_cli.cloud import add_cloud_command
+from bentoml_cli.containerize import add_containerize_command
+from bentoml_cli.deployment import add_deployment_command
 from bentoml_cli.env import add_env_command
+from bentoml_cli.models import add_model_management_commands
 from bentoml_cli.serve import add_serve_command
 from bentoml_cli.start import add_start_command
 from bentoml_cli.utils import BentoMLCommandGroup
-from bentoml_cli.cloud import add_cloud_command
-from bentoml_cli.bentos import add_bento_management_commands
-from bentoml_cli.models import add_model_management_commands
-from bentoml_cli.containerize import add_containerize_command
-from bentoml_cli.deployment import add_deployment_command
 
 
 def create_bentoml_cli() -> click.Group:

--- a/src/bentoml_cli/cloud.py
+++ b/src/bentoml_cli/cloud.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
-import click
 import json
+
+import click
 import click_option_group as cog
 
 
 def add_cloud_command(cli: click.Group) -> click.Group:
-    from bentoml_cli.utils import BentoMLCommandGroup
-    from bentoml.exceptions import CLIException
+    from bentoml._internal.cloud.client import RestApiClient
+    from bentoml._internal.cloud.config import CloudClientConfig
+    from bentoml._internal.cloud.config import CloudClientContext
+    from bentoml._internal.cloud.config import add_context
+    from bentoml._internal.cloud.config import default_context_name
     from bentoml._internal.configuration import get_quiet_mode
     from bentoml._internal.utils import bentoml_cattr
-    from bentoml._internal.cloud.client import RestApiClient
-    from bentoml._internal.cloud.config import add_context
-    from bentoml._internal.cloud.config import CloudClientContext
-    from bentoml._internal.cloud.config import default_context_name
-    from bentoml._internal.cloud.config import CloudClientConfig
+    from bentoml.exceptions import CLIException
+    from bentoml_cli.utils import BentoMLCommandGroup
 
     @cli.group(name="cloud", aliases=["yatai"], cls=BentoMLCommandGroup)
     def cloud():

--- a/src/bentoml_cli/containerize.py
+++ b/src/bentoml_cli/containerize.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-import sys
-import shutil
-import typing as t
-import logging
-import tempfile
 import itertools
+import logging
+import shutil
 import subprocess
-from typing import TYPE_CHECKING
+import sys
+import tempfile
+import typing as t
 from functools import partial
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from click import Group
     from click import Command
     from click import Context
+    from click import Group
     from click import Parameter
 
     from bentoml._internal.container import DefaultBuilder
@@ -355,16 +355,16 @@ def add_containerize_command(cli: Group) -> None:
     from click_option_group import optgroup
 
     from bentoml import container
-    from bentoml_cli.utils import opt_callback
-    from bentoml_cli.utils import kwargs_transformers
-    from bentoml_cli.utils import normalize_none_type
-    from bentoml_cli.utils import validate_container_tag
-    from bentoml.exceptions import BentoMLException
+    from bentoml._internal.configuration import get_debug_mode
     from bentoml._internal.container import FEATURES
-    from bentoml._internal.container import enable_buildkit
     from bentoml._internal.container import REGISTERED_BACKENDS
     from bentoml._internal.container import determine_container_tag
-    from bentoml._internal.configuration import get_debug_mode
+    from bentoml._internal.container import enable_buildkit
+    from bentoml.exceptions import BentoMLException
+    from bentoml_cli.utils import kwargs_transformers
+    from bentoml_cli.utils import normalize_none_type
+    from bentoml_cli.utils import opt_callback
+    from bentoml_cli.utils import validate_container_tag
 
     @cli.command()
     @click.argument("bento_tag", type=click.STRING, metavar="BENTO:TAG")

--- a/src/bentoml_cli/deployment.py
+++ b/src/bentoml_cli/deployment.py
@@ -1,22 +1,26 @@
 from __future__ import annotations
 
-import click
 import typing as t
+
+import click
 
 if t.TYPE_CHECKING:
     TupleStrAny = tuple[str, ...]
-    from bentoml._internal.cloud.schemas import DeploymentSchema
     from bentoml._internal.cloud.schemas import DeploymentListSchema
+    from bentoml._internal.cloud.schemas import DeploymentSchema
 else:
     TupleStrAny = tuple
 
 
 def add_deployment_command(cli: click.Group) -> None:
     import json
-    from bentoml_cli.utils import BentoMLCommandGroup
-    from bentoml._internal.configuration.containers import BentoMLContainer
-    from bentoml._internal.utils import rich_console as console, bentoml_cattr
+
     from rich.table import Table
+
+    from bentoml._internal.configuration.containers import BentoMLContainer
+    from bentoml._internal.utils import bentoml_cattr
+    from bentoml._internal.utils import rich_console as console
+    from bentoml_cli.utils import BentoMLCommandGroup
 
     client = BentoMLContainer.bentocloud_client.get()
     output_option = click.option(

--- a/src/bentoml_cli/env.py
+++ b/src/bentoml_cli/env.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import os
-import sys
+import platform
 import shlex
 import shutil
-import typing as t
-import platform
 import subprocess
+import sys
+import typing as t
 from gettext import gettext
 
 import click
@@ -106,9 +106,9 @@ def pretty_format(
 
 def add_env_command(cli: click.Group) -> None:
     from bentoml import __version__ as BENTOML_VERSION
-    from bentoml.exceptions import CLIException
-    from bentoml._internal.utils.pkg import get_pkg_version
     from bentoml._internal.utils.pkg import PackageNotFoundError
+    from bentoml._internal.utils.pkg import get_pkg_version
+    from bentoml.exceptions import CLIException
 
     @cli.command(help=gettext("Print environment info and exit"))
     @click.option(

--- a/src/bentoml_cli/env_manager.py
+++ b/src/bentoml_cli/env_manager.py
@@ -1,28 +1,28 @@
 from __future__ import annotations
 
+import functools
+import logging
 import os
 import re
 import sys
 import typing as t
-import logging
-import functools
 from shutil import which
 
-import fs
 import click
-from simple_di import inject
+import fs
 from simple_di import Provide
+from simple_di import inject
 
-from bentoml.exceptions import NotFound as BentoNotFound
-from bentoml.exceptions import BentoMLException
-from bentoml._internal.bento.bento import Bento
-from bentoml._internal.bento.bento import BentoStore
 from bentoml._internal.bento.bento import BENTO_YAML_FILENAME
 from bentoml._internal.bento.bento import DEFAULT_BENTO_BUILD_FILE
-from bentoml._internal.env_manager import EnvManager
+from bentoml._internal.bento.bento import Bento
+from bentoml._internal.bento.bento import BentoStore
 from bentoml._internal.configuration import get_debug_mode
-from bentoml._internal.env_manager.envs import Environment
 from bentoml._internal.configuration.containers import BentoMLContainer
+from bentoml._internal.env_manager import EnvManager
+from bentoml._internal.env_manager.envs import Environment
+from bentoml.exceptions import BentoMLException
+from bentoml.exceptions import NotFound as BentoNotFound
 
 if t.TYPE_CHECKING:
     P = t.ParamSpec("P")

--- a/src/bentoml_cli/models.py
+++ b/src/bentoml_cli/models.py
@@ -4,18 +4,18 @@ import json
 import typing as t
 from typing import TYPE_CHECKING
 
-import yaml
 import click
-from rich.table import Table
+import yaml
 from rich.syntax import Syntax
+from rich.table import Table
 
-from bentoml_cli.utils import is_valid_bento_tag
 from bentoml_cli.utils import BentoMLCommandGroup
 from bentoml_cli.utils import is_valid_bento_name
+from bentoml_cli.utils import is_valid_bento_tag
 
 if TYPE_CHECKING:
-    from click import Group
     from click import Context
+    from click import Group
     from click import Parameter
 
 
@@ -42,15 +42,15 @@ def parse_delete_targets_argument_callback(
 
 def add_model_management_commands(cli: Group) -> None:
     from bentoml import Tag
-    from bentoml.models import import_model
-    from bentoml.exceptions import InvalidArgument
-    from bentoml._internal.utils import rich_console as console
-    from bentoml._internal.utils import calc_dir_size
-    from bentoml._internal.utils import human_readable_size
-    from bentoml._internal.utils import resolve_user_filepath
     from bentoml._internal.bento.bento import DEFAULT_BENTO_BUILD_FILE
     from bentoml._internal.bento.build_config import BentoBuildConfig
     from bentoml._internal.configuration.containers import BentoMLContainer
+    from bentoml._internal.utils import calc_dir_size
+    from bentoml._internal.utils import human_readable_size
+    from bentoml._internal.utils import resolve_user_filepath
+    from bentoml._internal.utils import rich_console as console
+    from bentoml.exceptions import InvalidArgument
+    from bentoml.models import import_model
 
     model_store = BentoMLContainer.model_store.get()
     cloud_client = BentoMLContainer.bentocloud_client.get()

--- a/src/bentoml_cli/serve.py
+++ b/src/bentoml_cli/serve.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import typing as t
-import logging
 
 import click
 
@@ -47,10 +47,10 @@ def deprecated_option(*param_decls: str, **attrs: t.Any):
 
 
 def add_serve_command(cli: click.Group) -> None:
-    from bentoml.grpc.utils import LATEST_PROTOCOL_VERSION
-    from bentoml._internal.log import configure_server_logging
-    from bentoml_cli.env_manager import env_manager
     from bentoml._internal.configuration.containers import BentoMLContainer
+    from bentoml._internal.log import configure_server_logging
+    from bentoml.grpc.utils import LATEST_PROTOCOL_VERSION
+    from bentoml_cli.env_manager import env_manager
 
     @cli.command(aliases=["serve-http"])
     @click.argument("bento", type=click.STRING, default=".")

--- a/src/bentoml_cli/start.py
+++ b/src/bentoml_cli/start.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import os
-import sys
 import json
 import logging
+import os
+import sys
 from urllib.parse import urlparse
 
 import click
@@ -12,9 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 def add_start_command(cli: click.Group) -> None:
-    from bentoml.grpc.utils import LATEST_PROTOCOL_VERSION
-    from bentoml._internal.utils import add_experimental_docstring
     from bentoml._internal.configuration.containers import BentoMLContainer
+    from bentoml._internal.utils import add_experimental_docstring
+    from bentoml.grpc.utils import LATEST_PROTOCOL_VERSION
 
     @cli.command(hidden=True)
     @click.argument("bento", type=click.STRING, default=".")

--- a/src/bentoml_cli/utils.py
+++ b/src/bentoml_cli/utils.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+import difflib
+import functools
+import logging
 import os
 import re
 import time
 import typing as t
-import difflib
-import logging
-import functools
 from typing import TYPE_CHECKING
 
 import click
@@ -14,12 +14,12 @@ from click import ClickException
 from click.exceptions import UsageError
 
 if TYPE_CHECKING:
-    from click import Option
     from click import Command
-    from click import Group
     from click import Context
-    from click import Parameter
+    from click import Group
     from click import HelpFormatter
+    from click import Option
+    from click import Parameter
 
     P = t.ParamSpec("P")
 
@@ -217,11 +217,11 @@ class BentoMLCommandGroup(click.Group):
     @staticmethod
     def bentoml_common_params(func: F[P]) -> WrappedCLI[bool, bool]:
         # NOTE: update NUMBER_OF_COMMON_PARAMS when adding option.
-        from bentoml._internal.log import configure_logging
         from bentoml._internal.configuration import DEBUG_ENV_VAR
         from bentoml._internal.configuration import QUIET_ENV_VAR
         from bentoml._internal.configuration import set_debug_mode
         from bentoml._internal.configuration import set_quiet_mode
+        from bentoml._internal.log import configure_logging
         from bentoml._internal.utils.analytics import BENTOML_DO_NOT_TRACK
 
         @click.option(
@@ -273,10 +273,10 @@ class BentoMLCommandGroup(click.Group):
         cmd_group: click.Group,
         **kwargs: t.Any,
     ) -> WrappedCLI[bool]:
-        from bentoml._internal.utils.analytics import track
+        from bentoml._internal.utils.analytics import BENTOML_DO_NOT_TRACK
         from bentoml._internal.utils.analytics import CliEvent
         from bentoml._internal.utils.analytics import cli_events_map
-        from bentoml._internal.utils.analytics import BENTOML_DO_NOT_TRACK
+        from bentoml._internal.utils.analytics import track
 
         command_name = kwargs.get("name", func.__name__)
 
@@ -327,8 +327,8 @@ class BentoMLCommandGroup(click.Group):
     def raise_click_exception(
         func: F[P] | WrappedCLI[bool], cmd_group: click.Group, **kwargs: t.Any
     ) -> ClickFunctionWrapper[t.Any]:
-        from bentoml.exceptions import BentoMLException
         from bentoml._internal.configuration import get_debug_mode
+        from bentoml.exceptions import BentoMLException
 
         command_name = kwargs.get("name", func.__name__)
 

--- a/src/bentoml_cli/worker/grpc_api_server.py
+++ b/src/bentoml_cli/worker/grpc_api_server.py
@@ -109,9 +109,9 @@ def main(
     """
 
     import bentoml
-    from bentoml._internal.log import configure_server_logging
-    from bentoml._internal.context import component_context
     from bentoml._internal.configuration.containers import BentoMLContainer
+    from bentoml._internal.context import component_context
+    from bentoml._internal.log import configure_server_logging
 
     component_context.component_type = "grpc_api_server"
     component_context.component_index = worker_id

--- a/src/bentoml_cli/worker/grpc_prometheus_server.py
+++ b/src/bentoml_cli/worker/grpc_prometheus_server.py
@@ -51,14 +51,14 @@ def main(fd: int, backlog: int, prometheus_dir: str | None):
 
     import psutil
     import uvicorn
-    from starlette.middleware import Middleware
     from starlette.applications import Starlette
+    from starlette.middleware import Middleware
     from starlette.middleware.wsgi import WSGIMiddleware  # TODO: a2wsgi
 
-    from bentoml._internal.log import configure_server_logging
-    from bentoml._internal.context import component_context
     from bentoml._internal.configuration import get_debug_mode
     from bentoml._internal.configuration.containers import BentoMLContainer
+    from bentoml._internal.context import component_context
+    from bentoml._internal.log import configure_server_logging
 
     component_context.component_type = "prom_server"
 

--- a/src/bentoml_cli/worker/http_api_server.py
+++ b/src/bentoml_cli/worker/http_api_server.py
@@ -114,9 +114,9 @@ def main(
     import psutil
 
     import bentoml
-    from bentoml._internal.log import configure_server_logging
-    from bentoml._internal.context import component_context
     from bentoml._internal.configuration.containers import BentoMLContainer
+    from bentoml._internal.context import component_context
+    from bentoml._internal.log import configure_server_logging
 
     component_context.component_type = "api_server"
     component_context.component_index = worker_id

--- a/src/bentoml_cli/worker/runner.py
+++ b/src/bentoml_cli/worker/runner.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
-import json
 import typing as t
 
 import click

--- a/tests/e2e/bento_server_grpc/context_server_interceptor.py
+++ b/tests/e2e/bento_server_grpc/context_server_interceptor.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-import typing as t
-import functools
 import dataclasses
+import functools
+import typing as t
 from typing import TYPE_CHECKING
 
 from grpc import aio
 
 if TYPE_CHECKING:
+    from bentoml.grpc.types import AsyncHandlerMethod
+    from bentoml.grpc.types import BentoServicerContext
+    from bentoml.grpc.types import HandlerCallDetails
     from bentoml.grpc.types import Request
     from bentoml.grpc.types import Response
     from bentoml.grpc.types import RpcMethodHandler
-    from bentoml.grpc.types import AsyncHandlerMethod
-    from bentoml.grpc.types import HandlerCallDetails
-    from bentoml.grpc.types import BentoServicerContext
 
 
 @dataclasses.dataclass

--- a/tests/e2e/bento_server_grpc/python_model.py
+++ b/tests/e2e/bento_server_grpc/python_model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
 from typing import TYPE_CHECKING
+from typing import Any
 
 import numpy as np
 import pandas as pd

--- a/tests/e2e/bento_server_grpc/service.py
+++ b/tests/e2e/bento_server_grpc/service.py
@@ -4,20 +4,20 @@ import time
 import typing as t
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel
 from context_server_interceptor import AsyncContextInterceptor
+from pydantic import BaseModel
 
 import bentoml
-from bentoml.io import File
+from bentoml._internal.utils import LazyLoader
+from bentoml._internal.utils.metrics import exponential_buckets
 from bentoml.io import JSON
-from bentoml.io import Text
+from bentoml.io import File
 from bentoml.io import Image
 from bentoml.io import Multipart
 from bentoml.io import NumpyNdarray
-from bentoml.io import PandasSeries
 from bentoml.io import PandasDataFrame
-from bentoml._internal.utils import LazyLoader
-from bentoml._internal.utils.metrics import exponential_buckets
+from bentoml.io import PandasSeries
+from bentoml.io import Text
 
 if TYPE_CHECKING:
     import numpy as np
@@ -25,10 +25,10 @@ if TYPE_CHECKING:
     import PIL.Image
     from numpy.typing import NDArray
 
+    from bentoml._internal.runner.runner import RunnerMethod
     from bentoml._internal.types import FileLike
     from bentoml._internal.types import JSONSerializable
     from bentoml.picklable_model import get_runnable
-    from bentoml._internal.runner.runner import RunnerMethod
 
     RunnableImpl = get_runnable(bentoml.picklable_model.get("py_model.case-1.grpc.e2e"))
 

--- a/tests/e2e/bento_server_grpc/tests/conftest.py
+++ b/tests/e2e/bento_server_grpc/tests/conftest.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 import typing as t
-import subprocess
 from typing import TYPE_CHECKING
 
 import psutil
@@ -13,9 +13,9 @@ import pytest
 if TYPE_CHECKING:
     from contextlib import ExitStack
 
+    from _pytest.config import Config
     from _pytest.main import Session
     from _pytest.nodes import Item
-    from _pytest.config import Config
 
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tests/e2e/bento_server_grpc/tests/test_custom_components.py
+++ b/tests/e2e/bento_server_grpc/tests/test_custom_components.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import typing as t
 
 import pytest
+from google.protobuf import wrappers_pb2
 from grpc import aio
 from grpc_health.v1 import health_pb2 as pb_health
-from google.protobuf import wrappers_pb2
 
-from bentoml.testing.grpc import create_channel
 from bentoml.testing.grpc import async_client_call
+from bentoml.testing.grpc import create_channel
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/bento_server_grpc/tests/test_descriptors.py
+++ b/tests/e2e/bento_server_grpc/tests/test_descriptors.py
@@ -3,18 +3,18 @@ from __future__ import annotations
 import io
 import random
 import traceback
-from typing import TYPE_CHECKING
 from functools import partial
+from typing import TYPE_CHECKING
 
 import pytest
 
-from bentoml.grpc.utils import import_grpc
-from bentoml.grpc.utils import import_generated_stubs
-from bentoml.testing.grpc import create_channel
-from bentoml.testing.grpc import async_client_call
-from bentoml.testing.grpc import randomize_pb_ndarray
 from bentoml._internal.types import LazyType
 from bentoml._internal.utils import LazyLoader
+from bentoml.grpc.utils import import_generated_stubs
+from bentoml.grpc.utils import import_grpc
+from bentoml.testing.grpc import async_client_call
+from bentoml.testing.grpc import create_channel
+from bentoml.testing.grpc import randomize_pb_ndarray
 
 if TYPE_CHECKING:
     import grpc
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
     from google.protobuf import struct_pb2
     from google.protobuf import wrappers_pb2
 
-    from bentoml.grpc.v1 import service_pb2 as pb
     from bentoml._internal import external_typing as ext
+    from bentoml.grpc.v1 import service_pb2 as pb
 else:
     pb, _ = import_generated_stubs()
     grpc, _ = import_grpc()

--- a/tests/e2e/bento_server_http/tests/conftest.py
+++ b/tests/e2e/bento_server_http/tests/conftest.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 import typing as t
-import subprocess
 from typing import TYPE_CHECKING
 
 import pytest
@@ -12,10 +12,10 @@ import pytest
 if TYPE_CHECKING:
     from contextlib import ExitStack
 
-    from _pytest.main import Session
-    from _pytest.nodes import Item
     from _pytest.config import Config
     from _pytest.fixtures import FixtureRequest as _PytestFixtureRequest
+    from _pytest.main import Session
+    from _pytest.nodes import Item
 
     class FixtureRequest(_PytestFixtureRequest):
         param: str

--- a/tests/e2e/bento_server_http/tests/test_io.py
+++ b/tests/e2e/bento_server_http/tests/test_io.py
@@ -4,9 +4,9 @@ import io
 import json
 from typing import TYPE_CHECKING
 
+import aiohttp
 import numpy as np
 import pytest
-import aiohttp
 
 from bentoml.testing.utils import async_request
 from bentoml.testing.utils import parse_multipart_form

--- a/tests/e2e/bento_server_http/tests/test_meta.py
+++ b/tests/e2e/bento_server_http/tests/test_meta.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import time
 import asyncio
+import time
 from pathlib import Path
 
 import pytest

--- a/tests/integration/frameworks/conftest.py
+++ b/tests/integration/frameworks/conftest.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-import os
-import typing as t
 import logging
+import os
 import pkgutil
+import typing as t
+from importlib import import_module
 from types import ModuleType
 from typing import TYPE_CHECKING
-from importlib import import_module
 
 import pytest
 
 if TYPE_CHECKING:
-    from _pytest.nodes import Item
     from _pytest.config import Config
     from _pytest.config.argparsing import Parser
+    from _pytest.nodes import Item
 
     from .models import FrameworkTestModel
 

--- a/tests/integration/frameworks/mlflow/MNIST/mnist_autolog_example.py
+++ b/tests/integration/frameworks/mlflow/MNIST/mnist_autolog_example.py
@@ -8,22 +8,22 @@
 # pylint: disable=arguments-differ
 # pylint: disable=unused-argument
 # pylint: disable=abstract-method
-import os
 import logging
+import os
 from argparse import ArgumentParser
 
-import torch
 import mlflow
 import mlflow.pytorch
 import pytorch_lightning as pl
+import torch
+from pytorch_lightning.callbacks import LearningRateMonitor
+from pytorch_lightning.callbacks import ModelCheckpoint
+from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from torch.nn import functional as F
-from torchvision import datasets
-from torchvision import transforms
 from torch.utils.data import DataLoader
 from torch.utils.data import random_split
-from pytorch_lightning.callbacks import ModelCheckpoint
-from pytorch_lightning.callbacks import LearningRateMonitor
-from pytorch_lightning.callbacks.early_stopping import EarlyStopping
+from torchvision import datasets
+from torchvision import transforms
 
 try:
     from torchmetrics.functional import accuracy

--- a/tests/integration/frameworks/mlflow/test_apis.py
+++ b/tests/integration/frameworks/mlflow/test_apis.py
@@ -2,22 +2,22 @@ from __future__ import annotations
 
 import os
 import typing as t
-from typing import TYPE_CHECKING
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import numpy as np
 import mlflow
-import pytest
 import mlflow.models
 import mlflow.sklearn
 import mlflow.tracking
+import numpy as np
+import pytest
 from sklearn.datasets import load_iris
 from sklearn.neighbors import KNeighborsClassifier
 
 import bentoml
-from bentoml.exceptions import NotFound
-from bentoml.exceptions import BentoMLException
 from bentoml._internal.models.model import ModelContext
+from bentoml.exceptions import BentoMLException
+from bentoml.exceptions import NotFound
 
 if TYPE_CHECKING:
     from sklearn.utils import Bunch

--- a/tests/integration/frameworks/models/catboost.py
+++ b/tests/integration/frameworks/models/catboost.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 import typing as t
 from typing import TYPE_CHECKING
 
-from sklearn import metrics
 from catboost import CatBoostClassifier
+from sklearn import metrics
 from sklearn.datasets import make_classification
 from sklearn.model_selection import train_test_split
 
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 if TYPE_CHECKING:
     import bentoml._internal.external_typing as ext

--- a/tests/integration/frameworks/models/detectron.py
+++ b/tests/integration/frameworks/models/detectron.py
@@ -2,21 +2,21 @@ from __future__ import annotations
 
 import typing as t
 
-import numpy as np
-import torch
-import requests
 import detectron2.config as Cf
 import detectron2.engine as E
-import detectron2.modeling as M
 import detectron2.model_zoo as Mz
-from PIL import Image
+import detectron2.modeling as M
+import numpy as np
+import requests
+import torch
 from detectron2.data import transforms as T
+from PIL import Image
 
 import bentoml
 
 from . import FrameworkTestModel as Model
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 if t.TYPE_CHECKING:
     import torch.nn as nn

--- a/tests/integration/frameworks/models/diffusers.py
+++ b/tests/integration/frameworks/models/diffusers.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import numpy as np
 import diffusers
+import numpy as np
 
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 framework = bentoml.diffusers
 

--- a/tests/integration/frameworks/models/easyocr.py
+++ b/tests/integration/frameworks/models/easyocr.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 import typing as t
 
-import numpy as np
 import easyocr
+import numpy as np
 import requests
 from PIL import Image
 
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 framework = bentoml.easyocr
 backward_compatible = False

--- a/tests/integration/frameworks/models/fastai.py
+++ b/tests/integration/frameworks/models/fastai.py
@@ -6,20 +6,20 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 import torch.nn as nn
+from fastai.data.block import DataBlock
 from fastai.learner import Learner
 from fastai.metrics import accuracy
-from sklearn.datasets import load_iris
-from fastai.data.block import DataBlock
+from fastai.tabular.all import TabularDataLoaders
+from fastai.tabular.all import tabular_learner
 from fastai.torch_core import Module
 from fastai.torch_core import set_seed
-from fastai.tabular.all import tabular_learner
-from fastai.tabular.all import TabularDataLoaders
+from sklearn.datasets import load_iris
 
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 if TYPE_CHECKING:
     from sklearn.utils import Bunch

--- a/tests/integration/frameworks/models/flax.py
+++ b/tests/integration/frameworks/models/flax.py
@@ -4,15 +4,15 @@ import typing as t
 
 import chex
 import jax.numpy as jnp
-from jax import random
 from flax import linen as nn
+from jax import random
 from jax.nn import initializers
 
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 framework = bentoml.flax
 

--- a/tests/integration/frameworks/models/keras.py
+++ b/tests/integration/frameworks/models/keras.py
@@ -4,16 +4,16 @@ import typing as t
 from typing import TYPE_CHECKING
 
 import keras
-import numpy as np
-import tensorflow as tf
 import keras.layers
 import keras.optimizers
+import numpy as np
+import tensorflow as tf
 
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 if TYPE_CHECKING:
     from bentoml._internal import external_typing as ext

--- a/tests/integration/frameworks/models/lightgbm.py
+++ b/tests/integration/frameworks/models/lightgbm.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
+import lightgbm as lgb
 import numpy as np
 import pandas as pd
-import lightgbm as lgb
 from sklearn.datasets import load_breast_cancer
 
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 framework = bentoml.lightgbm
 

--- a/tests/integration/frameworks/models/onnx.py
+++ b/tests/integration/frameworks/models/onnx.py
@@ -1,30 +1,30 @@
 from __future__ import annotations
 
 import os
-import typing as t
 import tempfile
+import typing as t
 from typing import TYPE_CHECKING
 
-import onnx
 import numpy as np
-import torch
-import sklearn
-import torch.nn as nn
+import onnx
 import onnxruntime as ort
+import sklearn
+import torch
+import torch.nn as nn
 from skl2onnx import convert_sklearn
-from sklearn.datasets import load_iris
-from sklearn.ensemble import RandomForestClassifier
-from sklearn.preprocessing import LabelEncoder
-from sklearn.model_selection import train_test_split
 from skl2onnx.common.data_types import FloatTensorType
 from skl2onnx.common.data_types import Int64TensorType
 from skl2onnx.common.data_types import StringTensorType
+from sklearn.datasets import load_iris
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelEncoder
 
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 if TYPE_CHECKING:
     import bentoml._internal.external_typing as ext

--- a/tests/integration/frameworks/models/picklable_model.py
+++ b/tests/integration/frameworks/models/picklable_model.py
@@ -5,8 +5,8 @@ import numpy as np
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 framework = bentoml.picklable_model
 

--- a/tests/integration/frameworks/models/pytorch.py
+++ b/tests/integration/frameworks/models/pytorch.py
@@ -9,8 +9,8 @@ import torch.nn as nn
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 framework = bentoml.pytorch
 

--- a/tests/integration/frameworks/models/pytorch_lightning.py
+++ b/tests/integration/frameworks/models/pytorch_lightning.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
+import pytorch_lightning as pl
 import torch
 import torch.nn
-import pytorch_lightning as pl
 
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
-from .torchscript import test_y
+from . import FrameworkTestModelInput as Input
 from .torchscript import test_x_list
+from .torchscript import test_y
 
 framework = bentoml.pytorch_lightning
 

--- a/tests/integration/frameworks/models/sklearn.py
+++ b/tests/integration/frameworks/models/sklearn.py
@@ -10,8 +10,8 @@ from sklearn.ensemble import RandomForestClassifier
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 if TYPE_CHECKING:
     from sklearn.utils import Bunch

--- a/tests/integration/frameworks/models/tensorflow.py
+++ b/tests/integration/frameworks/models/tensorflow.py
@@ -9,8 +9,8 @@ import tensorflow as tf
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 if t.TYPE_CHECKING:
     from bentoml._internal.external_typing import tensorflow as tf_ext

--- a/tests/integration/frameworks/models/torchscript.py
+++ b/tests/integration/frameworks/models/torchscript.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 import numpy as np
-import torch
 import pandas as pd
+import torch
 import torch.nn
 
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 framework = bentoml.torchscript
 

--- a/tests/integration/frameworks/models/transformers.py
+++ b/tests/integration/frameworks/models/transformers.py
@@ -1,39 +1,39 @@
 from __future__ import annotations
 
-import typing as t
 import importlib
+import typing as t
 
 import numpy as np
 import requests
 import tensorflow as tf
 import transformers
-from PIL import Image
 from datasets import load_dataset
+from PIL import Image
 from transformers import Pipeline
-from transformers.utils import is_tf_available
-from transformers.utils import is_torch_available
-from transformers.pipelines import get_task
 from transformers.pipelines import get_supported_tasks
+from transformers.pipelines import get_task
 from transformers.testing_utils import nested_simplify
 from transformers.trainer_utils import set_seed
+from transformers.utils import is_tf_available
+from transformers.utils import is_torch_available
 
 import bentoml
+from bentoml._internal.frameworks.transformers import SimpleDefaultMapping
 from bentoml._internal.frameworks.transformers import TaskDefinition
+from bentoml._internal.frameworks.transformers import convert_to_autoclass
 from bentoml._internal.frameworks.transformers import delete_pipeline
 from bentoml._internal.frameworks.transformers import register_pipeline
-from bentoml._internal.frameworks.transformers import convert_to_autoclass
-from bentoml._internal.frameworks.transformers import SimpleDefaultMapping
 
 from . import FrameworkTestModel as Model
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 if t.TYPE_CHECKING:
     import torch
     from numpy.typing import NDArray
-    from transformers.utils.generic import ModelOutput
     from transformers.pipelines.base import GenericTensor
     from transformers.tokenization_utils_base import BatchEncoding
+    from transformers.utils.generic import ModelOutput
 
     from bentoml._internal.external_typing import transformers as transformers_ext
 

--- a/tests/integration/frameworks/models/xgboost.py
+++ b/tests/integration/frameworks/models/xgboost.py
@@ -7,14 +7,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 import xgboost as xgb
-from sklearn.datasets import load_iris
 from sklearn.datasets import load_breast_cancer
+from sklearn.datasets import load_iris
 
 import bentoml
 
 from . import FrameworkTestModel
-from . import FrameworkTestModelInput as Input
 from . import FrameworkTestModelConfiguration as Config
+from . import FrameworkTestModelInput as Input
 
 if TYPE_CHECKING:
     from sklearn.utils import Bunch

--- a/tests/integration/frameworks/test_fastai_unit.py
+++ b/tests/integration/frameworks/test_fastai_unit.py
@@ -1,28 +1,28 @@
 from __future__ import annotations
 
+import logging
 import re
 import typing as t
-import logging
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
-from unittest.mock import patch
 from unittest.mock import PropertyMock
+from unittest.mock import patch
 
-import torch
 import pytest
-import torch.nn as nn
+import torch
 import torch.functional as F
-from fastai.data.core import TfmdDL
-from fastai.data.core import Datasets
+import torch.nn as nn
 from fastai.data.core import DataLoaders
+from fastai.data.core import Datasets
+from fastai.data.core import TfmdDL
+from fastai.data.transforms import Transform
 from fastai.test_utils import synth_learner
 from fastai.torch_core import Module
 from fastcore.foundation import L
-from fastai.data.transforms import Transform
 
 import bentoml
-from bentoml.exceptions import InvalidArgument
 from bentoml.exceptions import BentoMLException
+from bentoml.exceptions import InvalidArgument
 from tests.integration.frameworks.models.fastai import custom_model
 
 if TYPE_CHECKING:

--- a/tests/integration/frameworks/test_frameworks.py
+++ b/tests/integration/frameworks/test_frameworks.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
+import logging
 import os
 import types
 import typing as t
-import logging
 from typing import TYPE_CHECKING
 
 import pytest
 
 import bentoml
-from bentoml.exceptions import NotFound
 from bentoml._internal.models.model import ModelContext
 from bentoml._internal.models.model import ModelSignature
 from bentoml._internal.runner.runner import Runner
-from bentoml._internal.runner.strategy import DefaultStrategy
 from bentoml._internal.runner.runner_handle.local import LocalRunnerRef
+from bentoml._internal.runner.strategy import DefaultStrategy
+from bentoml.exceptions import NotFound
 
 from .models import FrameworkTestModel
 
@@ -233,9 +233,9 @@ def test_runner_batching(
     test_model: FrameworkTestModel,
     saved_model: bentoml.Model,
 ):
+    from bentoml._internal.runner.container import AutoContainer
     from bentoml._internal.runner.utils import Params
     from bentoml._internal.runner.utils import payload_paramss_to_batch_params
-    from bentoml._internal.runner.container import AutoContainer
 
     ran_tests = False
 

--- a/tests/integration/frameworks/test_pytorch_unit.py
+++ b/tests/integration/frameworks/test_pytorch_unit.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import torch
 import pytest
+import torch
 
-from bentoml._internal.runner.container import AutoContainer
 from bentoml._internal.frameworks.pytorch import PyTorchTensorContainer
+from bentoml._internal.runner.container import AutoContainer
 
 
 @pytest.mark.parametrize("batch_axis", [0, 1])

--- a/tests/integration/frameworks/test_tensorflow_unit.py
+++ b/tests/integration/frameworks/test_tensorflow_unit.py
@@ -7,9 +7,9 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
-from bentoml._internal.types import LazyType
 from bentoml._internal.runner.container import AutoContainer
 from bentoml._internal.runner.container import DataContainerRegistry
+from bentoml._internal.types import LazyType
 
 if TYPE_CHECKING:
     from bentoml._internal.external_typing import tensorflow as ext

--- a/tests/integration/frameworks/test_transformers_unit.py
+++ b/tests/integration/frameworks/test_transformers_unit.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
+import logging
 import os
 import typing as t
-import logging
 
 import pytest
 import transformers
-from transformers.pipelines import pipeline  # type: ignore
-from transformers.pipelines import check_task  # type: ignore
-from transformers.trainer_utils import set_seed
-from transformers.models.auto.modeling_auto import AutoModelForCausalLM
 from transformers.models.auto.modeling_auto import AutoModelForAudioClassification
+from transformers.models.auto.modeling_auto import AutoModelForCausalLM
 from transformers.models.auto.modeling_auto import AutoModelForSequenceClassification
+from transformers.pipelines import check_task  # type: ignore
+from transformers.pipelines import pipeline  # type: ignore
 from transformers.pipelines.audio_classification import AudioClassificationPipeline
+from transformers.trainer_utils import set_seed
 
 import bentoml
 from bentoml.exceptions import BentoMLException

--- a/tests/test_cli_regression.py
+++ b/tests/test_cli_regression.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import time
 import shlex
+import time
 
 from click.testing import CliRunner
 

--- a/tests/unit/_internal/bento/test_bento.py
+++ b/tests/unit/_internal/bento/test_bento.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import os
-from sys import version_info
-from typing import TYPE_CHECKING
 from datetime import datetime
 from datetime import timezone
+from sys import version_info
+from typing import TYPE_CHECKING
 
 import fs
 import pytest
@@ -13,13 +13,13 @@ import pytest
 from bentoml import Tag
 from bentoml import bentos
 from bentoml._internal.bento import Bento
-from bentoml._internal.models import ModelStore
-from bentoml._internal.bento.bento import BentoInfo
 from bentoml._internal.bento.bento import BentoApiInfo
+from bentoml._internal.bento.bento import BentoInfo
 from bentoml._internal.bento.bento import BentoModelInfo
 from bentoml._internal.bento.bento import BentoRunnerInfo
-from bentoml._internal.configuration import BENTOML_VERSION
 from bentoml._internal.bento.build_config import BentoBuildConfig
+from bentoml._internal.configuration import BENTOML_VERSION
+from bentoml._internal.models import ModelStore
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/unit/_internal/bento/test_service_serialization.py
+++ b/tests/unit/_internal/bento/test_service_serialization.py
@@ -6,13 +6,13 @@ import typing as t
 from unittest.mock import ANY
 from unittest.mock import MagicMock
 
-import pytest
 import cloudpickle
+import pytest
 
 import bentoml
-from bentoml.exceptions import NotFound
-from bentoml._internal.tag import Tag
 from bentoml._internal.configuration.containers import BentoMLContainer
+from bentoml._internal.tag import Tag
+from bentoml.exceptions import NotFound
 
 from .test_bento import build_test_bento
 

--- a/tests/unit/_internal/cloud/test_deployment.py
+++ b/tests/unit/_internal/cloud/test_deployment.py
@@ -1,38 +1,38 @@
 from __future__ import annotations
-from datetime import datetime
 
 import typing as t
+from datetime import datetime
 from unittest.mock import patch
+
+import attr
 import pytest
-from bentoml._internal.cloud.schemas import (
-    BentoFullSchema,
-    BentoImageBuildStatus,
-    BentoManifestSchema,
-    BentoRepositorySchema,
-    BentoUploadStatus,
-    ClusterSchema,
-    DeploymentMode,
-    DeploymentRevisionSchema,
-    DeploymentRevisionStatus,
-    DeploymentSchema,
-    DeploymentStatus,
-    DeploymentTargetSchema,
-    ResourceType,
-)
-from bentoml._internal.cloud.schemas import DeploymentTargetType
-from bentoml._internal.cloud.schemas import UpdateDeploymentSchema
-from bentoml.cloud import BentoCloudClient
-from bentoml.cloud import Resource
+
+from bentoml._internal.cloud.schemas import BentoFullSchema
+from bentoml._internal.cloud.schemas import BentoImageBuildStatus
+from bentoml._internal.cloud.schemas import BentoManifestSchema
+from bentoml._internal.cloud.schemas import BentoRepositorySchema
+from bentoml._internal.cloud.schemas import BentoUploadStatus
+from bentoml._internal.cloud.schemas import ClusterSchema
 from bentoml._internal.cloud.schemas import CreateDeploymentSchema
 from bentoml._internal.cloud.schemas import CreateDeploymentTargetSchema
-from bentoml._internal.cloud.schemas import DeploymentTargetConfig
-from bentoml._internal.cloud.schemas import DeploymentTargetRunnerConfig
-from bentoml._internal.cloud.schemas import LabelItemSchema
+from bentoml._internal.cloud.schemas import DeploymentMode
+from bentoml._internal.cloud.schemas import DeploymentRevisionSchema
+from bentoml._internal.cloud.schemas import DeploymentRevisionStatus
+from bentoml._internal.cloud.schemas import DeploymentSchema
+from bentoml._internal.cloud.schemas import DeploymentStatus
 from bentoml._internal.cloud.schemas import DeploymentTargetCanaryRule
 from bentoml._internal.cloud.schemas import DeploymentTargetCanaryRuleType
+from bentoml._internal.cloud.schemas import DeploymentTargetConfig
 from bentoml._internal.cloud.schemas import DeploymentTargetHPAConf
+from bentoml._internal.cloud.schemas import DeploymentTargetRunnerConfig
+from bentoml._internal.cloud.schemas import DeploymentTargetSchema
+from bentoml._internal.cloud.schemas import DeploymentTargetType
+from bentoml._internal.cloud.schemas import LabelItemSchema
+from bentoml._internal.cloud.schemas import ResourceType
+from bentoml._internal.cloud.schemas import UpdateDeploymentSchema
 from bentoml._internal.cloud.schemas import UserSchema
-import attr
+from bentoml.cloud import BentoCloudClient
+from bentoml.cloud import Resource
 
 if t.TYPE_CHECKING:
     from unittest.mock import MagicMock

--- a/tests/unit/_internal/configuration/test_helpers.py
+++ b/tests/unit/_internal/configuration/test_helpers.py
@@ -5,11 +5,11 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from bentoml.exceptions import BentoMLConfigException
 from bentoml._internal.configuration.helpers import flatten_dict
-from bentoml._internal.configuration.helpers import rename_fields
-from bentoml._internal.configuration.helpers import load_config_file
 from bentoml._internal.configuration.helpers import is_valid_ip_address
+from bentoml._internal.configuration.helpers import load_config_file
+from bentoml._internal.configuration.helpers import rename_fields
+from bentoml.exceptions import BentoMLConfigException
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/unit/_internal/configuration/test_v1_migration.py
+++ b/tests/unit/_internal/configuration/test_v1_migration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/unit/_internal/io/test_custom.py
+++ b/tests/unit/_internal/io/test_custom.py
@@ -7,12 +7,12 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 import bentoml
-from bentoml.io import IODescriptor
-from bentoml.exceptions import BentoMLException
-from bentoml._internal.utils.http import set_cookies
 from bentoml._internal.service.openapi import SUCCESS_DESCRIPTION
-from bentoml._internal.service.openapi.specification import Schema
 from bentoml._internal.service.openapi.specification import MediaType
+from bentoml._internal.service.openapi.specification import Schema
+from bentoml._internal.utils.http import set_cookies
+from bentoml.exceptions import BentoMLException
+from bentoml.io import IODescriptor
 
 if TYPE_CHECKING:
     from google.protobuf import wrappers_pb2

--- a/tests/unit/_internal/io/test_file.py
+++ b/tests/unit/_internal/io/test_file.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from bentoml.io import File
 from bentoml.exceptions import BadInput
 from bentoml.grpc.utils import import_generated_stubs
+from bentoml.io import File
 
 if TYPE_CHECKING:
     from bentoml.grpc.v1 import service_pb2 as pb

--- a/tests/unit/_internal/io/test_image.py
+++ b/tests/unit/_internal/io/test_image.py
@@ -5,11 +5,11 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from bentoml.io import Image
+from bentoml._internal.utils import LazyLoader
 from bentoml.exceptions import BadInput
 from bentoml.exceptions import InvalidArgument
 from bentoml.grpc.utils import import_generated_stubs
-from bentoml._internal.utils import LazyLoader
+from bentoml.io import Image
 
 if TYPE_CHECKING:
     import numpy as np

--- a/tests/unit/_internal/io/test_json.py
+++ b/tests/unit/_internal/io/test_json.py
@@ -1,31 +1,31 @@
 from __future__ import annotations
 
-import json
-import typing as t
 import asyncio
+import json
 import logging
-from typing import TYPE_CHECKING
-from functools import partial
+import typing as t
 from dataclasses import dataclass
+from functools import partial
+from typing import TYPE_CHECKING
 
 import attr
 import numpy as np
 import pandas as pd
-import pytest
 import pydantic
+import pytest
 
-from bentoml.io import JSON
+from bentoml._internal.io_descriptors.json import DefaultJsonEncoder
+from bentoml._internal.utils import LazyLoader
 from bentoml.exceptions import BadInput
 from bentoml.grpc.utils import import_generated_stubs
-from bentoml._internal.utils import LazyLoader
-from bentoml._internal.io_descriptors.json import DefaultJsonEncoder
+from bentoml.io import JSON
 
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
     from google.protobuf import struct_pb2
 
-    from bentoml.grpc.v1 import service_pb2 as pb
     from bentoml._internal.service.openapi.specification import Schema
+    from bentoml.grpc.v1 import service_pb2 as pb
 else:
     pb, _ = import_generated_stubs()
     struct_pb2 = LazyLoader("struct_pb2", globals(), "google.protobuf.struct_pb2")

--- a/tests/unit/_internal/io/test_multipart.py
+++ b/tests/unit/_internal/io/test_multipart.py
@@ -5,12 +5,12 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from bentoml._internal.utils import LazyLoader
+from bentoml.exceptions import InvalidArgument
+from bentoml.grpc.utils import import_generated_stubs
 from bentoml.io import JSON
 from bentoml.io import Image
 from bentoml.io import Multipart
-from bentoml.exceptions import InvalidArgument
-from bentoml.grpc.utils import import_generated_stubs
-from bentoml._internal.utils import LazyLoader
 
 example = Multipart(arg1=JSON(), arg2=Image(mime_type="image/bmp", pilmode="RGB"))
 

--- a/tests/unit/_internal/io/test_numpy.py
+++ b/tests/unit/_internal/io/test_numpy.py
@@ -2,17 +2,17 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 from functools import partial
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
-from bentoml.io import NumpyNdarray
+from bentoml._internal.service.openapi.specification import Schema
 from bentoml.exceptions import BadInput
 from bentoml.exceptions import BentoMLException
 from bentoml.grpc.utils import import_generated_stubs
-from bentoml._internal.service.openapi.specification import Schema
+from bentoml.io import NumpyNdarray
 
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture

--- a/tests/unit/_internal/io/test_text.py
+++ b/tests/unit/_internal/io/test_text.py
@@ -4,10 +4,10 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from bentoml.io import Text
+from bentoml._internal.utils import LazyLoader
 from bentoml.exceptions import BentoMLException
 from bentoml.grpc.utils import import_generated_stubs
-from bentoml._internal.utils import LazyLoader
+from bentoml.io import Text
 
 if TYPE_CHECKING:
     from google.protobuf import wrappers_pb2

--- a/tests/unit/_internal/models/test_model.py
+++ b/tests/unit/_internal/models/test_model.py
@@ -1,25 +1,25 @@
 from __future__ import annotations
 
 import os
-from sys import version_info as pyver
-from typing import TYPE_CHECKING
 from datetime import datetime
 from datetime import timezone
+from sys import version_info as pyver
+from typing import TYPE_CHECKING
 
-import fs
 import attr
+import fs
+import fs.errors
 import numpy as np
 import pytest
-import fs.errors
 
 from bentoml import Tag
-from bentoml.exceptions import BentoMLException
-from bentoml.testing.pytest import TEST_MODEL_CONTEXT
+from bentoml._internal.configuration import BENTOML_VERSION
 from bentoml._internal.models import ModelOptions as InternalModelOptions
 from bentoml._internal.models.model import Model
 from bentoml._internal.models.model import ModelInfo
 from bentoml._internal.models.model import ModelStore
-from bentoml._internal.configuration import BENTOML_VERSION
+from bentoml.exceptions import BentoMLException
+from bentoml.testing.pytest import TEST_MODEL_CONTEXT
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/unit/_internal/service_loader/bento_with_models/service.py
+++ b/tests/unit/_internal/service_loader/bento_with_models/service.py
@@ -1,6 +1,5 @@
 import bentoml
 
-
 test_model = bentoml.models.get("testmodel")
 # get by alias
 another_model = bentoml.models.get("another")

--- a/tests/unit/_internal/service_loader/test_import_service.py
+++ b/tests/unit/_internal/service_loader/test_import_service.py
@@ -1,7 +1,7 @@
 import pytest
 
-from bentoml.exceptions import ImportServiceError
 from bentoml._internal.service.loader import import_service
+from bentoml.exceptions import ImportServiceError
 
 
 @pytest.mark.usefixtures("change_test_dir")

--- a/tests/unit/_internal/service_loader/test_service_loader.py
+++ b/tests/unit/_internal/service_loader/test_service_loader.py
@@ -1,9 +1,10 @@
-import pytest
 import sys
 
-from bentoml._internal.service.loader import load
+import pytest
+
 from bentoml._internal.bento import Bento
 from bentoml._internal.bento.build_config import BentoBuildConfig
+from bentoml._internal.service.loader import load
 
 
 @pytest.mark.usefixtures("change_test_dir", "model_store")

--- a/tests/unit/_internal/test_resource.py
+++ b/tests/unit/_internal/test_resource.py
@@ -4,12 +4,12 @@ import pytest
 
 import bentoml
 import bentoml.exceptions
-from bentoml.exceptions import BentoMLConfigException
-from bentoml._internal.resource import Resource
 from bentoml._internal.resource import CpuResource
+from bentoml._internal.resource import NvidiaGpuResource
+from bentoml._internal.resource import Resource
 from bentoml._internal.resource import get_resource
 from bentoml._internal.resource import system_resources
-from bentoml._internal.resource import NvidiaGpuResource
+from bentoml.exceptions import BentoMLConfigException
 
 
 class DummyResource(Resource[str], resource_id="dummy"):

--- a/tests/unit/_internal/test_service_api.py
+++ b/tests/unit/_internal/test_service_api.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 import bentoml
-from bentoml.io import Text
 from bentoml.exceptions import BentoMLException
+from bentoml.io import Text
 
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture

--- a/tests/unit/_internal/test_store.py
+++ b/tests/unit/_internal/test_store.py
@@ -2,18 +2,18 @@ import os
 import sys
 import time
 import typing as t
-from typing import TYPE_CHECKING
 from datetime import datetime
+from typing import TYPE_CHECKING
 
-import fs
 import attr
+import fs
 import pytest
 
 from bentoml import Tag
-from bentoml.exceptions import NotFound
-from bentoml.exceptions import BentoMLException
 from bentoml._internal.store import Store
 from bentoml._internal.store import StoreItem
+from bentoml.exceptions import BentoMLException
+from bentoml.exceptions import NotFound
 
 if sys.version_info < (3, 7):
     from backports.datetime_fromisoformat import MonkeyPatch

--- a/tests/unit/_internal/utils/circus/test_watchfilesplugin.py
+++ b/tests/unit/_internal/utils/circus/test_watchfilesplugin.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
+import logging
 import os
 import typing as t
-import logging
-from typing import TYPE_CHECKING
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest import skipUnless
 from unittest.mock import patch
 
 import pytest
 from circus.tests.support import TestCircus
 
-from bentoml._internal.utils.pkg import source_locations
 from bentoml._internal.utils.circus.watchfilesplugin import ServiceReloaderPlugin
+from bentoml._internal.utils.pkg import source_locations
 
 if TYPE_CHECKING:
     from unittest import TestCase

--- a/tests/unit/_internal/utils/test_analytics.py
+++ b/tests/unit/_internal/utils/test_analytics.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 import logging
 import typing as t
 from typing import TYPE_CHECKING
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
-from prometheus_client.parser import (
-    text_string_to_metric_families,
-)  # type: ignore (no prometheus types)
-from schema import And, Or, Schema
+from prometheus_client.parser import text_string_to_metric_families
+
+# type: ignore (no prometheus types)
+from schema import And
+from schema import Or
+from schema import Schema
 
 import bentoml
 from bentoml._internal.utils import analytics

--- a/tests/unit/_internal/utils/test_metrics.py
+++ b/tests/unit/_internal/utils/test_metrics.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import math
 
 from bentoml._internal.utils.metrics import INF
-from bentoml._internal.utils.metrics import metric_name
-from bentoml._internal.utils.metrics import linear_buckets
 from bentoml._internal.utils.metrics import exponential_buckets
+from bentoml._internal.utils.metrics import linear_buckets
+from bentoml._internal.utils.metrics import metric_name
 
 
 def _assert_equal(actual: tuple[float, ...], expected: tuple[float, ...]):

--- a/tests/unit/bentoml_cli/test_env_manager.py
+++ b/tests/unit/bentoml_cli/test_env_manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from bentoml_cli.env_manager import remove_env_arg
 
 testdata = [

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,13 +1,13 @@
 # pylint: disable=unused-argument
 from __future__ import annotations
 
-import typing as t
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
-import yaml
-import pytest
 import cloudpickle
+import pytest
+import yaml
 
 import bentoml
 from bentoml.testing.pytest import TEST_MODEL_CONTEXT
@@ -42,8 +42,8 @@ def reload_directory(
     ├── service.py
     └── train.py
     """
-    from bentoml._internal.utils import bentoml_cattr
     from bentoml._internal.bento.build_config import BentoBuildConfig
+    from bentoml._internal.utils import bentoml_cattr
 
     root = tmp_path_factory.mktemp("reload_directory")
     # create a models directory

--- a/tests/unit/grpc/interceptors/test_access.py
+++ b/tests/unit/grpc/interceptors/test_access.py
@@ -1,40 +1,40 @@
 # pylint: disable=unused-argument
 from __future__ import annotations
 
-import typing as t
-import logging
 import functools
+import logging
+import typing as t
 from typing import TYPE_CHECKING
 
 import pytest
 
-from tests.proto import service_test_pb2 as pb_test
-from tests.proto import service_test_pb2_grpc as services_test
-from bentoml.grpc.utils import import_grpc
-from bentoml.grpc.utils import wrap_rpc_handler
-from bentoml.grpc.utils import import_generated_stubs
-from bentoml.testing.grpc import create_channel
-from bentoml.testing.grpc import async_client_call
-from bentoml.testing.grpc import make_standalone_server
-from bentoml.testing.grpc import create_test_bento_servicer
 from bentoml._internal.utils import LazyLoader
-from tests.unit.grpc.conftest import TestServiceServicer
 from bentoml.grpc.interceptors.access import AccessLogServerInterceptor
 from bentoml.grpc.interceptors.opentelemetry import AsyncOpenTelemetryServerInterceptor
+from bentoml.grpc.utils import import_generated_stubs
+from bentoml.grpc.utils import import_grpc
+from bentoml.grpc.utils import wrap_rpc_handler
+from bentoml.testing.grpc import async_client_call
+from bentoml.testing.grpc import create_channel
+from bentoml.testing.grpc import create_test_bento_servicer
+from bentoml.testing.grpc import make_standalone_server
+from tests.proto import service_test_pb2 as pb_test
+from tests.proto import service_test_pb2_grpc as services_test
+from tests.unit.grpc.conftest import TestServiceServicer
 
 if TYPE_CHECKING:
     import grpc
-    from grpc import aio
     from _pytest.logging import LogCaptureFixture
     from google.protobuf import wrappers_pb2
+    from grpc import aio
 
     from bentoml import Service
+    from bentoml.grpc.types import AsyncHandlerMethod
+    from bentoml.grpc.types import BentoServicerContext
+    from bentoml.grpc.types import HandlerCallDetails
     from bentoml.grpc.types import Request
     from bentoml.grpc.types import Response
     from bentoml.grpc.types import RpcMethodHandler
-    from bentoml.grpc.types import AsyncHandlerMethod
-    from bentoml.grpc.types import HandlerCallDetails
-    from bentoml.grpc.types import BentoServicerContext
 else:
     grpc, aio = import_grpc()
     wrappers_pb2 = LazyLoader("wrappers_pb2", globals(), "google.protobuf.wrappers_pb2")

--- a/tests/unit/grpc/interceptors/test_prometheus.py
+++ b/tests/unit/grpc/interceptors/test_prometheus.py
@@ -1,26 +1,26 @@
 from __future__ import annotations
 
 import sys
-import typing as t
 import tempfile
-from typing import TYPE_CHECKING
+import typing as t
 from asyncio import Future
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
 
+from bentoml._internal.configuration.containers import BentoMLContainer
+from bentoml._internal.utils import LazyLoader
+from bentoml.grpc.interceptors.prometheus import PrometheusServerInterceptor
+from bentoml.grpc.utils import import_generated_stubs
+from bentoml.grpc.utils import import_grpc
+from bentoml.testing.grpc import async_client_call
+from bentoml.testing.grpc import create_channel
+from bentoml.testing.grpc import create_test_bento_servicer
+from bentoml.testing.grpc import make_standalone_server
 from tests.proto import service_test_pb2 as pb_test
 from tests.proto import service_test_pb2_grpc as services_test
-from bentoml.grpc.utils import import_grpc
-from bentoml.grpc.utils import import_generated_stubs
-from bentoml.testing.grpc import create_channel
-from bentoml.testing.grpc import async_client_call
-from bentoml.testing.grpc import make_standalone_server
-from bentoml.testing.grpc import create_test_bento_servicer
-from bentoml._internal.utils import LazyLoader
 from tests.unit.grpc.conftest import TestServiceServicer
-from bentoml.grpc.interceptors.prometheus import PrometheusServerInterceptor
-from bentoml._internal.configuration.containers import BentoMLContainer
 
 if TYPE_CHECKING:
     import grpc

--- a/tests/unit/grpc/test_grpc_utils.py
+++ b/tests/unit/grpc/test_grpc_utils.py
@@ -8,13 +8,13 @@ import grpc
 import pytest
 
 from bentoml.exceptions import BadInput
-from bentoml.exceptions import InvalidArgument
 from bentoml.exceptions import BentoMLException
+from bentoml.exceptions import InvalidArgument
 from bentoml.grpc.utils import MethodName
-from bentoml.grpc.utils import to_http_status
 from bentoml.grpc.utils import grpc_status_code
-from bentoml.grpc.utils import wrap_rpc_handler
 from bentoml.grpc.utils import parse_method_name
+from bentoml.grpc.utils import to_http_status
+from bentoml.grpc.utils import wrap_rpc_handler
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,18 +1,17 @@
+import importlib.metadata
 import os
-import time
 import random
 import string
+import time
 from sys import version_info as pyver
 from typing import TYPE_CHECKING
-
-import importlib.metadata
 
 import pytest
 
 import bentoml
-from bentoml.exceptions import NotFound
-from bentoml._internal.models import ModelStore
 from bentoml._internal.models import ModelContext
+from bentoml._internal.models import ModelStore
+from bentoml.exceptions import NotFound
 
 if TYPE_CHECKING:
     from pathlib import Path


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

## What does this PR address?

Adding `extend-select` actually makes it work!
But since `ruff` doesn't support sort imports by length, changes are expected.

Supersedes #4003 

@aarnphm 