### PR TITLE
fix: honor host and port config in service decorator

### DIFF
--- a/src/_bentoml_impl/server/serving.py
+++ b/src/_bentoml_impl/server/serving.py
@@ -138,7 +138,7 @@ def server_on_deployment(svc: AnyService) -> None:
             member()
 
 
-@inject
+@inject(squeeze_none=True)
 def serve_http(
     bento_identifier: str | AnyService,
     working_dir: str | None = None,

--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -638,10 +638,10 @@ class PythonOptions:
                     "--no-annotate",
                 ]
             )
-            if get_quiet_mode():
-                pip_compile_args.append("--quiet")
-            elif get_debug_mode():
+            if get_debug_mode():
                 pip_compile_args.append("--verbose")
+            else:
+                pip_compile_args.append("--quiet")
             logger.info("Locking PyPI package versions.")
             cmd = [sys.executable, "-m", "piptools", "compile"]
             cmd.extend(pip_compile_args)

--- a/src/bentoml/serve.py
+++ b/src/bentoml/serve.py
@@ -300,7 +300,7 @@ def _get_runner_socket_windows(
     )
 
 
-@inject
+@inject(squeeze_none=True)
 def serve_http_production(
     bento_identifier: str,
     working_dir: str,

--- a/src/bentoml/start.py
+++ b/src/bentoml/start.py
@@ -23,7 +23,7 @@ API_SERVER = "api_server"
 RUNNER = "runner"
 
 
-@inject
+@inject(squeeze_none=True)
 def start_runner_server(
     bento_identifier: str,
     working_dir: str,

--- a/src/bentoml/start.py
+++ b/src/bentoml/start.py
@@ -142,7 +142,7 @@ def start_runner_server(
         )
 
 
-@inject
+@inject(squeeze_none=True)
 def start_http_server(
     bento_identifier: str,
     runner_map: dict[str, str],

--- a/src/bentoml_cli/serve.py
+++ b/src/bentoml_cli/serve.py
@@ -81,26 +81,23 @@ def build_serve_command() -> click.Group:
         "-p",
         "--port",
         type=click.INT,
-        default=BentoMLContainer.http.port.get(),
         help="The port to listen on for the REST api server",
         envvar="BENTOML_PORT",
-        show_default=True,
+        show_envvar=True,
     )
     @click.option(
         "--host",
         type=click.STRING,
-        default=BentoMLContainer.http.host.get(),
         help="The host to bind for the REST api server",
         envvar="BENTOML_HOST",
-        show_default=True,
+        show_envvar=True,
     )
     @click.option(
         "--api-workers",
         type=click.INT,
-        default=BentoMLContainer.api_server_workers.get(),
         help="Specify the number of API server workers to start. Default to number of available CPU cores in production mode",
         envvar="BENTOML_API_WORKERS",
-        show_default=True,
+        show_envvar=True,
         hidden=True,
     )
     @click.option(
@@ -113,7 +110,6 @@ def build_serve_command() -> click.Group:
     @click.option(
         "--backlog",
         type=click.INT,
-        default=BentoMLContainer.api_server_config.backlog.get(),
         help="The maximum number of pending connections.",
         show_default=True,
         hidden=True,
@@ -136,7 +132,6 @@ def build_serve_command() -> click.Group:
     @click.option(
         "--ssl-certfile",
         type=str,
-        default=BentoMLContainer.ssl.certfile.get(),
         help="SSL certificate file",
         show_default=True,
         hidden=True,
@@ -144,7 +139,6 @@ def build_serve_command() -> click.Group:
     @click.option(
         "--ssl-keyfile",
         type=str,
-        default=BentoMLContainer.ssl.keyfile.get(),
         help="SSL key file",
         show_default=True,
         hidden=True,
@@ -152,7 +146,6 @@ def build_serve_command() -> click.Group:
     @click.option(
         "--ssl-keyfile-password",
         type=str,
-        default=BentoMLContainer.ssl.keyfile_password.get(),
         help="SSL keyfile password",
         show_default=True,
         hidden=True,
@@ -160,7 +153,6 @@ def build_serve_command() -> click.Group:
     @click.option(
         "--ssl-version",
         type=int,
-        default=BentoMLContainer.ssl.version.get(),
         help="SSL version to use (see stdlib 'ssl' module)",
         show_default=True,
         hidden=True,
@@ -168,7 +160,6 @@ def build_serve_command() -> click.Group:
     @click.option(
         "--ssl-cert-reqs",
         type=int,
-        default=BentoMLContainer.ssl.cert_reqs.get(),
         help="Whether client certificate is required (see stdlib 'ssl' module)",
         show_default=True,
         hidden=True,
@@ -176,7 +167,6 @@ def build_serve_command() -> click.Group:
     @click.option(
         "--ssl-ca-certs",
         type=str,
-        default=BentoMLContainer.ssl.ca_certs.get(),
         help="CA certificates file",
         show_default=True,
         hidden=True,
@@ -184,7 +174,6 @@ def build_serve_command() -> click.Group:
     @click.option(
         "--ssl-ciphers",
         type=str,
-        default=BentoMLContainer.ssl.ciphers.get(),
         help="Ciphers to use (see stdlib 'ssl' module)",
         show_default=True,
         hidden=True,

--- a/src/bentoml_cli/start.py
+++ b/src/bentoml_cli/start.py
@@ -55,29 +55,25 @@ def build_start_command() -> click.Group:
     @click.option(
         "--port",
         type=click.INT,
-        default=BentoMLContainer.http.port.get(),
         help="The port to listen on for the REST api server",
         envvar="BENTOML_PORT",
-        show_default=True,
+        show_envvar=True,
     )
     @click.option(
         "--host",
         type=click.STRING,
-        default=BentoMLContainer.http.host.get(),
         help="The host to bind for the REST api server [defaults: 127.0.0.1(dev), 0.0.0.0(production)]",
-        envvar="BENTOML_HOST",
+        show_envvar="BENTOML_HOST",
     )
     @click.option(
         "--backlog",
         type=click.INT,
-        default=BentoMLContainer.api_server_config.backlog.get(),
         help="The maximum number of pending connections.",
-        show_default=True,
+        show_envvar=True,
     )
     @click.option(
         "--api-workers",
         type=click.INT,
-        default=BentoMLContainer.api_server_workers.get(),
         help="Specify the number of API server workers to start. Default to number of available CPU cores in production mode",
         envvar="BENTOML_API_WORKERS",
     )
@@ -94,47 +90,20 @@ def build_start_command() -> click.Group:
         default=None,
         show_default=True,
     )
+    @click.option("--ssl-certfile", type=str, help="SSL certificate file")
+    @click.option("--ssl-keyfile", type=str, help="SSL key file")
+    @click.option("--ssl-keyfile-password", type=str, help="SSL keyfile password")
     @click.option(
-        "--ssl-certfile",
-        type=str,
-        default=BentoMLContainer.ssl.certfile.get(),
-        help="SSL certificate file",
-    )
-    @click.option(
-        "--ssl-keyfile",
-        type=str,
-        default=BentoMLContainer.ssl.keyfile.get(),
-        help="SSL key file",
-    )
-    @click.option(
-        "--ssl-keyfile-password",
-        type=str,
-        default=BentoMLContainer.ssl.keyfile_password.get(),
-        help="SSL keyfile password",
-    )
-    @click.option(
-        "--ssl-version",
-        type=int,
-        default=BentoMLContainer.ssl.version.get(),
-        help="SSL version to use (see stdlib 'ssl' module)",
+        "--ssl-version", type=int, help="SSL version to use (see stdlib 'ssl' module)"
     )
     @click.option(
         "--ssl-cert-reqs",
         type=int,
-        default=BentoMLContainer.ssl.cert_reqs.get(),
         help="Whether client certificate is required (see stdlib 'ssl' module)",
     )
+    @click.option("--ssl-ca-certs", type=str, help="CA certificates file")
     @click.option(
-        "--ssl-ca-certs",
-        type=str,
-        default=BentoMLContainer.ssl.ca_certs.get(),
-        help="CA certificates file",
-    )
-    @click.option(
-        "--ssl-ciphers",
-        type=str,
-        default=BentoMLContainer.ssl.ciphers.get(),
-        help="Ciphers to use (see stdlib 'ssl' module)",
+        "--ssl-ciphers", type=str, help="Ciphers to use (see stdlib 'ssl' module)"
     )
     @click.option(
         "--timeout-keep-alive",
@@ -154,9 +123,9 @@ def build_start_command() -> click.Group:
         depends: list[str] | None,
         runner_map: str | None,
         bind: str | None,
-        port: int,
-        host: str,
-        backlog: int,
+        port: int | None,
+        host: str | None,
+        backlog: int | None,
         working_dir: str | None,
         api_workers: int | None,
         timeout: int | None,


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

## What does this PR address?

Make CLI honor host and port config in service decorator, so the priorities are:

1. `--port` CLI option
2. `BENTOML_PORT` env var
3. `service(http={"port": 3456})`

## Possible impact

The config in service decorator may take effect on Cloud if not specified explicitly by start option or env var. @bojiang please confirm this. 
