### PR TITLE
fix: nvcc not found

### DIFF
--- a/src/bentoml/_internal/container/frontend/dockerfile/__init__.py
+++ b/src/bentoml/_internal/container/frontend/dockerfile/__init__.py
@@ -93,7 +93,7 @@ CONTAINER_METADATA: dict[str, dict[str, t.Any]] = {
             "supported_architectures": SUPPORTED_ARCHITECTURES,
         },
         "cuda": {
-            "image": "nvidia/cuda:{spec_version}-cudnn8-runtime-ubuntu20.04",
+            "image": "nvidia/cuda:{spec_version}-cudnn8-devel-ubuntu20.04",
             "supported_architectures": ["amd64", "arm64"],
         },
         "miniconda": {


### PR DESCRIPTION
## What does this PR address?
This PR fixes the installation process of packages that are dependent on CUDA. 

One of my Python packages is `deepspeed`, and it requires CUDA while installation. However, I was getting error as `nvcc: command not found`. After searching for a while, I came across with [this issue](https://github.com/NVIDIA/nvidia-container-toolkit/issues/161). If you use `devel`, instead of `runtime` version of CUDA, nvcc commands become available. 
Otherwise, for `runtime` version, `nvcc` and other CUDA related commands are available only if you use `docker run --gpus all` but since you get the error while building container, you can't even come to that part.

I tested this fix only on Ubuntu 20.04. UBI 8 distro is also using `runtime` instead of `devel` at line 84 in the same file. If anyone tests that distro it would be helpful for the future improvements as well.

