### PR TITLE
fix: bento build cache miss

### DIFF
--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -649,6 +649,7 @@ fi
                     "--no-header",
                     f"--output-file={pip_compile_out}",
                     "--resolver=backtracking",
+                    "--no-annotate",
                 ]
             )
             logger.info("Locking PyPI package versions.")


### PR DESCRIPTION
## What does this PR address?

fix: pip dependency cache miss in bento build stage

the root cause is that the requirement.text generated by pip compile contains some tmp and random annotations like 
![image](https://github.com/bentoml/BentoML/assets/141706136/ca93a8a9-2609-4011-a7e6-12a6a423e455)

fix this by adding `--no-annotate` to the pip compile comands

test result :

before:
![image](https://github.com/bentoml/BentoML/assets/141706136/8ed5467d-160e-402c-9bbb-e4b457eed4b8)
after:
![image](https://github.com/bentoml/BentoML/assets/141706136/62347f5d-e092-4cb6-b9c8-1fbae3a5a463)

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
