### PR TITLE
fix: mounted apps don't eagerly match path prefix

### DIFF
--- a/src/_bentoml_impl/server/app.py
+++ b/src/_bentoml_impl/server/app.py
@@ -31,6 +31,7 @@ from bentoml.exceptions import ServiceUnavailable
 
 from ..tasks import ResultStatus
 from ..tasks import Sqlite3Store
+from .mount import PassiveMount
 
 if t.TYPE_CHECKING:
     from opentelemetry.sdk.trace import Span
@@ -178,7 +179,7 @@ class ServiceAppFactory(BaseAppFactory):
         app.add_route("/schema.json", self.schema_view, name="schema")
 
         for mount_app, path, name in self.service.mount_apps:
-            app.mount(app=mount_app, path=path, name=name)
+            app.router.routes.append(PassiveMount(path, mount_app, name=name))
 
         if self.is_main:
             if BentoMLContainer.new_index:

--- a/src/_bentoml_impl/server/mount.py
+++ b/src/_bentoml_impl/server/mount.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from starlette.applications import Starlette
+from starlette.routing import Match
+from starlette.routing import Mount
+from starlette.types import Scope
+
+
+class PassiveMount(Mount):
+    """A subclass of mount that doesn't match the path prefix eagerly."""
+
+    def matches(self, scope: Scope) -> tuple[Match, Scope]:
+        match, child_scope = super().matches(scope)
+        if match == Match.FULL and isinstance(self.app, Starlette):
+            scope = {**scope, **child_scope}
+            partial_match: Match | None = None
+            for route in self.app.routes:
+                child_match, _ = route.matches(scope)
+                if child_match == Match.FULL:
+                    return child_match, child_scope
+                if child_match == Match.PARTIAL and partial_match is None:
+                    partial_match = child_match
+
+            if partial_match is not None:
+                return partial_match, child_scope
+            return Match.NONE, child_scope
+        return match, child_scope


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

## What does this PR address?

With this change, the following will be possible:

```python
import bentoml
from fastapi import FastAPI

app = FastAPI()


@app.get("/hello")
def hello():
    return {"Hello": "World"}


@bentoml.service
@bentoml.asgi_app(app, path="/")
class MyService:
    pass
```
Visiting `/` renders the swagger page, and visiting `/hello` gives the fastapi response. Previously, the app mounted at the root path `/` will shadow all internal endpoints