### PR TITLE
Fixed `FileExistsError: [Errno 17] File exists: '/root/bentoml'`

### DIFF
--- a/src/bentoml/_internal/utils/__init__.py
+++ b/src/bentoml/_internal/utils/__init__.py
@@ -147,7 +147,7 @@ def validate_or_create_dir(*path: PathType) -> None:
             if not path_obj.is_dir():
                 raise OSError(20, f"{path_obj} is not a directory")
         else:
-            path_obj.mkdir(parents=True)
+            path_obj.mkdir(parents=True, exist_ok=True)
 
 
 def calc_dir_size(path: PathType) -> int:


### PR DESCRIPTION
Randomly encountering the error below when serving a BentoML server with `bentoml serve . -p 5000`:
![image](https://github.com/bentoml/BentoML/assets/42506819/2675c850-2948-4ac0-92a8-9850f4fe13ba)

The accompanying change should fix it.


The script serves multiple models in parallel and some race condition might be causing the same:
```
#!/bin/bash
source activate venv_speech
port=${PORT:-6919}

# Check if styletts2-cog directory exists
if [ -d "styletts2-cog" ]; then
  cd styletts2-cog
  sudo rm -r /root/bentoml/models
  nohup bentoml serve . -p 5000 > styletts2-cog.log 2>&1 &
  cd ..
else
  echo "Directory styletts2-cog does not exist."
fi

# Check if ImageBind directory exists
if [ -d "ImageBind" ]; then
  cd ImageBind
  sudo rm -r /root/bentoml/models
  nohup bentoml serve . -p 5001 > ImageBind.log 2>&1 &
  cd ..
else
  echo "Directory ImageBind does not exist."
fi

if [ -d "whisper" ]; then
  cd whisper
  sudo rm -r /root/bentoml/models
  nohup bentoml serve . -p 5002 > whisper.log 2>&1 &
  cd ..
else
  echo "Directory whisper does not exist."
fi

uvicorn main:app --host 0.0.0.0 --port ${port}
```