### PR TITLE
fix: webui InputNumber range check fails when min or max equals 0

### DIFF
--- a/webui/src/components/form/InputNumber.tsx
+++ b/webui/src/components/form/InputNumber.tsx
@@ -51,9 +51,9 @@ export default function InputNumber({
       return onChange?.(e.target.value as unknown as number)
 
     // check range
-    if (max && value > max)
+    if (max !== undefined && value > max)
       value = max
-    if (min && value < min)
+    if (min !== undefined && value < min)
       value = min
     onChange?.(value)
   }, [onChange, min, max])


### PR DESCRIPTION
## What does this PR address?

Fix InputNumber range check fails when min or max equals 0 

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
