### PR TITLE
fix: Rename ASGIHTTPSender to BufferedASGISender for Ray compatibility.

### DIFF
--- a/src/bentoml/_internal/ray/__init__.py
+++ b/src/bentoml/_internal/ray/__init__.py
@@ -4,7 +4,7 @@ import typing as t
 from functools import partial
 
 import requests
-from ray.serve._private.http_util import ASGIHTTPSender
+from ray.serve._private.http_util import BufferedASGISender
 
 import bentoml
 from bentoml import Tag
@@ -94,7 +94,7 @@ def _get_service_deployment(svc: bentoml.Service, **kwargs) -> Deployment:
                 runner._set_handle(RayRunnerHandle, runner_deployments[runner.name])
 
         async def __call__(self, request: requests.Request):
-            sender = ASGIHTTPSender()
+            sender = BufferedASGISender()
             await self.app(request.scope, receive=request.receive, send=sender)
             return sender.build_asgi_response()
 

--- a/src/bentoml/_internal/ray/__init__.py
+++ b/src/bentoml/_internal/ray/__init__.py
@@ -50,13 +50,17 @@ def _get_runner_deployment(
                     inp_batch_dim = method.config.batch_dim[0]
                     out_batch_dim = method.config.batch_dim[1]
                     ray_batch_args = (
-                        batching_config[method.name] if method.name in batching_config else {}
+                        batching_config[method.name]
+                        if method.name in batching_config
+                        else {}
                     )
 
                     @serve.batch(**ray_batch_args)
                     async def _func(self, *args, **kwargs):
                         params = Params(*args, **kwargs).map(
-                            partial(AutoContainer.batches_to_batch, batch_dim=inp_batch_dim)
+                            partial(
+                                AutoContainer.batches_to_batch, batch_dim=inp_batch_dim
+                            )
                         )
                         run_params = params.map(lambda arg: arg[0])
                         indices = next(iter(params.items()))[1][1]
@@ -71,7 +75,9 @@ def _get_runner_deployment(
                 else:
 
                     async def _func(self, *args, **kwargs):
-                        return await getattr(_runner, method.name).async_run(*args, **kwargs)
+                        return await getattr(_runner, method.name).async_run(
+                            *args, **kwargs
+                        )
 
                     setattr(RunnerDeployment, method.name, _func)
 
@@ -207,4 +213,6 @@ def deployment(
         svc, runners_deployment_config_map, enable_batching, batching_config
     )
 
-    return _get_service_deployment(svc, **service_deployment_config).bind(**runner_deployments)
+    return _get_service_deployment(svc, **service_deployment_config).bind(
+        **runner_deployments
+    )

--- a/src/bentoml/_internal/ray/__init__.py
+++ b/src/bentoml/_internal/ray/__init__.py
@@ -11,7 +11,6 @@ if pkg.pkg_version_info("ray")[:2] >= (2, 5):
     from ray.serve._private.http_util import BufferedASGISender as ASGIHTTPSender
 else:
     from ray.serve._private.http_util import ASGIHTTPSender
-# from ray.serve._private.http_util import BufferedASGISender
 
 import bentoml
 from bentoml import Tag

--- a/src/bentoml/_internal/ray/__init__.py
+++ b/src/bentoml/_internal/ray/__init__.py
@@ -7,7 +7,7 @@ import requests
 
 from bentoml._internal.utils import pkg
 
-if pkg.pkg_version_info("ray")[1] >= 5:
+if pkg.pkg_version_info("ray")[:2] >= (2, 5):
     from ray.serve._private.http_util import BufferedASGISender as ASGIHTTPSender
 else:
     from ray.serve._private.http_util import ASGIHTTPSender

--- a/src/bentoml/_internal/ray/__init__.py
+++ b/src/bentoml/_internal/ray/__init__.py
@@ -5,7 +5,7 @@ from functools import partial
 
 import requests
 
-from bentoml._internal.utils import pkg
+from ._internal.utils import pkg
 
 if pkg.pkg_version_info("ray")[:2] >= (2, 5):
     from ray.serve._private.http_util import BufferedASGISender as ASGIHTTPSender


### PR DESCRIPTION
## What does this PR address?
An update in Ray renamed ASGIHTTPSender to BufferedASGISender. This change has not been made in BentoML. I just renamed it.

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
