### PR TITLE
fix: don't use temporary directory for temp bento copying

### DIFF
--- a/src/bentoml/_internal/bento/bento.py
+++ b/src/bentoml/_internal/bento/bento.py
@@ -16,11 +16,11 @@ import fs.mirror
 import fs.osfs
 import fs.walk
 import yaml
-from fs.tempfs import TempFS
 from cattr.gen import make_dict_structure_fn
 from cattr.gen import make_dict_unstructure_fn
 from cattr.gen import override
 from fs.copy import copy_file
+from fs.tempfs import TempFS
 from simple_di import Provide
 from simple_di import inject
 
@@ -228,7 +228,10 @@ class Bento(StoreItem):
             'Building BentoML service "%s" from build context "%s".', tag, build_ctx
         )
 
-        bento_fs = TempFS(identifier=f"bentoml_bento_{bento_name}", temp_dir=BentoMLContainer.tmp_bento_store_dir.get())
+        bento_fs = TempFS(
+            identifier=f"bentoml_bento_{bento_name}",
+            temp_dir=BentoMLContainer.tmp_bento_store_dir.get(),
+        )
         ctx_fs = fs.open_fs(encode_path_for_uri(build_ctx))
 
         models: t.Set[Model] = set()

--- a/src/bentoml/_internal/bento/bento.py
+++ b/src/bentoml/_internal/bento/bento.py
@@ -16,6 +16,7 @@ import fs.mirror
 import fs.osfs
 import fs.walk
 import yaml
+from fs.tempfs import TempFS
 from cattr.gen import make_dict_structure_fn
 from cattr.gen import make_dict_unstructure_fn
 from cattr.gen import override
@@ -227,7 +228,7 @@ class Bento(StoreItem):
             'Building BentoML service "%s" from build context "%s".', tag, build_ctx
         )
 
-        bento_fs = fs.open_fs(f"temp://bentoml_bento_{bento_name}")
+        bento_fs = TempFS(identifier=f"bentoml_bento_{bento_name}", temp_dir=BentoMLContainer.tmp_bento_store_dir.get())
         ctx_fs = fs.open_fs(encode_path_for_uri(build_ctx))
 
         models: t.Set[Model] = set()


### PR DESCRIPTION
This prevents the situation on linux where the default temp
directory can be on a RAM-backed FS, which meant large Bentos
could not be built.
