### PR TITLE
fix: format of PILImage is None which may cause buffer saving error, in the payload stage.

### DIFF
--- a/src/bentoml/_internal/runner/container.py
+++ b/src/bentoml/_internal/runner/container.py
@@ -459,7 +459,9 @@ class PILImageContainer(DataContainer["ext.PILImage", "ext.PILImage"]):
     def to_payload(cls, batch: ext.PILImage, batch_dim: int) -> Payload:
         buffer = io.BytesIO()
         if batch.format is None:
-            raise RuntimeError("PIL.Image recieved has no format, it may cause error in buffer saving. Please replace it or convert it to numpy.ndarray for safe.")
+            raise RuntimeError(
+                "PIL.Image recieved has no format, it may cause error in buffer saving. Please replace it or convert it to numpy.ndarray for safe."
+            )
         batch.save(buffer, format=batch.format)
         return cls.create_payload(buffer.getvalue(), batch_size=1)
 

--- a/src/bentoml/_internal/runner/container.py
+++ b/src/bentoml/_internal/runner/container.py
@@ -458,6 +458,8 @@ class PILImageContainer(DataContainer["ext.PILImage", "ext.PILImage"]):
     @classmethod
     def to_payload(cls, batch: ext.PILImage, batch_dim: int) -> Payload:
         buffer = io.BytesIO()
+        if batch.format is None:
+            raise RuntimeError("PIL.Image recieved has no format, it may cause error in buffer saving. Please replace it or convert it to numpy.ndarray for safe.")
         batch.save(buffer, format=batch.format)
         return cls.create_payload(buffer.getvalue(), batch_size=1)
 


### PR DESCRIPTION
## What does this PR address?
Sometimes the PILImage processed does not contain format information, so the following error will be raised. It may take a long time for users to troubleshoot positioning. Therefore, when PILImage does not contain format information, the user should be reminded to use other formats.
```bash
2023-12-27 02:33:34.030 | CRITICAL | service:inference:118 - Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/PIL/Image.py", line 2409, in save
    format = EXTENSION[ext]
KeyError: ''

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/tilediffusion/service.py", line 114, in inference
    ) = await tilediffusion_inference_runner.tilediffusion_infer.async_run(
  File "/usr/local/lib/python3.10/site-packages/bentoml/_internal/runner/runner.py", line 55, in async_run
    return await self.runner._runner_handle.async_run_method(self, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/bentoml/_internal/runner/runner_handle/remote.py", line 201, in async_run_method
    payload_params = Params[Payload](*args, **kwargs).map(
  File "/usr/local/lib/python3.10/site-packages/bentoml/_internal/runner/utils.py", line 65, in map
    kwargs = {k: function(v) for k, v in self.kwargs.items()}
  File "/usr/local/lib/python3.10/site-packages/bentoml/_internal/runner/utils.py", line 65, in <dictcomp>
    kwargs = {k: function(v) for k, v in self.kwargs.items()}
  File "/usr/local/lib/python3.10/site-packages/bentoml/_internal/runner/container.py", line 665, in to_payload
    return container_cls.to_payload(batch, batch_dim)
  File "/usr/local/lib/python3.10/site-packages/bentoml/_internal/runner/container.py", line 461, in to_payload
    batch.save(buffer, format=batch.format)
  File "/usr/local/lib/python3.10/site-packages/PIL/Image.py", line 2412, in save
    raise ValueError(msg) from e
ValueError: unknown file extension: 
```
This problem does not trigger in development mode, but will trigger in production mode.
<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->

Fixes #(issue)

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
