### PR TITLE
feat(metrics): init zero for request count of apis

### DIFF
--- a/src/_bentoml_impl/worker/service.py
+++ b/src/_bentoml_impl/worker/service.py
@@ -186,6 +186,7 @@ def main(
     BentoMLContainer.development_mode.set(development_mode)
 
     server_context.service_name = service.name
+    server_context.service_apis = [api for api in service.apis.keys()]
     if service.bento is None:
         server_context.bento_name = service.name
         server_context.bento_version = "not available"

--- a/src/_bentoml_impl/worker/service.py
+++ b/src/_bentoml_impl/worker/service.py
@@ -186,7 +186,7 @@ def main(
     BentoMLContainer.development_mode.set(development_mode)
 
     server_context.service_name = service.name
-    server_context.service_apis = [api for api in service.apis.keys()]
+    server_context.service_routes = [api.route for api in service.apis.values()]
     if service.bento is None:
         server_context.bento_name = service.name
         server_context.bento_version = "not available"

--- a/src/bentoml/_internal/context.py
+++ b/src/bentoml/_internal/context.py
@@ -225,7 +225,7 @@ class _ComponentContext:
     service_type: str | None = None
     service_name: str | None = None
     worker_index: int | None = None
-    service_apis: list[str] = attr.field(factory=list)
+    service_routes: list[str] = attr.field(factory=list)
 
     @property
     def component_type(self) -> str | None:

--- a/src/bentoml/_internal/context.py
+++ b/src/bentoml/_internal/context.py
@@ -225,6 +225,7 @@ class _ComponentContext:
     service_type: str | None = None
     service_name: str | None = None
     worker_index: int | None = None
+    service_apis: list[str] = attr.field(factory=list)
 
     @property
     def component_type(self) -> str | None:

--- a/src/bentoml/_internal/server/http/instruments.py
+++ b/src/bentoml/_internal/server/http/instruments.py
@@ -207,6 +207,23 @@ class RunnerTrafficMetricsMiddleware:
             documentation="Total number of bytes sent to websocket",
             labelnames=["endpoint", "service_name", "service_version", "runner_name"],
         )
+        # place holder metrics to initialize endpoints with 0 to facilitate rate calculation
+        # otherwise, rate() can be 0 if the endpoint is hit for the first time
+        for endpoint in server_context.service_apis:
+            self.metrics_request_total.labels(
+                endpoint=endpoint,
+                service_name=server_context.bento_name,
+                service_version=server_context.bento_version,
+                http_response_code=200,
+                runner_name=server_context.service_name,
+            )
+            self.metrics_request_total.labels(
+                endpoint=endpoint,
+                service_name=server_context.bento_name,
+                service_version=server_context.bento_version,
+                http_response_code=500,
+                runner_name=server_context.service_name,
+            )
         self._is_setup = True
 
     async def __call__(

--- a/src/bentoml/_internal/server/http/instruments.py
+++ b/src/bentoml/_internal/server/http/instruments.py
@@ -209,7 +209,7 @@ class RunnerTrafficMetricsMiddleware:
         )
         # place holder metrics to initialize endpoints with 0 to facilitate rate calculation
         # otherwise, rate() can be 0 if the endpoint is hit for the first time
-        for endpoint in server_context.service_apis:
+        for endpoint in server_context.service_routes:
             self.metrics_request_total.labels(
                 endpoint=endpoint,
                 service_name=server_context.bento_name,


### PR DESCRIPTION
This initializes endpoints metrics with 0 request count. This way, doing `rate()` in PromQL will correctly capture the rate of change. Currently,  if it's the first time an endpoint returns error, metric is incremented to 1, but 0 value is not recorded. `rate()` will show 0 for error counts. Also imo we don't have to enumerate all http code, which spams the metrics, but we can. 
![Screenshot 2025-01-16 at 6 48 04 PM](https://github.com/user-attachments/assets/c6647914-cbcf-4a97-b8a4-427bef30fe40)
