### PR TITLE
fix(sse): Using header bytes to determine payload size for streaming payload

### DIFF
--- a/src/bentoml/_internal/runner/runner_handle/remote.py
+++ b/src/bentoml/_internal/runner/runner_handle/remote.py
@@ -326,13 +326,29 @@ class RemoteRunnerClient(RunnerHandle):
                 data=data,
                 headers=headers,
             ) as resp:
+                # buffer = bytearray()
+                # async for b, end_of_http_chunk in resp.content.iter_chunks():
+                #     buffer.extend(b)
+
+                #     # This is to handle large payload that is split into multiple chunks
+                #     if end_of_http_chunk and len(buffer) > 0:
+                #         # TODO: To remove pickling so that we can stream data as it is
+                #         payload = pickle.loads(buffer)
+                #         yield AutoContainer.from_payload(payload)
+
+                #         # Clearing the buffer for the next data
+                #         buffer = bytearray()
+
                 buffer = bytearray()
-                async for b, end_of_http_chunk in resp.content.iter_chunks():
+                async for b in resp.content.iter_any():
                     buffer.extend(b)
 
+                    print(f"First 100 bytes of buffer: {buffer[:100]}")
+                    print(f"Last 100 bytes of buffer: {buffer[-100:]}")
                     # This is to handle large payload that is split into multiple chunks
-                    if end_of_http_chunk and len(buffer) > 0:
+                    if b"ilovebentoml!@#$%^&*()" in buffer:
                         # TODO: To remove pickling so that we can stream data as it is
+                        # We dont need to remove the stop bytes because pickle will ignore them
                         payload = pickle.loads(buffer)
                         yield AutoContainer.from_payload(payload)
 

--- a/src/bentoml/_internal/server/runner_app.py
+++ b/src/bentoml/_internal/server/runner_app.py
@@ -354,7 +354,7 @@ class RunnerAppFactory(BaseAppFactory):
                     Extract Data from a AsyncGenerator[Payload, None]
                     """
                     async for p in payload:
-                        yield pickle.dumps(p)
+                        yield pickle.dumps(p) + b"ilovebentoml!@#$%^&*()"
 
                 return StreamingResponse(
                     streamer(),


### PR DESCRIPTION
## What does this PR address?
Using header bytes to determine payload size for streaming payload.

This is to solve situation where payloads are prematurely resolved when using `iter_chunks` when there are proxy layers between API server and runner.

<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->

Fixes #(issue)

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
