### PR TITLE
feat: threaded serving

### DIFF
--- a/examples/quickstart/service.py
+++ b/examples/quickstart/service.py
@@ -28,3 +28,15 @@ class IrisClassifier:
     ) -> np.ndarray:
         input_series = self.preprocessing.preprocess(input_series)
         return self.model.predict(input_series)
+
+
+if __name__ == "__main__":
+    server = IrisClassifier.serve_http(threaded=True)
+    try:
+        with bentoml.SyncHTTPClient(
+            "http://localhost:3000", server_ready_timeout=10
+        ) as client:
+            response = client.classify([[5.1, 3.5, 1.4, 0.2]])
+            print(response)
+    finally:
+        server.stop()

--- a/examples/quickstart/service.py
+++ b/examples/quickstart/service.py
@@ -28,15 +28,3 @@ class IrisClassifier:
     ) -> np.ndarray:
         input_series = self.preprocessing.preprocess(input_series)
         return self.model.predict(input_series)
-
-
-if __name__ == "__main__":
-    server = IrisClassifier.serve_http(threaded=True)
-    try:
-        with bentoml.SyncHTTPClient(
-            "http://localhost:3000", server_ready_timeout=10
-        ) as client:
-            response = client.classify([[5.1, 3.5, 1.4, 0.2]])
-            print(response)
-    finally:
-        server.stop()

--- a/src/_bentoml_impl/server/serving.py
+++ b/src/_bentoml_impl/server/serving.py
@@ -331,7 +331,7 @@ def serve_http(
                 port,
             ),
         )
-        return Server(url=f"{scheme}://{host}:{port}", arbiter=arbiter)
+        return Server(url=f"{scheme}://{log_host}:{port}", arbiter=arbiter)
     except Exception:
         shutil.rmtree(uds_path, ignore_errors=True)
         raise

--- a/src/_bentoml_impl/server/serving.py
+++ b/src/_bentoml_impl/server/serving.py
@@ -199,6 +199,7 @@ def serve_http(
     if service_name:
         svc = svc.find_dependent(service_name)
     num_workers, worker_envs = allocator.get_worker_env(svc)
+    server_on_deployment(svc)
     uds_path = tempfile.mkdtemp(prefix="bentoml-uds-")
     try:
         if not service_name and not development_mode:

--- a/src/_bentoml_impl/server/serving.py
+++ b/src/_bentoml_impl/server/serving.py
@@ -342,9 +342,18 @@ class Server:
     url: str
     arbiter: Arbiter = attrs.field(repr=False)
 
+    def start(self) -> None:
+        pass
+
     def stop(self) -> None:
         self.arbiter.stop()
 
     @property
     def running(self) -> bool:
         return self.arbiter.running
+
+    def __enter__(self) -> Server:
+        return self
+
+    def __exit__(self, exc_type: t.Any, exc_value: t.Any, traceback: t.Any) -> None:
+        self.stop()

--- a/src/_bentoml_sdk/service/factory.py
+++ b/src/_bentoml_sdk/service/factory.py
@@ -30,6 +30,7 @@ logger = logging.getLogger("bentoml.io")
 T = t.TypeVar("T", bound=object)
 
 if t.TYPE_CHECKING:
+    from _bentoml_impl.server.serving import Server
     from bentoml._internal import external_typing as ext
     from bentoml._internal.service.openapi.specification import OpenAPISpecification
 
@@ -286,13 +287,14 @@ class Service(t.Generic[T]):
         bentoml_home: str = Provide[BentoMLContainer.bentoml_home],
         development_mode: bool = False,
         reload: bool = False,
-    ) -> None:
+        threaded: bool = False,
+    ) -> Server:
         from _bentoml_impl.server import serve_http
         from bentoml._internal.log import configure_logging
 
         configure_logging()
 
-        serve_http(
+        return serve_http(
             self,
             working_dir=working_dir,
             host=host,
@@ -309,6 +311,7 @@ class Service(t.Generic[T]):
             bentoml_home=bentoml_home,
             development_mode=development_mode,
             reload=reload,
+            threaded=threaded,
         )
 
 


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

## What does this PR address?

This should benefit workflow in REPL and Jupyter notebook. Basically, it enables the following usage:

```python
import bentoml
from service import MyService

server = MyService.serve_http(threaded=True)  # this doesn't block the following
client = bentoml.SyncHTTPClient(server.url)
try:
    # do stuff with the client
    result = client.classify([[1,2,3,4]])
finally:
    client.close()
    server.stop()
```