### PR TITLE
fix(build): make sure to parse pip_args in correct order

### DIFF
--- a/src/bentoml/_internal/bento/install.sh.j2
+++ b/src/bentoml/_internal/bento/install.sh.j2
@@ -17,11 +17,11 @@ BENTOML_VERSION=${BENTOML_VERSION:-<< bentoml_version >>}
 pushd "$BASEDIR" &>/dev/null
 if [ -f "$REQUIREMENTS_LOCK" ]; then
     echo "Installing pip packages from 'requirements.lock.txt'.."
-    pip3 install -r "$REQUIREMENTS_LOCK" "${PIP_ARGS[@]}"
+    pip3 install "${PIP_ARGS[@]}" -r "$REQUIREMENTS_LOCK"
 else
     if [ -f "$REQUIREMENTS_TXT" ]; then
         echo "Installing pip packages from 'requirements.txt'.."
-        pip3 install -r "$REQUIREMENTS_TXT" "${PIP_ARGS[@]}"
+        pip3 install "${PIP_ARGS[@]}" -r "$REQUIREMENTS_TXT"
     fi
 fi
 popd &>/dev/null
@@ -33,7 +33,7 @@ wheels=($WHEELS_DIR/*.whl)
 {% raw %}
 if [ ${#wheels[@]} -gt 0 ]; then
     echo "Installing wheels packaged in Bento.."
-    pip3 install "${wheels[@]}" "${PIP_ARGS[@]}"
+    pip3 install "${PIP_ARGS[@]}" "${wheels[@]}"
 fi
 {% endraw %}
 


### PR DESCRIPTION
all pip args should be parse after `install`, such that it will work in conjunction with -r

This will fail if user pass in `pip_args` in bentofile.yaml, or via the API call.
