### PR TITLE
fix(build): remove deprecated warnings

### DIFF
--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -101,10 +101,6 @@ def _convert_env(
     if not env:
         return None
 
-    logger.warning(
-        "Deprecated build option: 'docker.env' is used, please use 'envs' instead."
-    )
-
     if isinstance(env, str):
         env_path = os.path.expanduser(os.path.expandvars(env))
         if os.path.exists(env_path):


### PR DESCRIPTION
Remove this warning for now since we are still using the converter for backward compatibility

this means that even `envs` is specified, this will still be thrown
