### PR TITLE
fix: use kantoku instead of circus

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "aiohttp",
     "attrs>=22.2.0",
     "cattrs>=22.1.0,<23.2.0",
-    "circus>=0.17.0,!=0.17.2",
+    "kantoku>=0.18.1",
     "click>=7.0",
     "click-option-group",
     "cloudpickle>=2.0.0",


### PR DESCRIPTION
Have to fork for Python3.13