### PR TITLE
fix(cli): fill out missing `apply` CLI args

### DIFF
--- a/src/bentoml_cli/deployment.py
+++ b/src/bentoml_cli/deployment.py
@@ -307,7 +307,24 @@ def add_deployment_command(cli: click.Group) -> None:
         click.echo(f"Deployment '{name}' updated successfully.")
 
     @deployment_cli.command()
+    @shared_decorator()
     @cog.optgroup.group(cls=cog.MutuallyExclusiveOptionGroup, name="target options")
+    @cog.optgroup.option(
+        "--bento",
+        type=click.STRING,
+        help="Bento name",
+    )
+    @cog.optgroup.option(
+        "--project-path",
+        type=click.Path(exists=True),
+        help="Path to the project",
+    )
+    @click.option(
+        "-n",
+        "--name",
+        type=click.STRING,
+        help="Deployment name",
+    )
     @click.option(
         "-f",
         "--config-file",


### PR DESCRIPTION
There are some click CLI args that are missing for `bentoml deployment apply`