### PR TITLE
fix: add memoization to `pkg_version_info` to reduce cpu overhead

### DIFF
--- a/src/bentoml/_internal/utils/pkg.py
+++ b/src/bentoml/_internal/utils/pkg.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import importlib.util
+from functools import lru_cache
 from importlib.metadata import PackageNotFoundError
 from types import ModuleType
 from typing import cast
@@ -20,6 +21,7 @@ get_pkg_version = importlib.metadata.version
 find_spec = importlib.util.find_spec
 
 
+@lru_cache(maxsize=None)
 def pkg_version_info(pkg_name: str | ModuleType) -> tuple[int, int, int]:
     if isinstance(pkg_name, ModuleType):
         pkg_name = pkg_name.__name__


### PR DESCRIPTION
Addresses resource overhead from repeated calls to `pkg_version_info`. This function is called with only a handful of static strings, so it seems reasonable to just memoize the value indefinitely. The function is called in hot regions of the code, for example request json parsing and formatting when checking pydantic versions.

Fixes #4784

No tests written, but seems like this should be covered by existing tests. 