### PR TITLE
fix(pandas): `Annotated[pd.DataFrame, DataframeSchema(columns=["a"])]` output spec

### DIFF
--- a/src/_bentoml_sdk/validators.py
+++ b/src/_bentoml_sdk/validators.py
@@ -278,7 +278,10 @@ class TensorSchema:
 @attrs.frozen(unsafe_hash=True)
 class DataframeSchema:
     orient: str = "records"
-    columns: list[str] | None = None
+    columns: tuple[str] | None = attrs.field(
+        default=None,
+        converter=lambda x: tuple(x) if x else None,
+    )
 
     def __get_pydantic_json_schema__(
         self, schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler

--- a/tests/unit/bentoml_io/test_decorators.py
+++ b/tests/unit/bentoml_io/test_decorators.py
@@ -1,8 +1,11 @@
 from typing import Generator
 
+import pandas as pd
 import pytest
+from typing_extensions import Annotated
 
 import bentoml
+from bentoml.validators import DataframeSchema
 
 
 @pytest.mark.asyncio
@@ -89,4 +92,27 @@ async def test_service_instantiate_to_async():
         "Hello, world! 0",
         "Hello, world! 1",
         "Hello, world! 2",
+    ]
+
+
+def test_api_decorator_pandas():
+    @bentoml.api
+    def pandas_func(
+        _,  # The decorator assumes `self` is the first arg.
+        df1: pd.DataFrame,
+        df2: Annotated[pd.DataFrame, DataframeSchema(columns=("b",))],
+    ) -> Annotated[
+        pd.DataFrame,
+        DataframeSchema(orient="columns", columns=["a", "b"]),
+    ]:
+        return pd.concat([df1, df2], axis=1)
+
+    pandas_func.input_spec.model_fields["df1"].annotation is pd.DataFrame
+    pandas_func.input_spec.model_fields["df2"].annotation is Annotated[
+        pd.DataFrame,
+        DataframeSchema(columns=("b",)),
+    ]
+    pandas_func.output_spec.model_fields["root"].annotation is Annotated[
+        pd.DataFrame,
+        DataframeSchema(orient="columns", columns=("a", "b")),
     ]


### PR DESCRIPTION
## What does this PR address?

Output specs defined as `Annotated[pd.DataFrame, DataframeSchema(columns=["a"])]` don't work because lists are not hashable. This PR adds a converted to the `columns` field of `DataframeSchema` to convert them to a `tuple`. 

Also adds another missing test!

<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->


## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [x] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [x] Did you write tests to cover your changes?
