### PR TITLE
docs: fix typo in frameworks transformers guide

### DIFF
--- a/docs/source/frameworks/transformers.rst
+++ b/docs/source/frameworks/transformers.rst
@@ -362,7 +362,7 @@ To serve a custom pipeline, simply create a runner and service with the previous
 Adaptive Batching
 -----------------
 
-If the model supports batched interence, it is recommended to enable batching to take advantage of the adaptive batching capability
+If the model supports batched inference, it is recommended to enable batching to take advantage of the adaptive batching capability
 in BentoML by overriding the :code:`signatures` argument with the method name (:code:`__call__`), :code:`batchable`, and :code:`batch_dim`
 configurations when saving the model to the model store .
 


### PR DESCRIPTION
## What does this PR address?

Fix typo in hugging face transformers framework guide

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [x] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
