### PR TITLE
refactor(1.4): Make the cloud client APIs more structured and aligned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-unit-data
+          name: coverage-unit-data-${{ matrix.os }}-${{ matrix.python-version }}
           path: .coverage.*
           include-hidden-files: true
   integrations:
@@ -98,7 +98,7 @@ jobs:
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-integrations-data
+          name: coverage-integrations-data-${{ matrix.framework }}
           path: .coverage.*
           include-hidden-files: true
   e2e-monitoring:
@@ -137,7 +137,7 @@ jobs:
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-monitoring-data
+          name: coverage-monitoring-data-${{ matrix.os }}-${{ matrix.python-version }}
           path: .coverage.*
           include-hidden-files: true
   e2e-test:
@@ -184,7 +184,7 @@ jobs:
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-e2e-data
+          name: coverage-e2e-data-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.suite }}
           path: .coverage.*
           include-hidden-files: true
   coverage:
@@ -208,19 +208,23 @@ jobs:
       - name: Download e2e coverage
         uses: actions/download-artifact@v4
         with:
-          name: coverage-e2e-data
+          pattern: coverage-e2e-data-*
+          merge-multiple: true
       - name: Download monitoring coverage
         uses: actions/download-artifact@v4
         with:
-          name: coverage-monitoring-data
+          pattern: coverage-monitoring-data-*
+          merge-multiple: true
       - name: Download integrations coverage
         uses: actions/download-artifact@v4
         with:
-          name: coverage-integrations-data
+          pattern: coverage-integrations-data-*
+          merge-multiple: true
       - name: Download unit coverage
         uses: actions/download-artifact@v4
         with:
-          name: coverage-unit-data
+          pattern: coverage-unit-data-*
+          merge-multiple: true
       - name: Install dependencies
         run: pipx install pdm && pipx install nox
       - name: Export coverage reports and generate summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           name: coverage-unit-data
           path: .coverage.*
+          include-hidden-files: true
   integrations:
     name: framework-integration-tests
     runs-on: ubuntu-latest
@@ -99,6 +100,7 @@ jobs:
         with:
           name: coverage-integrations-data
           path: .coverage.*
+          include-hidden-files: true
   e2e-monitoring:
     strategy:
       fail-fast: false
@@ -137,6 +139,7 @@ jobs:
         with:
           name: coverage-monitoring-data
           path: .coverage.*
+          include-hidden-files: true
   e2e-test:
     strategy:
       fail-fast: false
@@ -183,6 +186,7 @@ jobs:
         with:
           name: coverage-e2e-data
           path: .coverage.*
+          include-hidden-files: true
   coverage:
     name: report-coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Disambiguate coverage filename
         run: mv .coverage ".coverage.unit.${{ matrix.os }}.${{ matrix.python-version }}"
       - name: Upload coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-unit-data
           path: .coverage.*
@@ -95,7 +95,7 @@ jobs:
       - name: Disambiguate coverage filename
         run: mv .coverage ".coverage.integrations.ubuntu-latest.3.9.${{ matrix.framework }}"
       - name: Upload coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-integrations-data
           path: .coverage.*
@@ -179,7 +179,7 @@ jobs:
       - name: Disambiguate coverage filename
         run: mv .coverage ".coverage.e2e.${{ matrix.os }}.${{ matrix.python-version }}.${{ matrix.suite }}"
       - name: Upload coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-e2e-data
           path: .coverage.*

--- a/src/_bentoml_sdk/models/base.py
+++ b/src/_bentoml_sdk/models/base.py
@@ -135,7 +135,7 @@ class BentoModel(Model[StoredModel]):
                     target_model_store=model_store,
                 )
             return stored
-        model = cloud_client.pull_model(self.tag, model_store=model_store)
+        model = cloud_client.model.pull(self.tag, model_store=model_store)
         assert model is not None, "non-bentoml model"
         return model
 

--- a/src/bentoml/__init__.py
+++ b/src/bentoml/__init__.py
@@ -29,7 +29,7 @@ from pydantic import Field
 
 # BentoML built-in types
 from ._internal.bento import Bento
-from ._internal.cloud import YataiClient
+from ._internal.cloud import BentoCloudClient
 from ._internal.context import ServiceContext as Context
 from ._internal.context import server_context
 from ._internal.models import Model
@@ -244,7 +244,7 @@ __all__ = [
     "Runner",
     "Runnable",
     "monitoring",
-    "YataiClient",  # Yatai REST API Client
+    "BentoCloudClient",  # BentoCloud REST API Client
     # bento APIs
     "list",
     "get",

--- a/src/bentoml/_internal/cloud/__init__.py
+++ b/src/bentoml/_internal/cloud/__init__.py
@@ -1,3 +1,63 @@
-from .base import CloudClient as CloudClient
-from .bentocloud import BentoCloudClient as BentoCloudClient
+from __future__ import annotations
+
+import attrs
+
+from bentoml._internal.cloud.client import RestApiClient
+
+from .bento import BentoAPI
+from .config import CloudClientConfig
+from .deployment import DeploymentAPI
+from .model import ModelAPI
+from .secret import SecretAPI
 from .yatai import YataiClient as YataiClient
+
+DEFAULT_ENDPOINT = "https://cloud.bentoml.com"
+
+
+@attrs.frozen
+class BentoCloudClient:
+    """
+    BentoCloudClient is a client for the BentoCloud API.
+
+    Args:
+        api_key: The API key to use for the client. env: BENTO_CLOUD_API_KEY
+        endpoint: The endpoint to use for the client. env: BENTO_CLOUD_ENDPOINT
+
+    Attributes:
+        bento: Bento API
+        model: Model API
+        deployment: Deployment API
+        secret: Secret API
+    """
+
+    bento: BentoAPI
+    model: ModelAPI
+    deployment: DeploymentAPI
+    secret: SecretAPI
+
+    def __init__(
+        self, api_key: str | None = None, endpoint: str = DEFAULT_ENDPOINT
+    ) -> None:
+        if api_key is None:
+            from ..configuration.containers import BentoMLContainer
+
+            cfg = CloudClientConfig.get_config()
+            ctx = cfg.get_context(BentoMLContainer.cloud_context.get())
+            api_key = ctx.api_token
+            endpoint = ctx.endpoint
+
+        client = RestApiClient(endpoint, api_key)
+        bento = BentoAPI(client)
+        model = ModelAPI(client)
+        deployment = DeploymentAPI(client)
+        secret = SecretAPI(client)
+
+        self.__attrs_init__(
+            bento=bento, model=model, deployment=deployment, secret=secret
+        )
+
+    @classmethod
+    def for_context(cls, context: str | None = None) -> "BentoCloudClient":
+        cfg = CloudClientConfig.get_config()
+        ctx = cfg.get_context(context)
+        return cls(ctx.api_token, ctx.endpoint)

--- a/src/bentoml/_internal/cloud/base.py
+++ b/src/bentoml/_internal/cloud/base.py
@@ -24,6 +24,7 @@ if t.TYPE_CHECKING:
     from rich.console import RenderResult
 
 FILE_CHUNK_SIZE = 100 * 1024 * 1024  # 100Mb
+UPLOAD_RETRY_COUNT = 3
 
 
 @attrs.define
@@ -168,9 +169,3 @@ class Spinner:
 
     def __exit__(self, *_: t.Any) -> None:
         self.stop()
-
-
-class CloudClient:
-    # Moved atrributes to __init__ because otherwise it will keep all the log when running SDK.
-    def __init__(self):
-        self.spinner = Spinner()

--- a/src/bentoml/_internal/cloud/deployment.py
+++ b/src/bentoml/_internal/cloud/deployment.py
@@ -1279,6 +1279,7 @@ def _build_requirements_txt(bento_dir: str, config: BentoBuildConfig) -> bytes:
             UserWarning,
             stacklevel=2,
         )
-        bentoml_requirement = f"bentoml<{BENTOML_VERSION}"
+        version_without_local = BENTOML_VERSION.split("+")[0]
+        bentoml_requirement = f"bentoml~={version_without_local}"
     content += f"{bentoml_requirement}\n".encode("utf8")
     return content

--- a/src/bentoml/_internal/cloud/deployment.py
+++ b/src/bentoml/_internal/cloud/deployment.py
@@ -19,8 +19,7 @@ from rich.console import Console
 from simple_di import Provide
 from simple_di import inject
 
-from bentoml._internal.bento.bento import Bento
-
+from ..bento.bento import Bento
 from ..bento.build_config import BentoBuildConfig
 
 if t.TYPE_CHECKING:
@@ -28,7 +27,6 @@ if t.TYPE_CHECKING:
     from _bentoml_impl.client import SyncHTTPClient
 
     from ..bento.bento import BentoStore
-    from .bentocloud import BentoCloudClient
     from .client import RestApiClient
 
 from ...exceptions import BentoMLException
@@ -85,9 +83,7 @@ class DeploymentConfigParameters:
     cfg_dict: dict[str, t.Any] | None = None
     _param_config: dict[str, t.Any] | None = None
 
-    def verify(
-        self,
-    ):
+    def verify(self):
         deploy_by_param = (
             self.name
             or self.bento
@@ -304,8 +300,11 @@ def ensure_bento(
     push: bool = True,
     reload: bool = False,
     _bento_store: BentoStore = Provide[BentoMLContainer.bento_store],
-    _cloud_client: BentoCloudClient = Provide[BentoMLContainer.bentocloud_client],
+    _client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
 ) -> Bento | BentoManifestSchema:
+    from .bento import BentoAPI
+
+    bento_api = BentoAPI(_client)
     if project_path:
         from bentoml.bentos import build_bentofile
 
@@ -315,7 +314,7 @@ def ensure_bento(
         if cli:
             rich.print(f"🍱 Built bento [green]{bento_obj.info.tag}[/]")
         if push:
-            _cloud_client.push_bento(bento=bento_obj, bare=bare)
+            bento_api.push(bento=bento_obj, bare=bare)
         return bento_obj
     elif bento:
         bento = Tag.from_taglike(bento)
@@ -326,16 +325,14 @@ def ensure_bento(
 
         # try to get from bentocloud
         try:
-            bento_schema = _cloud_client.get_bento(
-                name=bento.name, version=bento.version
-            )
+            bento_schema = bento_api.get(name=bento.name, version=bento.version)
         except NotFound:
             bento_schema = None
 
         if bento_obj is not None:
             # push to bentocloud
             if push:
-                _cloud_client.push_bento(bento=bento_obj, bare=bare)
+                bento_api.push(bento=bento_obj, bare=bare)
             return bento_obj
         if bento_schema is not None:
             assert bento_schema.manifest is not None
@@ -381,12 +378,13 @@ class DeploymentState:
 
 
 @attr.define
-class DeploymentInfo:
+class Deployment:
     name: str
     admin_console: str
     created_at: str
     created_by: str
     cluster: str
+    _client: RestApiClient = attr.field(alias="_client", repr=False)
     _schema: DeploymentSchema = attr.field(alias="_schema", repr=False)
     _urls: t.Optional[list[str]] = attr.field(alias="_urls", default=None, repr=False)
 
@@ -415,7 +413,7 @@ class DeploymentInfo:
         return yaml.dump(self.to_dict(), sort_keys=False)
 
     def _refetch(self) -> None:
-        res = Deployment.get(self.name, self.cluster)
+        res = DeploymentAPI(self._client).get(self.name, self.cluster)
         self._schema = res._schema
         self._urls = res._urls
 
@@ -505,13 +503,11 @@ class DeploymentInfo:
             raise BentoMLException("Deployment url is not ready")
         return AsyncHTTPClient(self._urls[0], token=token)
 
-    @inject
     def wait_until_ready(
         self,
         spinner: Spinner,
         timeout: int = 3600,
         check_interval: int = 10,
-        cloud_rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
     ) -> int:
         from httpx import TimeoutException
 
@@ -524,7 +520,7 @@ class DeploymentInfo:
             wait_pod_timeout = 60 * 10
             pod: KubePodSchema | None = None
             while True:
-                pod = cloud_rest_client.v2.get_deployment_image_builder_pod(
+                pod = self._client.v2.get_deployment_image_builder_pod(
                     self.name, self.cluster
                 )
                 if pod is None:
@@ -547,7 +543,7 @@ class DeploymentInfo:
                     return
 
             is_first = True
-            logs_tailer = cloud_rest_client.v2.tail_logs(
+            logs_tailer = self._client.v2.tail_logs(
                 cluster_name=self.cluster,
                 namespace=self._schema.kube_namespace,
                 pod_name=pod.name,
@@ -639,12 +635,7 @@ class DeploymentInfo:
                 tail_thread.join()
         return 0
 
-    @inject
-    def upload_files(
-        self,
-        files: t.Iterable[tuple[str, bytes]],
-        cloud_rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
-    ) -> None:
+    def upload_files(self, files: t.Iterable[tuple[str, bytes]]) -> None:
         data = {
             "files": [
                 {
@@ -654,39 +645,28 @@ class DeploymentInfo:
                 for path, content in files
             ]
         }
-        cloud_rest_client.v2.upload_files(
+        self._client.v2.upload_files(
             self.name,
             bentoml_cattr.structure(data, UploadDeploymentFilesSchema),
             cluster=self.cluster,
         )
 
-    @inject
-    def delete_files(
-        self,
-        paths: t.Iterable[str],
-        cloud_rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
-    ) -> None:
+    def delete_files(self, paths: t.Iterable[str]) -> None:
         data = {"paths": paths}
-        cloud_rest_client.v2.delete_files(
+        self._client.v2.delete_files(
             self.name,
             bentoml_cattr.structure(data, DeleteDeploymentFilesSchema),
             cluster=self.cluster,
         )
 
-    @inject
-    def list_files(
-        self,
-        cloud_rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
-    ) -> DeploymentFileListSchema:
-        return cloud_rest_client.v2.list_files(self.name, cluster=self.cluster)
+    def list_files(self) -> DeploymentFileListSchema:
+        return self._client.v2.list_files(self.name, cluster=self.cluster)
 
-    @inject
     def _init_deployment_files(
         self,
         bento_dir: str,
         console: Console | None = None,
         timeout: int = 600,
-        cloud_rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
     ) -> str:
         from ..bento.build_config import BentoPathSpec
 
@@ -695,7 +675,7 @@ class DeploymentInfo:
         if console is None:
             console = rich.get_console()
         while time.time() - start_time < timeout:
-            pods = cloud_rest_client.v2.list_deployment_pods(self.name, self.cluster)
+            pods = self._client.v2.list_deployment_pods(self.name, self.cluster)
             if any(
                 pod.labels.get("yatai.ai/bento-function-component-type") == "api-server"
                 and pod.status.phase == "Running"
@@ -736,17 +716,15 @@ class DeploymentInfo:
         self.upload_files(upload_files)
         return requirements_md5
 
-    @inject
-    def watch(
-        self,
-        bento_dir: str,
-        cloud_client: BentoCloudClient = Provide[BentoMLContainer.bentocloud_client],
-    ) -> None:
+    def watch(self, bento_dir: str) -> None:
         import watchfiles
 
         from ..bento.build_config import BentoPathSpec
+        from .bento import BentoAPI
 
         build_config = get_bento_build_config(bento_dir)
+        deployment_api = DeploymentAPI(self._client)
+        bento_api = BentoAPI(self._client)
         bento_spec = BentoPathSpec(
             build_config.include, build_config.exclude, bento_dir
         )
@@ -762,7 +740,9 @@ class DeploymentInfo:
             return bento_spec.includes(path)
 
         console = Console(highlight=False)
-        bento_info = ensure_bento(bento_dir, bare=True, push=False, reload=True)
+        bento_info = ensure_bento(
+            bento_dir, bare=True, push=False, reload=True, _client=self._client
+        )
         assert isinstance(bento_info, Bento)
         target = self._refetch_target(False)
 
@@ -780,7 +760,7 @@ class DeploymentInfo:
                 ):
                     console.print("✨ [green bold]Bento change detected[/]")
                     spinner.update("🔄 Pushing Bento to BentoCloud")
-                    cloud_client._do_push_bento(bento_info, upload_id, bare=True)  # type: ignore
+                    bento_api._do_push_bento(bento_info, upload_id, bare=True)  # type: ignore
                     spinner.update("🔄 Updating deployment with new configuration")
                     update_config = DeploymentConfigParameters(
                         bento=str(bento_info.tag),
@@ -790,7 +770,7 @@ class DeploymentInfo:
                         dev=True,
                     )
                     update_config.verify()
-                    self = Deployment.update(update_config)
+                    self = deployment_api.update(update_config)
                     target = self._refetch_target(False)
                     requirements_hash = self._init_deployment_files(
                         bento_dir, console=spinner.console
@@ -806,7 +786,11 @@ class DeploymentInfo:
                         bento_dir, watch_filter=watch_filter
                     ):
                         bento_info = ensure_bento(
-                            bento_dir, bare=True, push=False, reload=True
+                            bento_dir,
+                            bare=True,
+                            push=False,
+                            reload=True,
+                            _client=self._client,
                         )
                         assert isinstance(bento_info, Bento)
                         if (
@@ -878,16 +862,11 @@ class DeploymentInfo:
             spinner.stop()
 
     @contextlib.contextmanager
-    @inject
-    def _tail_logs(
-        self,
-        console: Console,
-        cloud_rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
-    ) -> t.Generator[None, None, None]:
+    def _tail_logs(self, console: Console) -> t.Generator[None, None, None]:
         import itertools
         from collections import defaultdict
 
-        pods = cloud_rest_client.v2.list_deployment_pods(self.name, self.cluster)
+        pods = self._client.v2.list_deployment_pods(self.name, self.cluster)
         stop_event = Event()
         workers: list[Thread] = []
 
@@ -897,7 +876,7 @@ class DeploymentInfo:
         def pod_log_worker(pod: KubePodSchema, stop_event: Event) -> None:
             current = ""
             color = runner_color[pod.runner_name]
-            for chunk in cloud_rest_client.v2.tail_logs(
+            for chunk in self._client.v2.tail_logs(
                 cluster_name=self.cluster,
                 namespace=self._schema.kube_namespace,
                 pod_name=pod.name,
@@ -935,7 +914,9 @@ class DeploymentInfo:
 
 
 @attr.define
-class Deployment:
+class DeploymentAPI:
+    _client: RestApiClient = attr.field(repr=False)
+
     @staticmethod
     def _fix_scaling(
         scaling: DeploymentTargetHPAConf | None,
@@ -1004,34 +985,38 @@ class Deployment:
             target_schema.bento.repository.name + ":" + target_schema.bento.name
         )
 
-    @staticmethod
-    @inject
     def _generate_deployment_info_(
-        res: DeploymentSchema,
-        urls: list[str] | None = None,
-        client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
-    ) -> DeploymentInfo:
-        admin_console = f"{client.v1.endpoint}/deployments/{res.name}"
+        self, res: DeploymentSchema, urls: list[str] | None = None
+    ) -> Deployment:
+        client = self._client
+        admin_console = f"{client.endpoint}/deployments/{res.name}"
         if res.cluster.is_first is False:
-            admin_console = f"{client.v1.endpoint}/deployments/{res.name}?cluster={res.cluster.name}&namespace={res.kube_namespace}"
-        return DeploymentInfo(
+            admin_console = f"{client.endpoint}/deployments/{res.name}?cluster={res.cluster.name}&namespace={res.kube_namespace}"
+        return Deployment(
             name=res.name,
             admin_console=admin_console,
             created_at=res.created_at.strftime("%Y-%m-%d %H:%M:%S"),
             created_by=res.creator.name,
             cluster=res.cluster.name,
+            _client=self._client,
             _schema=res,
             _urls=urls,
         )
 
-    @classmethod
-    @inject
     def list(
-        cls,
-        cluster: str | None = None,
-        search: str | None = None,
-        cloud_rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
-    ) -> list[DeploymentInfo]:
+        self, cluster: str | None = None, search: str | None = None
+    ) -> list[Deployment]:
+        """
+        List all deployments in the cluster.
+
+        Args:
+            cluster: The name of the cluster to list deployments from. If not specified, list deployments from all clusters.
+            search: The search query to filter deployments.
+
+        Returns:
+            A list of DeploymentInfo objects.
+        """
+        cloud_rest_client = self._client
         if cluster is None:
             res_count = cloud_rest_client.v2.list_deployment(all=True, search=search)
             if res_count.total == 0:
@@ -1046,15 +1031,22 @@ class Deployment:
             res = cloud_rest_client.v2.list_deployment(
                 cluster, search=search, count=res_count.total
             )
-        return [cls._generate_deployment_info_(schema) for schema in res.items]
+        return [self._generate_deployment_info_(schema) for schema in res.items]
 
-    @classmethod
-    @inject
     def create(
-        cls,
+        self,
         deployment_config_params: DeploymentConfigParameters,
-        rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
-    ) -> DeploymentInfo:
+    ) -> Deployment:
+        """
+        Create a new deployment.
+
+        Args:
+            deployment_config_params: The parameters for the deployment.
+
+        Returns:
+            The DeploymentInfo object.
+        """
+        rest_client = self._client
         cluster = deployment_config_params.get_cluster()
         if (
             deployment_config_params.cfg_dict is None
@@ -1064,7 +1056,7 @@ class Deployment:
 
         config_params = deployment_config_params.get_config_dict()
         config_struct = bentoml_cattr.structure(config_params, CreateDeploymentSchemaV2)
-        cls._fix_and_validate_schema(config_struct)
+        self._fix_and_validate_schema(config_struct)
 
         res = rest_client.v2.create_deployment(
             create_schema=config_struct, cluster=cluster
@@ -1072,22 +1064,28 @@ class Deployment:
 
         logger.debug("Deployment Schema: %s", config_struct)
 
-        return cls._generate_deployment_info_(res, res.urls)
+        return self._generate_deployment_info_(res, res.urls)
 
-    @classmethod
-    @inject
     def update(
-        cls,
+        self,
         deployment_config_params: DeploymentConfigParameters,
-        cloud_rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
-    ) -> DeploymentInfo:
+    ) -> Deployment:
+        """
+        Update a deployment.
+
+        Args:
+            deployment_config_params: The parameters for the deployment.
+
+        Returns:
+            The DeploymentInfo object.
+        """
         name = deployment_config_params.get_name()
         if name is None:
             raise ValueError("name is required")
         cluster = deployment_config_params.get_cluster()
 
-        deployment_schema = cloud_rest_client.v2.get_deployment(name, cluster)
-        orig_dict = cls._convert_schema_to_update_schema(deployment_schema)
+        deployment_schema = self._client.v2.get_deployment(name, cluster)
+        orig_dict = self._convert_schema_to_update_schema(deployment_schema)
 
         config_params = deployment_config_params.get_config_dict(
             orig_dict.get("bento"),
@@ -1096,31 +1094,38 @@ class Deployment:
         config_merger.merge(orig_dict, config_params)
         config_struct = bentoml_cattr.structure(orig_dict, UpdateDeploymentSchemaV2)
 
-        cls._fix_and_validate_schema(config_struct)
+        self._fix_and_validate_schema(config_struct)
 
-        res = cloud_rest_client.v2.update_deployment(
+        res = self._client.v2.update_deployment(
             cluster=deployment_schema.cluster.name,
             name=name,
             update_schema=config_struct,
         )
         logger.debug("Deployment Schema: %s", config_struct)
-        return cls._generate_deployment_info_(res, res.urls)
+        return self._generate_deployment_info_(res, res.urls)
 
-    @classmethod
-    @inject
     def apply(
-        cls,
+        self,
         deployment_config_params: DeploymentConfigParameters,
-        rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
-    ) -> DeploymentInfo:
+    ) -> Deployment:
+        """
+        Apply a deployment.
+
+        Args:
+            deployment_config_params: The parameters for the deployment.
+
+        Returns:
+            The DeploymentInfo object.
+        """
         name = deployment_config_params.get_name()
+        rest_client = self._client
         if name is not None:
             try:
                 deployment_schema = rest_client.v2.get_deployment(
                     name, deployment_config_params.get_cluster(pop=False)
                 )
             except NotFound:
-                return cls.create(
+                return self.create(
                     deployment_config_params=deployment_config_params,
                 )
             # directly update the deployment with the schema, do not merge with the existing schema
@@ -1138,7 +1143,7 @@ class Deployment:
             config_struct = bentoml_cattr.structure(
                 deployment_config_params.get_config_dict(), UpdateDeploymentSchemaV2
             )
-            cls._fix_and_validate_schema(config_struct)
+            self._fix_and_validate_schema(config_struct)
 
             res = rest_client.v2.update_deployment(
                 name=name,
@@ -1146,50 +1151,59 @@ class Deployment:
                 cluster=deployment_schema.cluster.name,
             )
             logger.debug("Deployment Schema: %s", config_struct)
-            return cls._generate_deployment_info_(res, res.urls)
+            return self._generate_deployment_info_(res, res.urls)
 
-        return cls.create(deployment_config_params=deployment_config_params)
+        return self.create(deployment_config_params=deployment_config_params)
 
-    @classmethod
-    @inject
-    def get(
-        cls,
-        name: str,
-        cluster: str | None = None,
-        cloud_rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
-    ) -> DeploymentInfo:
-        res = cloud_rest_client.v2.get_deployment(name, cluster)
-        return cls._generate_deployment_info_(res, res.urls)
+    def get(self, name: str, cluster: str | None = None) -> Deployment:
+        """
+        Get a deployment.
 
-    @classmethod
-    @inject
-    def terminate(
-        cls,
-        name: str,
-        cluster: str | None = None,
-        cloud_rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
-    ) -> DeploymentInfo:
-        res = cloud_rest_client.v2.terminate_deployment(name, cluster)
-        return cls._generate_deployment_info_(res, res.urls)
+        Args:
+            name: The name of the deployment.
+            cluster: The name of the cluster.
 
-    @classmethod
-    @inject
-    def delete(
-        cls,
-        name: str,
-        cluster: str | None = None,
-        cloud_rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
-    ) -> None:
-        cloud_rest_client.v2.delete_deployment(name, cluster)
+        Returns:
+            The DeploymentInfo object.
+        """
+        res = self._client.v2.get_deployment(name, cluster)
+        return self._generate_deployment_info_(res, res.urls)
 
-    @classmethod
-    @inject
-    def list_instance_types(
-        cls,
-        cluster: str | None = None,
-        cloud_rest_client: RestApiClient = Provide[BentoMLContainer.rest_api_client],
-    ) -> list[InstanceTypeInfo]:
-        res = cloud_rest_client.v2.list_instance_types(cluster)
+    def terminate(self, name: str, cluster: str | None = None) -> Deployment:
+        """
+        Terminate a deployment.
+
+        Args:
+            name: The name of the deployment.
+            cluster: The name of the cluster.
+
+        Returns:
+            The DeploymentInfo object.
+        """
+        res = self._client.v2.terminate_deployment(name, cluster)
+        return self._generate_deployment_info_(res, res.urls)
+
+    def delete(self, name: str, cluster: str | None = None) -> None:
+        """
+        Delete a deployment.
+
+        Args:
+            name: The name of the deployment.
+            cluster: The name of the cluster.
+        """
+        self._client.v2.delete_deployment(name, cluster)
+
+    def list_instance_types(self, cluster: str | None = None) -> list[InstanceTypeInfo]:
+        """
+        List all instance types in the cluster.
+
+        Args:
+            cluster: The name of the cluster.
+
+        Returns:
+            A list of InstanceTypeInfo objects.
+        """
+        res = self._client.v2.list_instance_types(cluster)
         return [
             InstanceTypeInfo(
                 name=schema.display_name,

--- a/src/bentoml/_internal/cloud/model.py
+++ b/src/bentoml/_internal/cloud/model.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+import math
+import tarfile
+import typing as t
+import warnings
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+import attrs
+import fs
+import httpx
+from simple_di import Provide
+from simple_di import inject
+
+from ...exceptions import BentoMLException
+from ...exceptions import NotFound
+from ..configuration.containers import BentoMLContainer
+from ..models import Model as StoredModel
+from ..models import ModelStore
+from ..tag import Tag
+from .base import FILE_CHUNK_SIZE
+from .base import UPLOAD_RETRY_COUNT
+from .base import CallbackIOWrapper
+from .base import Spinner
+from .schemas.modelschemas import ModelUploadStatus
+from .schemas.schemasv1 import CompleteMultipartUploadSchema
+from .schemas.schemasv1 import CompletePartSchema
+from .schemas.schemasv1 import CreateModelRepositorySchema
+from .schemas.schemasv1 import FinishUploadModelSchema
+from .schemas.schemasv1 import PreSignMultipartUploadUrlSchema
+from .schemas.schemasv1 import TransmissionStrategy
+
+if t.TYPE_CHECKING:
+    from concurrent.futures import Future
+
+    from rich.progress import TaskID
+
+    from _bentoml_sdk.models import Model
+
+    from .client import RestApiClient
+    from .schemas.schemasv1 import ModelWithRepositoryListSchema
+
+
+@attrs.frozen
+class ModelAPI:
+    _client: RestApiClient = attrs.field(repr=False)
+    spinner: Spinner = attrs.field(repr=False, factory=Spinner)
+
+    def push(
+        self,
+        model: Model[t.Any],
+        *,
+        force: bool = False,
+        threads: int = 10,
+    ) -> None:
+        """Push a model to remote model store
+
+        Args:
+            model: The model to push
+            force: Whether to force push the model
+            threads: The number of threads to use for the push
+        """
+        with self.spinner:
+            upload_task_id = self.spinner.transmission_progress.add_task(
+                f'Pushing model "{model}"', start=False, visible=False
+            )
+            self._do_push_model(model, upload_task_id, force=force, threads=threads)
+
+    @inject
+    def _do_push_model(
+        self,
+        model: Model[t.Any],
+        upload_task_id: TaskID,
+        *,
+        force: bool = False,
+        threads: int = 10,
+        bentoml_tmp_dir: str = Provide[BentoMLContainer.tmp_bento_store_dir],
+    ):
+        from _bentoml_sdk.models import BentoModel
+
+        rest_client = self._client
+
+        model_info = model.to_info()
+        name = model_info.tag.name
+        version = model_info.tag.version
+        if version is None:
+            raise BentoMLException(f'Model "{model}" version cannot be None')
+
+        with self.spinner.spin(text=f'Fetching model repository "{name}"'):
+            model_repository = rest_client.v1.get_model_repository(
+                model_repository_name=name
+            )
+        if not model_repository:
+            with self.spinner.spin(
+                text=f'Model repository "{name}" not found, creating now..'
+            ):
+                model_repository = rest_client.v1.create_model_repository(
+                    req=CreateModelRepositorySchema(name=name, description="")
+                )
+        with self.spinner.spin(
+            text=f'Try fetching model "{model}" from remote model store..'
+        ):
+            remote_model = rest_client.v1.get_model(
+                model_repository_name=name, version=version
+            )
+        if (
+            not force
+            and remote_model
+            and remote_model.upload_status == ModelUploadStatus.SUCCESS.value
+        ):
+            self.spinner.log(
+                f'[bold blue]Model "{model}" already exists in remote model store, skipping'
+            )
+            return
+        if not remote_model:
+            with self.spinner.spin(
+                text=f'Registering model "{model}" with remote model store..'
+            ):
+                remote_model = rest_client.v1.create_model(
+                    model_repository_name=model_repository.name,
+                    req=model.to_create_schema(),
+                )
+        if not isinstance(model, BentoModel):
+            self.spinner.log(f"[bold blue]Skip uploading non-bentoml model {model}")
+            return
+        assert model.stored is not None
+        transmission_strategy: TransmissionStrategy = "proxy"
+        presigned_upload_url: str | None = None
+
+        if remote_model.transmission_strategy is not None:
+            transmission_strategy = remote_model.transmission_strategy
+        else:
+            with self.spinner.spin(
+                text=f'Getting a presigned upload url for Model "{model.tag}" ..'
+            ):
+                remote_model = rest_client.v1.presign_model_upload_url(
+                    model_repository_name=model_repository.name, version=version
+                )
+                if remote_model.presigned_upload_url:
+                    transmission_strategy = "presigned_url"
+                    presigned_upload_url = remote_model.presigned_upload_url
+
+        def io_cb(x: int):
+            self.spinner.transmission_progress.update(upload_task_id, advance=x)
+
+        with NamedTemporaryFile(
+            prefix="bentoml-model-", suffix=".tar", dir=bentoml_tmp_dir
+        ) as tar_io:
+            with self.spinner.spin(
+                text=f'Creating tar archive for model "{model.tag}"..'
+            ):
+                with tarfile.open(fileobj=tar_io, mode="w:") as tar:
+                    tar.add(model.stored.path, arcname="./")
+            with self.spinner.spin(text=f'Start uploading model "{model.tag}"..'):
+                rest_client.v1.start_upload_model(
+                    model_repository_name=model_repository.name, version=version
+                )
+            file_size = tar_io.tell()
+            self.spinner.transmission_progress.update(
+                upload_task_id,
+                description=f'Uploading model "{model.tag}"',
+                total=file_size,
+                visible=True,
+            )
+            self.spinner.transmission_progress.start_task(upload_task_id)
+            io_with_cb = CallbackIOWrapper(tar_io, read_cb=io_cb)
+
+            if transmission_strategy == "proxy":
+                try:
+                    rest_client.v1.upload_model(
+                        model_repository_name=model_repository.name,
+                        version=version,
+                        data=io_with_cb,
+                    )
+                except Exception as e:  # pylint: disable=broad-except
+                    self.spinner.log(f'[bold red]Failed to upload model "{model.tag}"')
+                    raise e
+                self.spinner.log(f'[bold green]Successfully pushed model "{model.tag}"')
+                return
+            finish_req = FinishUploadModelSchema(
+                status=ModelUploadStatus.SUCCESS.value, reason=""
+            )
+            try:
+                if presigned_upload_url is not None:
+                    resp = httpx.put(
+                        presigned_upload_url, content=io_with_cb, timeout=36000
+                    )
+                    if resp.status_code != 200:
+                        finish_req = FinishUploadModelSchema(
+                            status=ModelUploadStatus.FAILED.value,
+                            reason=resp.text,
+                        )
+                else:
+                    with self.spinner.spin(
+                        text=f'Start multipart uploading Model "{model.tag}"...'
+                    ):
+                        remote_model = rest_client.v1.start_model_multipart_upload(
+                            model_repository_name=model_repository.name,
+                            version=version,
+                        )
+                        if not remote_model.upload_id:
+                            raise BentoMLException(
+                                f'Failed to start multipart upload for model "{model.tag}", upload_id is empty'
+                            )
+
+                        upload_id: str = remote_model.upload_id
+
+                    chunks_count = math.ceil(file_size / FILE_CHUNK_SIZE)
+                    tar_io.file.close()
+
+                    def chunk_upload(
+                        upload_id: str, chunk_number: int
+                    ) -> FinishUploadModelSchema | tuple[str, int]:
+                        with self.spinner.spin(
+                            text=f'({chunk_number}/{chunks_count}) Presign multipart upload url of model "{model.tag}"...'
+                        ):
+                            remote_model = (
+                                rest_client.v1.presign_model_multipart_upload_url(
+                                    model_repository_name=model_repository.name,
+                                    version=version,
+                                    req=PreSignMultipartUploadUrlSchema(
+                                        upload_id=upload_id,
+                                        part_number=chunk_number,
+                                    ),
+                                )
+                            )
+
+                        with self.spinner.spin(
+                            text=f'({chunk_number}/{chunks_count}) Uploading chunk of model "{model.tag}"...'
+                        ):
+                            with open(tar_io.name, "rb") as f:
+                                chunk_io = CallbackIOWrapper(
+                                    f,
+                                    read_cb=io_cb,
+                                    start=(chunk_number - 1) * FILE_CHUNK_SIZE,
+                                    end=chunk_number * FILE_CHUNK_SIZE
+                                    if chunk_number < chunks_count
+                                    else None,
+                                )
+
+                                for i in range(UPLOAD_RETRY_COUNT):
+                                    resp = httpx.put(
+                                        remote_model.presigned_upload_url,
+                                        content=chunk_io,
+                                        timeout=36000,
+                                    )
+                                    if resp.status_code == 200:
+                                        break
+                                    if i == UPLOAD_RETRY_COUNT - 1:
+                                        return FinishUploadModelSchema(
+                                            status=ModelUploadStatus.FAILED.value,
+                                            reason=resp.text,
+                                        )
+                                    else:  # retry and reset and update progress
+                                        read = chunk_io.reset()
+                                        self.spinner.transmission_progress.update(
+                                            upload_task_id, advance=-read
+                                        )
+                                return resp.headers["ETag"], chunk_number
+
+                    futures_: list[
+                        Future[FinishUploadModelSchema | tuple[str, int]]
+                    ] = []
+
+                    with ThreadPoolExecutor(
+                        max_workers=min(max(chunks_count, 1), threads)
+                    ) as executor:
+                        for i in range(1, chunks_count + 1):
+                            future = executor.submit(
+                                chunk_upload,
+                                upload_id,
+                                i,
+                            )
+                            futures_.append(future)
+
+                    parts: list[CompletePartSchema] = []
+
+                    for future in futures_:
+                        result = future.result()
+                        if isinstance(result, FinishUploadModelSchema):
+                            finish_req = result
+                            break
+                        else:
+                            etag, chunk_number = result
+                            parts.append(
+                                CompletePartSchema(
+                                    part_number=chunk_number,
+                                    etag=etag,
+                                )
+                            )
+
+                    with self.spinner.spin(
+                        text=f'Completing multipart upload of model "{model.tag}"...'
+                    ):
+                        remote_model = rest_client.v1.complete_model_multipart_upload(
+                            model_repository_name=model_repository.name,
+                            version=version,
+                            req=CompleteMultipartUploadSchema(
+                                upload_id=upload_id,
+                                parts=parts,
+                            ),
+                        )
+
+            except Exception as e:  # pylint: disable=broad-except
+                finish_req = FinishUploadModelSchema(
+                    status=ModelUploadStatus.FAILED.value,
+                    reason=str(e),
+                )
+            if finish_req.status == ModelUploadStatus.FAILED.value:
+                self.spinner.log(f'[bold red]Failed to upload model "{model.tag}"')
+            with self.spinner.spin(
+                text="Submitting upload status to remote model store"
+            ):
+                rest_client.v1.finish_upload_model(
+                    model_repository_name=model_repository.name,
+                    version=version,
+                    req=finish_req,
+                )
+
+            if finish_req.status != ModelUploadStatus.SUCCESS.value:
+                self.spinner.log(
+                    f'[bold red]Failed pushing model "{model.tag}" : {finish_req.reason}'
+                )
+                raise BentoMLException(f'Failed to upload model "{model.tag}"')
+            else:
+                self.spinner.log(f'[bold green]Successfully pushed model "{model.tag}"')
+
+    @inject
+    def pull(
+        self,
+        tag: str | Tag,
+        *,
+        force: bool = False,
+        model_store: ModelStore = Provide[BentoMLContainer.model_store],
+        query: str | None = None,
+    ) -> StoredModel | None:
+        """Pull a model from remote model store
+
+        Args:
+            tag: The tag of the model to pull
+            force: Whether to force pull the model
+            model_store: The model store to pull the model to
+            query: The query to use for the pull
+
+        Returns:
+            The pulled model
+        """
+        with self.spinner:
+            download_task_id = self.spinner.transmission_progress.add_task(
+                f'Pulling model "{tag}"', start=False, visible=False
+            )
+            return self._do_pull_model(
+                tag,
+                download_task_id,
+                force=force,
+                model_store=model_store,
+                query=query,
+            )
+
+    @inject
+    def _do_pull_model(
+        self,
+        tag: str | Tag,
+        download_task_id: TaskID,
+        *,
+        force: bool = False,
+        model_store: ModelStore = Provide[BentoMLContainer.model_store],
+        query: str | None = None,
+    ) -> StoredModel | None:
+        rest_client = self._client
+        _tag = Tag.from_taglike(tag)
+        try:
+            model = model_store.get(_tag)
+        except NotFound:
+            model = None
+        else:
+            if _tag.version not in (None, "latest"):
+                if not force:
+                    self.spinner.log(
+                        f'[bold blue]Model "{tag}" already exists locally, skipping'
+                    )
+                    return model
+                else:
+                    model_store.delete(tag)
+        name = _tag.name
+        version = _tag.version
+        if version in (None, "latest"):
+            latest_model = rest_client.v1.get_latest_model(name, query=query)
+            if latest_model is None:
+                raise BentoMLException(
+                    f'Model "{_tag}" not found on remote model store, you may need to specify a version'
+                )
+            if model is not None:
+                if not force and latest_model.build_at < model.creation_time:
+                    self.spinner.log(
+                        f'[bold blue]Newer version of model "{name}" exists locally, skipping'
+                    )
+                    return model
+                if model.tag.version == latest_model.version:
+                    if not force:
+                        self.spinner.log(
+                            f'[bold blue]Model "{model.tag}" already exists locally, skipping'
+                        )
+                        return model
+                    else:
+                        model_store.delete(model.tag)
+            version = latest_model.version
+        elif query:
+            warnings.warn(
+                "`query` is ignored when model version is specified", UserWarning
+            )
+
+        with self.spinner.spin(
+            text=f'Getting a presigned download url for model "{_tag}"..'
+        ):
+            remote_model = rest_client.v1.presign_model_download_url(name, version)
+
+        if not remote_model:
+            raise BentoMLException(f'Model "{_tag}" not found on remote model store')
+        if remote_model.manifest.metadata.get("registry") == "huggingface":
+            self.spinner.log(f"[bold blue]No content to download for model {_tag}")
+            return
+        # Download model files from remote model store
+        transmission_strategy: TransmissionStrategy = "proxy"
+        presigned_download_url: str | None = None
+
+        if remote_model.transmission_strategy is not None:
+            transmission_strategy = remote_model.transmission_strategy
+        else:
+            with self.spinner.spin(
+                text=f'Getting a presigned download url for model "{_tag}"'
+            ):
+                remote_model = rest_client.v1.presign_model_download_url(name, version)
+                if remote_model.presigned_download_url:
+                    presigned_download_url = remote_model.presigned_download_url
+                    transmission_strategy = "presigned_url"
+
+        if transmission_strategy == "proxy":
+            response_ctx = rest_client.v1.download_model(
+                model_repository_name=name, version=version
+            )
+        else:
+            if presigned_download_url is None:
+                with self.spinner.spin(
+                    text=f'Getting a presigned download url for model "{_tag}"'
+                ):
+                    remote_model = rest_client.v1.presign_model_download_url(
+                        name, version
+                    )
+                    presigned_download_url = remote_model.presigned_download_url
+
+            response_ctx = httpx.stream("GET", presigned_download_url)
+
+        with NamedTemporaryFile() as tar_file:
+            with response_ctx as response:
+                if response.status_code != 200:
+                    raise BentoMLException(
+                        f'Failed to download model "{_tag}": {response.text}'
+                    )
+
+                total_size_in_bytes = int(response.headers.get("content-length", 0))
+                block_size = 1024  # 1 Kibibyte
+                self.spinner.transmission_progress.update(
+                    download_task_id,
+                    description=f'Downloading model "{_tag}"',
+                    total=total_size_in_bytes,
+                    visible=True,
+                )
+                self.spinner.transmission_progress.start_task(download_task_id)
+                for data in response.iter_bytes(block_size):
+                    self.spinner.transmission_progress.update(
+                        download_task_id, advance=len(data)
+                    )
+                    tar_file.write(data)
+
+            self.spinner.log(f'[bold green]Finished downloading model "{_tag}" files')
+            tar_file.seek(0, 0)
+            tar = tarfile.open(fileobj=tar_file, mode="r")
+            with self.spinner.spin(text=f'Extracting model "{_tag}" tar file'):
+                with fs.open_fs("temp://") as temp_fs:
+                    for member in tar.getmembers():
+                        f = tar.extractfile(member)
+                        if f is None:
+                            continue
+                        p = Path(member.name)
+                        if p.parent != Path("."):
+                            temp_fs.makedirs(str(p.parent), recreate=True)
+                        temp_fs.writebytes(member.name, f.read())
+                    model = StoredModel.from_fs(temp_fs).save(model_store)
+                    self.spinner.log(f'[bold green]Successfully pulled model "{_tag}"')
+                    return model
+
+    def list(self) -> ModelWithRepositoryListSchema:
+        """List all models in the remote model store
+
+        Returns:
+            The list of models
+        """
+        res = self._client.v1.get_models_list()
+        if res is None:
+            raise BentoMLException("List models request failed")
+
+        res.items = [
+            model
+            for model in sorted(res.items, key=lambda x: x.created_at, reverse=True)
+        ]
+        return res

--- a/src/bentoml/_internal/cloud/yatai.py
+++ b/src/bentoml/_internal/cloud/yatai.py
@@ -26,7 +26,7 @@ from ..tag import Tag
 from ..utils import calc_dir_size
 from .base import FILE_CHUNK_SIZE
 from .base import CallbackIOWrapper
-from .base import CloudClient
+from .base import Spinner
 from .config import get_rest_api_client
 from .schemas.modelschemas import BentoApiSchema
 from .schemas.modelschemas import BentoRunnerResourceSchema
@@ -54,7 +54,10 @@ if t.TYPE_CHECKING:
     from rich.progress import TaskID
 
 
-class YataiClient(CloudClient):
+class YataiClient:
+    def __init__(self) -> None:
+        self.spinner = Spinner()
+
     def push_bento(
         self,
         bento: Bento,

--- a/src/bentoml/_internal/configuration/containers.py
+++ b/src/bentoml/_internal/configuration/containers.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 
     from .. import external_typing as ext
     from ..bento import BentoStore
+    from ..cloud import BentoCloudClient
     from ..cloud.client import RestApiClient
     from ..models import ModelStore
     from ..server.metrics.prometheus import PrometheusClient
@@ -251,20 +252,6 @@ class _BentoMLContainerClass:
         "EXPORT_BENTO"
     )
     worker_index: providers.Static[int] = providers.Static(0)
-
-    @providers.SingletonFactory
-    @staticmethod
-    def yatai_client():
-        from ..cloud.yatai import YataiClient
-
-        return YataiClient()
-
-    @providers.SingletonFactory
-    @staticmethod
-    def bentocloud_client():
-        from ..cloud.bentocloud import BentoCloudClient
-
-        return BentoCloudClient()
 
     @providers.SingletonFactory
     @staticmethod
@@ -509,12 +496,23 @@ class _BentoMLContainerClass:
 
     cloud_context = providers.Static[t.Optional[str]](None)
 
-    @providers.Factory
+    @providers.SingletonFactory
     @staticmethod
-    def rest_api_client(context: str | None = Provide[cloud_context]) -> RestApiClient:
+    def rest_api_client(
+        context: str | None = Provide[cloud_context],
+    ) -> RestApiClient:
         from ..cloud.config import get_rest_api_client
 
         return get_rest_api_client(context)
+
+    @providers.SingletonFactory
+    @staticmethod
+    def bentocloud_client(
+        context: str | None = Provide[cloud_context],
+    ) -> BentoCloudClient:
+        from ..cloud import BentoCloudClient
+
+        return BentoCloudClient.for_context(context)
 
 
 BentoMLContainer = _BentoMLContainerClass()

--- a/src/bentoml/_internal/service/service.py
+++ b/src/bentoml/_internal/service/service.py
@@ -186,7 +186,7 @@ class Service:
                         return load_bento_dir(bento.path)
                     except NotFound:
                         cloud_client = BentoMLContainer.bentocloud_client.get()
-                        cloud_client.pull_bento(bento_tag, bento_store=tmp_bento_store)
+                        cloud_client.bento.pull(bento_tag, bento_store=tmp_bento_store)
                         return get_or_pull(bento_tag)
 
                 return (get_or_pull, (self.bento.tag,))

--- a/src/bentoml/bentos.py
+++ b/src/bentoml/bentos.py
@@ -253,7 +253,7 @@ def push(
     bento = _bento_store.get(tag)
     if not bento:
         raise BentoMLException(f"Bento {tag} not found in local store")
-    _cloud_client.push_bento(bento, force=force)
+    _cloud_client.bento.push(bento, force=force)
 
 
 @inject
@@ -264,7 +264,7 @@ def pull(
     _bento_store: BentoStore = Provide[BentoMLContainer.bento_store],
     _cloud_client: BentoCloudClient = Provide[BentoMLContainer.bentocloud_client],
 ):
-    _cloud_client.pull_bento(tag, force=force, bento_store=_bento_store)
+    _cloud_client.bento.pull(tag, force=force, bento_store=_bento_store)
 
 
 @inject

--- a/src/bentoml/models.py
+++ b/src/bentoml/models.py
@@ -220,7 +220,7 @@ def push(
     model_obj = BentoModel(tag)
     if model_obj.stored is None:
         raise BentoMLException(f"Model {tag} not found in local store")
-    _cloud_client.push_model(model_obj, force=force)
+    _cloud_client.model.push(model_obj, force=force)
 
 
 @inject
@@ -230,7 +230,7 @@ def pull(
     force: bool = False,
     _cloud_client: BentoCloudClient = Provide[BentoMLContainer.bentocloud_client],
 ) -> Model | None:
-    return _cloud_client.pull_model(tag, force=force)
+    return _cloud_client.model.pull(tag, force=force)
 
 
 if t.TYPE_CHECKING:

--- a/src/bentoml/testing/pytest/plugin.py
+++ b/src/bentoml/testing/pytest/plugin.py
@@ -12,6 +12,7 @@ import pytest
 from pytest import MonkeyPatch
 
 import bentoml
+from bentoml._internal.cloud import BentoCloudClient
 from bentoml._internal.configuration import clean_bentoml_version
 from bentoml._internal.configuration.containers import BentoMLContainer
 from bentoml._internal.models import ModelContext
@@ -194,6 +195,7 @@ def _setup_test_directory() -> tuple[str, str]:
     BentoMLContainer.model_store_dir.set(models)
     BentoMLContainer.tmp_bento_store_dir.set(tmp_bentos)
     BentoMLContainer.prometheus_multiproc_dir.set(multiproc_dir)
+    BentoMLContainer.bentocloud_client.set(BentoCloudClient(""))
     return bentoml_home, multiproc_dir
 
 

--- a/src/bentoml_cli/bentos.py
+++ b/src/bentoml_cli/bentos.py
@@ -308,7 +308,7 @@ def bento_management_commands() -> click.Group:
         cloud_client: BentoCloudClient = Provide[BentoMLContainer.bentocloud_client],
     ) -> None:  # type: ignore (not accessed)
         """Pull Bento from a remote Bento store server."""
-        cloud_client.pull_bento(bento_tag, force=force)
+        cloud_client.bento.pull(bento_tag, force=force)
 
     @bentos.command()
     @click.argument("bento_tag", type=click.STRING)
@@ -337,7 +337,7 @@ def bento_management_commands() -> click.Group:
         bento_obj = bento_store.get(bento_tag)
         if not bento_obj:
             raise click.ClickException(f"Bento {bento_tag} not found in local store")
-        cloud_client.push_bento(bento_obj, force=force, threads=threads)
+        cloud_client.bento.push(bento_obj, force=force, threads=threads)
 
     @bentos.command()
     @click.argument("build_ctx", type=click.Path(), default=".")
@@ -462,7 +462,7 @@ def bento_management_commands() -> click.Group:
         if push:
             if not get_quiet_mode():
                 rich.print(f"\n[magenta]Pushing {bento} to BentoCloud...[/]")
-            _cloud_client.push_bento(bento, force=force, threads=threads)
+            _cloud_client.bento.push(bento, force=force, threads=threads)
         elif containerize:
             backend: DefaultBuilder = t.cast(
                 "DefaultBuilder", os.getenv("BENTOML_CONTAINERIZE_BACKEND", "docker")

--- a/src/bentoml_cli/models.py
+++ b/src/bentoml_cli/models.py
@@ -300,7 +300,7 @@ def pull(
     if model_tag is not None:
         if ctx.get_parameter_source("bentofile") != ParameterSource.DEFAULT:
             rich.print("-f bentofile is ignored when model_tag is provided")
-        cloud_client.pull_model(model_tag, force=force)
+        cloud_client.model.pull(model_tag, force=force)
         return
 
     try:
@@ -316,7 +316,7 @@ def pull(
             "No model to pull, please provide a model tag or define models in bentofile.yaml"
         )
     for model_spec in build_config.models:
-        cloud_client.pull_model(
+        cloud_client.model.pull(
             model_spec.tag,
             force=force,
             query=model_spec.filter,
@@ -352,7 +352,7 @@ def push(
     model_obj = BentoModel(model_tag)
     if model_obj.stored is None:
         raise click.ClickException(f"Model {model_tag} not found in local store")
-    cloud_client.push_model(
+    cloud_client.model.push(
         model_obj,
         force=force,
         threads=threads,

--- a/tests/unit/_internal/bento/test_service_serialization.py
+++ b/tests/unit/_internal/bento/test_service_serialization.py
@@ -116,7 +116,7 @@ def test_remote_bento_strategy_pull_yatai(build_bento: bentoml.Bento):
         if "simplebento" in sys.modules:
             del sys.modules["simplebento"]
 
-    mock_bentocloud_client.pull_bento.side_effect = pull_bento
+    mock_bentocloud_client.bento.pull.side_effect = pull_bento
 
     _bentocloud_client = BentoMLContainer.bentocloud_client.get()
     BentoMLContainer.bentocloud_client.set(mock_bentocloud_client)
@@ -126,7 +126,7 @@ def test_remote_bento_strategy_pull_yatai(build_bento: bentoml.Bento):
 
     del sys.modules["simplebento"]
     assert svc == cloudpickle.loads(serialized_svc)
-    mock_bentocloud_client.pull_bento.assert_called_once_with(
+    mock_bentocloud_client.bento.pull.assert_called_once_with(
         Tag("test.simplebento", "1.0"), bento_store=ANY
     )
 


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

## What does this PR address?

Make the cloud client APIs more structured and aligned

```python
import bentoml
import os

# Use default client
deployment = bentoml.deployment.get('mydeployment')
# Use from cloud client
client = bentoml.BentoCloudClient("token")
deployment = client.deployment.get("mydeployment")
# Env vars are supported
os.environ['BENTO_CLOUD_API_KEY'] = 'mytoken'
os.environ['BENTO_CLOUD_API_ENDPOINT'] = 'https://my.cloud.bentoml.org'
client = bentoml.BentoCloudClient()
deployment = client.deployment.get("mydeployment")
```