### PR TITLE
fix(triton): correctly set client handle

### DIFF
--- a/src/bentoml/triton.py
+++ b/src/bentoml/triton.py
@@ -179,6 +179,8 @@ class _TritonRunner(_AbstractRunner):
         if handle_class is None:
             handle_class = TritonRunnerHandle
 
+        _object_setattr(self, "_runner_handle", handle_class(self))
+
         super().init_client(handle_class=handle_class, *args, **kwargs)
 
     def destroy(self):

--- a/src/bentoml/triton.py
+++ b/src/bentoml/triton.py
@@ -20,6 +20,7 @@ from ._internal.runner.runner_handle.remote import (
     handle_triton_exception as _handle_triton_exception,
 )
 from ._internal.utils import LazyLoader as _LazyLoader
+from .exceptions import StateException as _StateException
 
 if t.TYPE_CHECKING:
     import tritonclient.grpc.aio as _tritongrpcclient
@@ -168,20 +169,27 @@ class _TritonRunner(_AbstractRunner):
             "TritonRunner '%s' will not be available for development mode.", self.name
         )
 
+    def _set_handle(
+        self, handle_class: type[RunnerHandle], *args: t.Any, **kwargs: t.Any
+    ) -> None:
+        if not isinstance(self._runner_handle, _DummyRunnerHandle):
+            raise _StateException("Runner already initialized")
+
+        runner_handle = handle_class(self, *args, **kwargs)
+        _object_setattr(self, "_runner_handle", runner_handle)
+
     def init_client(
         self,
         handle_class: type[RunnerHandle] | None = None,
         *args: t.Any,
         **kwargs: t.Any,
     ):
-        from ._internal.runner.runner_handle.remote import TritonRunnerHandle
-
         if handle_class is None:
-            handle_class = TritonRunnerHandle
+            from ._internal.runner.runner_handle.remote import TritonRunnerHandle
 
-        _object_setattr(self, "_runner_handle", handle_class(self))
-
-        super().init_client(handle_class=handle_class, *args, **kwargs)
+            self._set_handle(TritonRunnerHandle)
+        else:
+            self._set_handle(handle_class, *args, **kwargs)
 
     def destroy(self):
         _object_setattr(self, "_runner_handle", _DummyRunnerHandle())


### PR DESCRIPTION
Fixes #4045 

An error occurs when inferring using triton runner as of bentoml 1.0.21. 
With the change to the `init_client` function in the `Runner` class in version 1.0.21, the `init_client` function in the `_TritonRunner` class was also changed.
As a result of this, the `_runner_handle` in the `_TritonRunner` class does not change a `TritonRunnerHandle` class, remains a `_DummyRunnerHandle` class.
This results in the error below.
```
root@427afba6823c:/opt/tritonserver# bentoml serve
2023-08-21T06:29:21+0000 [INFO] [cli] Prometheus metrics for HTTP BentoServer from "." can be accessed at http://localhost:3000/metrics.

...

I0821 06:29:27.504148 33884 grpc_server.cc:2450] Started GRPCInferenceService at 0.0.0.0:36469
I0821 06:29:27.504191 33884 http_server.cc:185] Started Metrics Service at 0.0.0.0:8002
2023-08-21T06:29:29+0000 [ERROR] [api_server:triton-integration:48] Exception on /predict [POST] (trace=b790f47fd5dfa2b0a06d00bd5b269c05,span=4b0482ef625b15b7,sampled=0,service.name=triton-integration)
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/bentoml/_internal/server/http_app.py", line 341, in api_func
    output = await api.func(*args)
  File "/opt/tritonserver/server.py", line 24, in predict
    infer_result = await triton_runner.infer(
  File "/usr/local/lib/python3.8/dist-packages/bentoml/triton.py", line 247, in __getattr__
    return super().__getattribute__(item)
AttributeError: '_TritonRunner' object has no attribute 'infer'
2023-08-21T06:29:29+0000 [INFO] [api_server:triton-integration:48] 10.2.1.92:54959 (scheme=http,method=POST,path=/predict,type=application/json,length=338) (status=500,type=application/json,length=110) 2.221ms (trace=b790f47fd5dfa2b0a06d00bd5b269c05,span=4b0482ef625b15b7,sampled=0,service.name=triton-integration)
```

<br>

So I put the deleted code(`_object_setattr(self, "_runner_handle", handle_class(self))`) below back into `init_client` in the `_TritonRunner` class.
```python
    def init_client(
        self,
        handle_class: type[RunnerHandle] | None = None,
        *args: t.Any,
        **kwargs: t.Any,
    ):
        from ._internal.runner.runner_handle.remote import TritonRunnerHandle

        if handle_class is None:
            handle_class = TritonRunnerHandle

        _object_setattr(self, "_runner_handle", handle_class(self))

        super().init_client(handle_class=handle_class, *args, **kwargs)
```

Please let us know if this fix is not appropriate for your current version.


## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
