### PR TITLE
fix: Path issues with pip modules

### DIFF
--- a/src/bentoml/_internal/service/loader.py
+++ b/src/bentoml/_internal/service/loader.py
@@ -71,15 +71,15 @@ def import_service(
         os.chdir(prev_cwd)
         BentoMLContainer.model_store.set(global_model_store)
 
-    try:
-        if working_dir is not None:
-            working_dir = os.path.realpath(os.path.expanduser(working_dir))
-            # Set cwd(current working directory) to the Bento's project directory,
-            # which allows user code to read files using relative path
-            os.chdir(working_dir)
-        else:
-            working_dir = os.getcwd()
+    if working_dir is not None:
+        working_dir = os.path.realpath(os.path.expanduser(working_dir))
+        # Set cwd(current working directory) to the Bento's project directory,
+        # which allows user code to read files using relative path
+        os.chdir(working_dir)
+    else:
+        working_dir = os.getcwd()
 
+    try:
         sys.path.insert(0, working_dir)
 
         if model_store is not global_model_store:
@@ -169,9 +169,8 @@ def import_service(
         object.__setattr__(instance, "_import_str", f"{module_name}:{attrs_str}")
         return instance
     except ImportServiceError:
-        if working_dir:
-            # Undo changes to sys.path
-            sys.path.remove(working_dir)
+        # Undo changes to sys.path
+        sys.path.remove(working_dir)
 
         recover_standalone_env_change()
         raise

--- a/src/bentoml/_internal/service/loader.py
+++ b/src/bentoml/_internal/service/loader.py
@@ -63,7 +63,6 @@ def import_service(
     from bentoml import Service
 
     prev_cwd = None
-    sys_path_modified = False
     prev_cwd = os.getcwd()
     global_model_store = BentoMLContainer.model_store.get()
 
@@ -81,9 +80,7 @@ def import_service(
         else:
             working_dir = os.getcwd()
 
-        if working_dir not in sys.path:
-            sys.path.insert(0, working_dir)
-            sys_path_modified = True
+        sys.path.insert(0, working_dir)
 
         if model_store is not global_model_store:
             BentoMLContainer.model_store.set(model_store)
@@ -172,7 +169,7 @@ def import_service(
         object.__setattr__(instance, "_import_str", f"{module_name}:{attrs_str}")
         return instance
     except ImportServiceError:
-        if sys_path_modified and working_dir:
+        if working_dir:
             # Undo changes to sys.path
             sys.path.remove(working_dir)
 


### PR DESCRIPTION
Always prepend current bentofile directory to system path to avoid unwanted behavior when other bentofiles are on the system PATH
This is especially evident when trying to use bentoml cli on python folders that are also pip modules see https://github.com/bentoml/BentoML/issues/4217