### PR TITLE
feat: Add task_id to request inference context

### DIFF
--- a/src/_bentoml_impl/server/app.py
+++ b/src/_bentoml_impl/server/app.py
@@ -440,6 +440,7 @@ class ServiceAppFactory(BaseAppFactory):
 
     async def _run_task(self, task_id: str, name: str, request: Request) -> None:
         try:
+            self.service.context.response.task_id = task_id
             resp = await self.api_endpoint_wrapper(name, request)
             await self._result_store.set_result(
                 task_id,

--- a/src/_bentoml_impl/server/app.py
+++ b/src/_bentoml_impl/server/app.py
@@ -440,7 +440,7 @@ class ServiceAppFactory(BaseAppFactory):
 
     async def _run_task(self, task_id: str, name: str, request: Request) -> None:
         try:
-            self.service.context.response.task_id = task_id
+            self.service.context.request.state.task_id = task_id
             resp = await self.api_endpoint_wrapper(name, request)
             await self._result_store.set_result(
                 task_id,

--- a/src/bentoml/_internal/context.py
+++ b/src/bentoml/_internal/context.py
@@ -133,6 +133,7 @@ class ServiceContext:
         cookies: list[Cookie] = attr.field(factory=list)
         status_code: int = 200
         background: BackgroundTasks = attr.field(factory=BackgroundTasks)
+        task_id: str | None = None
 
         @property
         def headers(self) -> Metadata:

--- a/src/bentoml/_internal/context.py
+++ b/src/bentoml/_internal/context.py
@@ -133,7 +133,6 @@ class ServiceContext:
         cookies: list[Cookie] = attr.field(factory=list)
         status_code: int = 200
         background: BackgroundTasks = attr.field(factory=BackgroundTasks)
-        task_id: str | None = None
 
         @property
         def headers(self) -> Metadata:


### PR DESCRIPTION
## What does this PR address?

**feat: Add `task_id` tracking to request inference context**

### Description
This PR introduces `task_id` tracking in `Inference context request state`, making `task_id` accessible within API functions with the task decorator by accessing `ctx.request.state.task_id`. Based on the starlette documentation the request.state attribute is there to add additional information. This provides access to `task_id` across task functions, setting up support for features like state management and task control (e.g., pausing/resuming #5058).

Key changes:
- Adds `task_id` to `ctx.request.state`, available during task execution.
- Enables task functions to retrieve `task_id` directly, improving task observability.

Edit:
Initially I put the task_id in the response context, but after the comment from @frostming I modified it to be contained within the request context since the response context is mainly for modifying the properties of the response to be returned and task_id is a fixed value and therefore fits better in the request inference context.

---

## Before submitting:

- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? 
- [ ] Does the code follow BentoML's code style, `pre-commit run -a` script has passed?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Documentation has been updated accordingly.
- [ ] Added tests to cover the new feature’s behavior.