### PR TITLE
fix(config): set default runner timeout to 15min

### DIFF
--- a/src/bentoml/_internal/configuration/v1/default_configuration.yaml
+++ b/src/bentoml/_internal/configuration/v1/default_configuration.yaml
@@ -70,7 +70,7 @@ runners:
   resources: ~
   workers_per_resource: 1
   traffic:
-    timeout: 300
+    timeout: 900
     max_concurrency: ~
   batching:
     enabled: true


### PR DESCRIPTION
This allows for the amount of time it takes to cold-start a service when running with serverless.
