### PR TITLE
refactor(tests): testing.util.async_request to client.AsyncHTTPClient

### DIFF
--- a/tests/e2e/bento_server_http/tests/test_io.py
+++ b/tests/e2e/bento_server_http/tests/test_io.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import io
 import json
 from typing import TYPE_CHECKING
+from typing import Dict
+from typing import Tuple
 
-import aiohttp
 import numpy as np
 import pytest
 
-from bentoml.testing.utils import async_request
+from bentoml.client import AsyncHTTPClient
 from bentoml.testing.utils import parse_multipart_form
 
 if TYPE_CHECKING:
@@ -21,90 +22,93 @@ else:
 
 @pytest.mark.asyncio
 async def test_numpy(host: str):
-    await async_request(
-        "POST",
-        f"http://{host}/predict_ndarray_enforce_shape",
-        headers={"Content-Type": "application/json"},
-        data="[[1,2],[3,4]]",
-        assert_status=200,
-        assert_data=b"[[2, 4], [6, 8]]",
-    )
-    await async_request(
-        "POST",
-        f"http://{host}/predict_ndarray_multi_output",
-        headers={"Content-Type": "application/json"},
-        data="[[1,2],[3,4]]",
-        assert_status=200,
-        assert_data=b"[[2, 4], [6, 8]]",
-    )
-    await async_request(
-        "POST",
-        f"http://{host}/predict_ndarray_enforce_shape",
-        headers={"Content-Type": "application/json"},
-        data="[1,2,3,4]",
-        assert_status=400,
-    )
-    await async_request(
-        "POST",
-        f"http://{host}/predict_ndarray_enforce_dtype",
-        headers={"Content-Type": "application/json"},
-        data="[[2,1],[4,3]]",
-        assert_status=200,
-        assert_data=b'[["4", "2"], ["8", "6"]]',
-    )
-    await async_request(
-        "POST",
-        f"http://{host}/predict_ndarray_enforce_dtype",
-        headers={"Content-Type": "application/json"},
-        data='[["2f",1],[4,3]]',
-        assert_status=400,
-    )
+    async with await AsyncHTTPClient.from_url(f"http://{host}") as client:
+        data = json.dumps([[1, 2], [3, 4]])
+        response = await client.client.post(
+            "/predict_ndarray_enforce_shape",
+            headers={"Content-Type": "application/json"},
+            data=data,
+        )
+        assert response.status_code == 200
+        assert await response.aread() == b"[[2, 4], [6, 8]]"
+
+        data = json.dumps([[1, 2], [3, 4]])
+        response = await client.client.post(
+            "/predict_ndarray_multi_output",
+            headers={"Content-Type": "application/json"},
+            data=data,
+        )
+        assert response.status_code == 200
+        assert await response.aread() == b"[[2, 4], [6, 8]]"
+
+        data = json.dumps([1, 2, 3, 4])
+        response = await client.client.post(
+            "/predict_ndarray_enforce_shape",
+            headers={"Content-Type": "application/json"},
+            data=data,
+        )
+        assert response.status_code == 400
+
+        data = json.dumps([[2, 1], [4, 3]])
+        response = await client.client.post(
+            "/predict_ndarray_enforce_dtype",
+            headers={"Content-Type": "application/json"},
+            data=data,
+        )
+        assert response.status_code == 200
+        assert await response.aread() == b'[["4", "2"], ["8", "6"]]'
+
+        data = json.dumps([["2f", 1], [4, 3]])
+        response = await client.client.post(
+            "/predict_ndarray_enforce_dtype",
+            headers={"Content-Type": "application/json"},
+            data=data,
+        )
+        assert response.status_code == 400
 
 
 @pytest.mark.asyncio
 async def test_json(host: str):
     ORIGIN = "http://bentoml.ai"
+    async with await AsyncHTTPClient.from_url(f"http://{host}") as client:
+        headers = {"Content-Type": "application/json", "Origin": ORIGIN}
+        data = json.dumps("hi")
+        response = await client.client.post("/echo_json", headers=headers, data=data)
+        assert response.status_code == 200
+        assert await response.aread() == b'"hi"'
 
-    await async_request(
-        "POST",
-        f"http://{host}/echo_json",
-        headers=(("Content-Type", "application/json"), ("Origin", ORIGIN)),
-        data='"hi"',
-        assert_status=200,
-        assert_data=b'"hi"',
-    )
+        headers = {"Content-Type": "application/json", "Origin": ORIGIN}
+        data = json.dumps("hi")
+        response = await client.client.post(
+            "/echo_json_sync", headers=headers, data=data
+        )
+        assert response.status_code == 200
+        assert await response.aread() == b'"hi"'
 
-    await async_request(
-        "POST",
-        f"http://{host}/echo_json_sync",
-        headers=(("Content-Type", "application/json"), ("Origin", ORIGIN)),
-        data='"hi"',
-        assert_status=200,
-        assert_data=b'"hi"',
-    )
-
-    await async_request(
-        "POST",
-        f"http://{host}/echo_json_enforce_structure",
-        headers=(("Content-Type", "application/json"), ("Origin", ORIGIN)),
-        data='{"name":"test","endpoints":["predict","health"]}',
-        assert_status=200,
-        assert_data=b'{"name":"test","endpoints":["predict","health"]}',
-    )
+        headers = {"Content-Type": "application/json", "Origin": ORIGIN}
+        data = json.dumps({"name": "test", "endpoints": ["predict", "health"]})
+        response = await client.client.post(
+            "/echo_json_enforce_structure", headers=headers, data=data
+        )
+        assert response.status_code == 200
+        assert (
+            await response.aread()
+            == b'{"name":"test","endpoints":["predict","health"]}'
+        )
 
 
 @pytest.mark.asyncio
 async def test_obj(host: str):
-    for obj in [1, 2.2, "str", [1, 2, 3], {"a": 1, "b": 2}]:
-        obj_str = json.dumps(obj, separators=(",", ":"))
-        await async_request(
-            "POST",
-            f"http://{host}/echo_obj",
-            headers=(("Content-Type", "application/json"),),
-            data=obj_str,
-            assert_status=200,
-            assert_data=obj_str.encode("utf-8"),
-        )
+    async with await AsyncHTTPClient.from_url(f"http://{host}") as client:
+        for obj in [1, 2.2, "str", [1, 2, 3], {"a": 1, "b": 2}]:
+            obj_str = json.dumps(obj, separators=(",", ":"))
+            response = await client.client.post(
+                "/echo_obj",
+                headers={"Content-Type": "application/json"},
+                data=obj_str,
+            )
+            assert response.status_code == 200
+            assert await response.aread() == obj_str.encode("utf-8")
 
 
 @pytest.mark.asyncio
@@ -113,155 +117,149 @@ async def test_pandas(host: str):
 
     ORIGIN = "http://bentoml.ai"
 
-    df = pd.DataFrame([[101]], columns=["col1"])
+    async with await AsyncHTTPClient.from_url(f"http://{host}") as client:
+        df = pd.DataFrame([[101]], columns=["col1"])
 
-    await async_request(
-        "POST",
-        f"http://{host}/predict_dataframe",
-        headers=(("Content-Type", "application/json"), ("Origin", ORIGIN)),
-        data=df.to_json(orient="records"),
-        assert_status=200,
-        assert_data=b'[{"col1":202}]',
-    )
+        headers = {"Content-Type": "application/json", "Origin": ORIGIN}
+        data = df.to_json(orient="records")
+        response = await client.client.post(
+            "/predict_dataframe", headers=headers, data=data
+        )
+        assert response.status_code == 200
+        assert await response.aread() == b'[{"col1":202}]'
 
-    await async_request(
-        "POST",
-        f"http://{host}/predict_dataframe",
-        headers=(("Content-Type", "application/octet-stream"), ("Origin", ORIGIN)),
-        data=df.to_parquet(),
-        assert_status=200,
-        assert_data=b'[{"col1":202}]',
-    )
+        headers = {"Content-Type": "application/octet-stream", "Origin": ORIGIN}
+        data = df.to_parquet()
+        response = await client.client.post(
+            "/predict_dataframe", headers=headers, data=data
+        )
+        assert response.status_code == 200
+        assert await response.aread() == b'[{"col1":202}]'
 
-    await async_request(
-        "POST",
-        f"http://{host}/predict_dataframe",
-        headers=(("Content-Type", "text/csv"), ("Origin", ORIGIN)),
-        data=df.to_csv(),
-        assert_status=200,
-        assert_data=b'[{"col1":202}]',
-    )
+        headers = {"Content-Type": "text/csv", "Origin": ORIGIN}
+        data = df.to_csv()
+        response = await client.client.post(
+            "/predict_dataframe", headers=headers, data=data
+        )
+        assert response.status_code == 200
+        assert await response.aread() == b'[{"col1":202}]'
 
 
 @pytest.mark.asyncio
 async def test_file(host: str, bin_file: str):
-    # Test File as binary
-    with open(str(bin_file), "rb") as f:
-        b = f.read()
+    async with await AsyncHTTPClient.from_url(f"http://{host}") as client:
+        # Test File as binary
+        with open(str(bin_file), "rb") as f:
+            b = f.read()
 
-    await async_request(
-        "POST",
-        f"http://{host}/predict_file",
-        data=b,
-        headers={"Content-Type": "application/octet-stream"},
-        assert_data=b"\x810\x899",
-    )
+        response = await client.client.post(
+            "/predict_file",
+            data=b,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        assert await response.aread() == b"\x810\x899"
 
-    # Test File as multipart binary
-    form = aiohttp.FormData()
-    form.add_field("file", b, content_type="application/octet-stream")
+        # Test File as multipart binary
+        files = {"file": ("file.bin", b, "application/octet-stream")}
+        response = await client.client.post("/predict_file", files=files)
+        assert await response.aread() == b"\x810\x899"
 
-    await async_request(
-        "POST",
-        f"http://{host}/predict_file",
-        data=form,
-        assert_data=b"\x810\x899",
-    )
-
-    await async_request(
-        "POST",
-        f"http://{host}/predict_file",
-        data=b,
-        headers={"Content-Type": "application/pdf"},
-        assert_data=b"\x810\x899",
-    )
+        response = await client.client.post(
+            "/predict_file",
+            data=b,
+            headers={"Content-Type": "application/pdf"},
+        )
+        assert await response.aread() == b"\x810\x899"
 
 
 @pytest.mark.asyncio
 async def test_image(host: str, img_file: str):
-    with open(str(img_file), "rb") as f1:
-        img_bytes = f1.read()
+    async with await AsyncHTTPClient.from_url(f"http://{host}") as client:
+        with open(str(img_file), "rb") as f1:
+            img_bytes = f1.read()
 
-    status, headers, body = await async_request(
-        "POST",
-        f"http://{host}/echo_image",
-        data=img_bytes,
-        headers={"Content-Type": "image/bmp"},
-    )
-    assert status == 200
-    assert headers["Content-Type"] == "image/bmp"
+        response = await client.client.post(
+            "/echo_image",
+            data=img_bytes,
+            headers={"Content-Type": "image/bmp"},
+        )
+        assert response.status_code == 200
+        assert response.headers["Content-Type"] == "image/bmp"
 
-    bio = io.BytesIO(body)
-    bio.name = "test.bmp"
-    img = PILImage.open(bio)
-    array1 = np.array(img)
-    array2 = PILImage.open(img_file)
+        bio = io.BytesIO(await response.aread())
+        bio.name = "test.bmp"
+        img = PILImage.open(bio)
+        array1 = np.array(img)
+        array2 = PILImage.open(img_file)
 
-    np.testing.assert_array_almost_equal(array1, np.array(array2))
+        np.testing.assert_array_almost_equal(array1, np.array(array2))
 
-    await async_request(
-        "POST",
-        f"http://{host}/echo_image",
-        data=img_bytes,
-        headers={"Content-Type": "application/json"},
-        assert_status=400,
-    )
+        response = await client.client.post(
+            "/echo_image",
+            data=img_bytes,
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 400
 
-    with open(str(img_file), "rb") as f1:
-        b = f1.read()
-    await async_request(
-        "POST",
-        f"http://{host}/echo_image",
-        data=b,
-        headers={"Content-Type": "application/pdf"},
-        assert_status=400,
-    )
+        with open(str(img_file), "rb") as f1:
+            b = f1.read()
+        response = await client.client.post(
+            "/echo_image",
+            data=b,
+            headers={"Content-Type": "application/pdf"},
+        )
+        assert response.status_code == 400
 
 
 @pytest.fixture(name="img_form_data")
-def fixture_img_form_data(img_file: str):
+def fixture_img_form_data(img_file: str) -> Dict[str, Tuple[str, bytes, str]]:
     with open(img_file, "rb") as f1, open(img_file, "rb") as f2:
-        form = aiohttp.FormData()
-        form.add_field("original", f1.read(), content_type="image/bmp")
-        form.add_field("compared", f2.read(), content_type="image/bmp")
-    yield form
+        files = {
+            "original": (img_file, f1.read(), "image/bmp"),
+            "compared": (img_file, f2.read(), "image/bmp"),
+        }
+    yield files
 
 
 @pytest.mark.asyncio
-async def test_multipart_image_io(host: str, img_form_data: aiohttp.FormData):
+async def test_multipart_image_io(
+    host: str, img_form_data: Dict[str, Tuple[str, bytes, str]]
+):
     from starlette.datastructures import UploadFile
 
-    _, headers, body = await async_request(
-        "POST",
-        f"http://{host}/predict_multi_images",
-        data=img_form_data,
-        assert_status=200,
-    )
+    async with await AsyncHTTPClient.from_url(f"http://{host}") as client:
+        response = await client.client.post(
+            "/predict_multi_images", files=img_form_data
+        )
+        assert response.status_code == 200
 
-    form = await parse_multipart_form(headers=headers, body=body)
-    for _, v in form.items():
-        assert isinstance(v, UploadFile)
-        img = PILImage.open(v.file)
-        assert np.array(img).shape == (10, 10, 3)
+        form = await parse_multipart_form(
+            headers=response.headers, body=response.content
+        )
+        for _, v in form.items():
+            assert isinstance(v, UploadFile)
+            img = PILImage.open(v.file)
+            assert np.array(img).shape == (10, 10, 3)
 
 
 @pytest.mark.asyncio
-async def test_multipart_different_args(host: str, img_form_data: aiohttp.FormData):
-    await async_request(
-        "POST",
-        f"http://{host}/predict_different_args",
-        data=img_form_data,
-        assert_status=200,
-    )
+async def test_multipart_different_args(
+    host: str, img_form_data: Dict[str, Tuple[str, bytes, str]]
+):
+    async with await AsyncHTTPClient.from_url(f"http://{host}") as client:
+        response = await client.client.post(
+            "/predict_different_args", files=img_form_data
+        )
+        assert response.status_code == 200
 
 
 @pytest.mark.asyncio
 async def test_text_stream(host: str):
-    await async_request(
-        "POST",
-        f"http://{host}/predict_text_stream",
-        headers={"Content-Type": "text/plain"},
-        data="yo",
-        assert_status=200,
-        assert_data=b"yo 0yo 1yo 2yo 3yo 4yo 5yo 6yo 7yo 8yo 9",
-    )
+    async with await AsyncHTTPClient.from_url(f"http://{host}") as client:
+        response = await client.client.post(
+            "/predict_text_stream",
+            headers={"Content-Type": "text/plain"},
+            data="yo",
+        )
+        assert response.status_code == 200
+        assert await response.aread() == b"yo 0yo 1yo 2yo 3yo 4yo 5yo 6yo 7yo 8yo 9"


### PR DESCRIPTION
## What does this PR address?

Fixes https://github.com/bentoml/BentoML/issues/3411

- The async_request function in `bento.testing.utils` performs an action that duplicates the functionality of AsyncHTTPClient in `bento.client`. Since the Client is correctly implemented, I have refactored the test code to operate using it.
- Since AsyncHTTPClient use httpx, there's minor datatype change on aiohttp.FormData.

## Before submitting:
- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [x] Did you write tests to cover your changes?
