### PR TITLE
fix: StreamingResponse compatibility issue

### DIFF
--- a/src/bentoml/_internal/io_descriptors/text.py
+++ b/src/bentoml/_internal/io_descriptors/text.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import typing as t
 
 from starlette.requests import Request
+from starlette.responses import Response
 from starlette.responses import StreamingResponse
 
 from ..service.openapi import SUCCESS_DESCRIPTION
@@ -161,20 +162,30 @@ class Text(IODescriptor[str], descriptor_id="bentoml.io.Text", proto_fields=("te
 
     async def to_http_response(
         self, obj: str | t.AsyncGenerator[str, None], ctx: Context | None = None
-    ) -> StreamingResponse:
+    ) -> Response | StreamingResponse:
         content_stream = iter([obj]) if isinstance(obj, str) else obj
-
         if ctx is not None:
-            res = StreamingResponse(
-                content_stream,
-                media_type=self._mime_type,
-                headers=ctx.response.metadata,  # type: ignore (bad starlette types)
-                status_code=ctx.response.status_code,
-            )
+            if isinstance(obj, str):
+                res = Response(
+                    obj,
+                    media_type=self._mime_type,
+                    headers=ctx.response.metadata,  # type: ignore (bad starlette types)
+                    status_code=ctx.response.status_code,
+                )
+            else:
+                res = StreamingResponse(
+                    content_stream,
+                    media_type=self._mime_type,
+                    headers=ctx.response.metadata,  # type: ignore (bad starlette types)
+                    status_code=ctx.response.status_code,
+                )
             set_cookies(res, ctx.response.cookies)
             return res
         else:
-            return StreamingResponse(content_stream, media_type=self._mime_type)
+            if isinstance(obj, str):
+                return Response(obj, media_type=self._mime_type)
+            else:
+                return StreamingResponse(content_stream, media_type=self._mime_type)
 
     async def from_proto(self, field: wrappers_pb2.StringValue | bytes) -> str:
         if isinstance(field, bytes):

--- a/tests/unit/_internal/io/test_multipart.py
+++ b/tests/unit/_internal/io/test_multipart.py
@@ -14,7 +14,7 @@ from bentoml.io import Multipart
 from bentoml.io import Text
 
 example = Multipart(arg1=JSON(), arg2=Image(mime_type="image/bmp", pilmode="RGB"))
-example2 = Multipart(arg1=Image(), arg2=Text())
+example2 = Multipart(arg1=Image(), arg2=Text(content_type='text/event-stream'))
 
 if TYPE_CHECKING:
     import PIL.Image as PILImage

--- a/tests/unit/_internal/io/test_multipart.py
+++ b/tests/unit/_internal/io/test_multipart.py
@@ -11,8 +11,10 @@ from bentoml.grpc.utils import import_generated_stubs
 from bentoml.io import JSON
 from bentoml.io import Image
 from bentoml.io import Multipart
+from bentoml.io import Text
 
 example = Multipart(arg1=JSON(), arg2=Image(mime_type="image/bmp", pilmode="RGB"))
+example2 = Multipart(arg1=Image(), arg2=Text())
 
 if TYPE_CHECKING:
     import PIL.Image as PILImage
@@ -98,3 +100,14 @@ async def test_multipart_from_to_proto(img_file: str):
     )
     assert isinstance(message, pb.Multipart)
     assert message.fields["arg1"].json.struct_value.fields["asd"].string_value == "asd"
+
+
+@pytest.mark.asyncio
+async def test_multipart_to_http_response(img_file: str):
+    try:
+        res = await example2.to_http_response(
+            {"arg1": PILImage.open(img_file), "arg2": "test prompt"}
+        )
+        assert res
+    except Exception as e:
+        pytest.fail(f"Unexpected exception: {e}")

--- a/tests/unit/_internal/io/test_multipart.py
+++ b/tests/unit/_internal/io/test_multipart.py
@@ -14,7 +14,7 @@ from bentoml.io import Multipart
 from bentoml.io import Text
 
 example = Multipart(arg1=JSON(), arg2=Image(mime_type="image/bmp", pilmode="RGB"))
-example2 = Multipart(arg1=Image(), arg2=Text(content_type='text/event-stream'))
+example2 = Multipart(arg1=Image(), arg2=Text(content_type="text/event-stream"))
 
 if TYPE_CHECKING:
     import PIL.Image as PILImage


### PR DESCRIPTION
## What does this PR address?
fix issue:
Exception raised when calling bentoml.client with a Multipart format. 
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/paperspace/.local/lib/python3.9/site-packages/bentoml/_internal/client/__init__.py", line 133, in _sync_call
    return asyncio.run(self._call(inp, _bentoml_api=_bentoml_api, **kwargs))
  File "/usr/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/home/paperspace/.local/lib/python3.9/site-packages/bentoml/_internal/client/http.py", line 167, in _call
    fake_resp = await api.input.to_http_response(kwargs, None)
  File "/home/paperspace/.local/lib/python3.9/site-packages/bentoml/_internal/io_descriptors/multipart.py", line 294, in to_http_response
    return await concat_to_multipart_response(dict(zip(self._inputs, resps)), ctx)
  File "/home/paperspace/.local/lib/python3.9/site-packages/bentoml/_internal/utils/formparser.py", line 371, in concat_to_multipart_response
    writer.write(resp.body)
AttributeError: 'StreamingResponse' object has no attribute 'body'
```

The reason is that we directly change the output of Text descriptor to `StreamingResponse` from `Response`, while it may not compatible with `concat_to_multipart_response` func of  multi-part descriptor

this fix is to return `StreamingResponse` or `Response`  according to the input.

test:
case 1: in linux 
![image](https://github.com/bentoml/BentoML/assets/141706136/496f13bc-34f7-4eab-be8a-a4138ca6dd80)

case 2: in colab
![image](https://github.com/bentoml/BentoML/assets/141706136/3d6865a2-bdbf-44f6-a636-6b2fa9993838)

<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->

Fixes #(issue)

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [x] Did you write tests to cover your changes?
