### PR TITLE
fix(client): make get_client raise instead of logging

### DIFF
--- a/src/bentoml/exceptions.py
+++ b/src/bentoml/exceptions.py
@@ -119,3 +119,15 @@ class ImportServiceError(BentoMLException):
     """Raised when BentoML failed to import the user's service file."""
 
     pass
+
+
+class UnservableException(StateException):
+    """Raised when a service is not servable."""
+
+    pass
+
+
+class ServerStateException(StateException):
+    """Raised when a server API requiring the BentoML server to be running is executed when the server is not running."""
+
+    pass


### PR DESCRIPTION
This fixes a questionable choice of mine, where getting a client when a server was not running would return `None` and warn instead of raising an exception. This is now fixed.

I also have replaced instances of deprecation warnings with `warnings.warn`, which I believe is idiomatic.