### PR TITLE
feat(build): expose `pip_preheat_packages`

### DIFF
--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -174,6 +174,7 @@ class DockerOptions:
     setup_script: t.Optional[str] = None
     base_image: t.Optional[str] = None
     dockerfile_template: t.Optional[str] = None
+    pip_preheat_packages: t.Optional[t.List[str]] = None
 
     def __attrs_post_init__(self):
         if self.base_image is not None:

--- a/src/bentoml/_internal/container/generate.py
+++ b/src/bentoml/_internal/container/generate.py
@@ -100,6 +100,14 @@ def get_templates_variables(
 
     PREHEAT_PIP_PACKAGES = ["torch", "vllm"]
 
+    preheat_packages: list[str] = []
+    if docker.pip_preheat_packages:
+        preheat_packages.extend(docker.pip_preheat_packages)
+    if python_packages:
+        preheat_packages.extend(
+            [python_packages[k] for k in PREHEAT_PIP_PACKAGES if python_packages.get(k)]
+        )
+
     return {
         **{to_options_field(k): v for k, v in docker.to_dict().items()},
         **{to_bento_field(k): v for k, v in default_env.items()},
@@ -107,11 +115,7 @@ def get_templates_variables(
         "__base_image__": base_image,
         "__conda_python_version__": conda_python_version,
         "__is_cuda__": _is_cuda,
-        "__pip_preheat_packages__": [
-            python_packages[k]
-            for k in PREHEAT_PIP_PACKAGES
-            if python_packages and python_packages.get(k)
-        ],
+        "__pip_preheat_packages__": preheat_packages,
     }
 
 


### PR DESCRIPTION
With the addition of #4690, added a field under `docker.pip_preheat_packages` under bentofile.yaml allowing user to specifying a list of dependencies to be preheated within the cache layers for improvement of build time

```yaml
docker:
  pip_preheat_packages:
    - vllm==0.4.2
    - lmdeploy
```

Would be useful for openllm as openllm will lock specific vllm version.
