### PR TITLE
feat/support label service

### DIFF
--- a/src/_bentoml_sdk/service/factory.py
+++ b/src/_bentoml_sdk/service/factory.py
@@ -75,6 +75,7 @@ class Service(t.Generic[T]):
     inner: type[T]
     image: t.Optional[Image] = None
     envs: t.List[BentoEnvSchema] = attrs.field(factory=list, converter=convert_envs)
+    labels: t.Dict[str, t.Any] = attrs.field(factory=dict)
     bento: t.Optional[Bento] = attrs.field(init=False, default=None)
     models: list[Model[t.Any]] = attrs.field(factory=list)
     apis: dict[str, APIMethod[..., t.Any]] = attrs.field(factory=dict)
@@ -424,6 +425,7 @@ def service(
     *,
     image: Image | None = None,
     envs: list[dict[str, t.Any]] | None = None,
+    labels: dict[str, t.Any] | None = None,
     **kwargs: Unpack[Config],
 ) -> _ServiceDecorator: ...
 
@@ -434,6 +436,7 @@ def service(
     *,
     image: Image | None = None,
     envs: list[dict[str, t.Any]] | None = None,
+    labels: dict[str, t.Any] | None = None,
     **kwargs: Unpack[Config],
 ) -> t.Any:
     """Mark a class as a BentoML service.
@@ -451,7 +454,13 @@ def service(
     def decorator(inner: type[T]) -> Service[T]:
         if isinstance(inner, Service):
             raise TypeError("service() decorator can only be applied once")
-        return Service(config=config, inner=inner, image=image, envs=envs or [])
+        return Service(
+            config=config,
+            inner=inner,
+            image=image,
+            envs=envs or [],
+            labels=labels or {},
+        )
 
     return decorator(inner) if inner is not None else decorator
 

--- a/src/bentoml/_internal/bento/bento.py
+++ b/src/bentoml/_internal/bento/bento.py
@@ -281,6 +281,7 @@ class Bento(StoreItem):
                 else to_snake_case(svc.name)
             )
             build_config.envs.extend(svc.envs)
+            build_config.labels.update(svc.labels)
             if svc.image is not None:
                 image = svc.image
         if image is None and not disable_image:


### PR DESCRIPTION
- **fix: stop spinner before starting to stream logs (#4846)**
- **docs: Add azure byoc setup doc (#4847)**
- **Update azure.rst**
- **docs: Update the BYOC architecture image (#4848)**
- **fix: fix error message with trace id (#4853)**
- **doc: locking (#4850)**
- **fix(containerize): command to create group and user in alpine base image (#4855)**
- **fix: encode special charaters in path (#4854)**
- **doc: locking for platform (#4858)**
- **fix: correct the params passed to keras.save_model (#4857)**
- **fix: change forbid extra keys to false for bentocloud (#4866)**
- **feat(dev): 1.3 (#4849)**
- **fix: delete cluster and ns if it is first cluster (#4869)**
- **fix: auto login confirm ask logic (#4864)**
- **fix: secret default value (#4870)**
- **fix: fix typo in error msg (#4871)**
- **docs: Add 2 examples (#4872)**
- **docs: update theme to match branding (#4874)**
- **docs: Add task doc (#4873)**
- **fix: set prometheus env before importing service (#4875)**
- **docs: Add API docs (#4877)**
- **fix: inject prometheus env from arbiter (#4878)**
- **fix: Don't run bentoml.build_bentofile in subprocess (#4876)**
- **docs: update azure byoc instructions (#4881)**
- **docs(azure): update azure byoc instructions (#4882)**
- **fix(framework): transformers vs 1.3.0 "TypeError: __init__() got an unexpected keyword argument 'task'" (#4880)**
- **fix: silence git output (#4883)**
- **fix: surface config error on bento build (#4888)**
- **docs: Refactor tasks doc (#4890)**
- **Docs: Sync the BYOC doc with blog and update BentoCloud guides index page (#4891)**
- **fix: move user setup to base template to make custom base image work (#4893)**
- **fix: Cannot define custom duration histogram buckets via `@bentoml.service(metrics=...)` (#4895)**
- **fix: press text (#4898)**
- **ci: pre-commit autoupdate (#4897)**
- **docs: Update doc images (#4901)**
- **fix: fix resource type (#4904)**
- **fix: direct return response if tracer id is null (#4899)**
- **docs: update azure byoc instructions (#4905)**
- **fix: metrics duration defined with min,max,factor not taking effect (#4903)**
- **refactor: store the cloud context into the container instead of passing it around (#4907)**
- **docs: Update README.md (#4906)**
- **docs: Update messages (#4910)**
- **docs: Update index.rst (#4913)**
- **doc: update the HTTP behavior test instruction (#4915)**
- **docs: Add metrics doc (#4912)**
- **feat(cli): reload option for start-http-server (#4916)**
- **chore: update pdm.lock file witht the lock targets (#4911)**
- **fix(build): preserve the index url options in requirements.txt file (#4914)**
- **fix: try to fix the timeout test cases (#4917)**
- **doc: update CI status badge (#4918)**
- **fix(keras): compatibility with Keras 3.4.0 (#4922)**
- **fix(cli): do not hide output behind a spinner for building bento (#4923)**
- **feat: expose client url and sync client (#4925)**
- **fix: always preserve str and bytes when serializing (#4929)**
- **fix(cloud-client): raise error if multipart push fails (#4932)**
- **feat: Pass torch kwargs to bentoml.pytorch.load_model (#4930)**
- **docs: Add function calling example link (#4934)**
- **fix: pydantic/numpy patching causes `Cannot interpret 'numpy.float16 | numpy.float32' as a data type` (#4933)**
- **fix: uploading large files saving to disk instead of memory (#4935)**
- **fix: don't use temporary directory for temp bento copying (#4938)**
- **refactor: path spec ignore pattern checks children files only (#4939)**
- **fix: improve exception handling for pynvml (#4943)**
- **doc: update cloud deploy with yaml guide (#4944)**
- **doc: fix instructions of http testing (#4945)**
- **chore(deps): bump protobufjs from 7.2.4 to 7.2.6 in /grpc-client/node (#4647)**
- **chore(deps): bump transformers from 4.30.0 to 4.38.0 in /examples/inference-graph (#4695)**
- **chore(deps): bump h2 from 0.3.24 to 0.3.26 in /grpc-client/rust (#4635)**
- **chore(deps): bump tar from 6.1.11 to 6.2.1 in /grpc-client/node (#4650)**
- **chore(deps): bump mio from 0.8.8 to 0.8.11 in /grpc-client/rust (#4550)**
- **fix: bentoml.serve to support serving new SDK services from a bento (#4946)**
- **docs: Let search engine ignore 1.1 doc (#4950)**
- **docs: Update readme example links (#4951)**
- **ci: pre-commit autoupdate [skip ci] (#4953)**
- **fix: don't pull models if already exists when puling bento (#4954)**
- **feat: lock packages for linux by default (#4955)**
- **chore(deps): bump actions/download-artifact from 3 to 4.1.7 in /.github/workflows in the github_actions group across 1 directory (#4957)**
- **docs: Add function calling example doc (#4956)**
- **docs: Add a placeholder RAG doc (#4959)**
- **fix: support pydantic 2.9 (#4960)**
- **fix: retry for model and bento upload failure (#4961)**
- **fix: reload plugin missing file changes (#4958)**
- **chore(ci): release workflow fix (#4962)**
- **fix: on_deployment failed to run for serve_grpc (#4963)**
- **doc: include cli commands in secret doc (#4968)**
- **fix: switch back to post-release version scheme (#4969)**
- **doc: Add documentation about platform option of bentoml build (#4966)**
- **fix: only add bentoml requirement if absent (#4973)**
- **fix: null filename causes parsing failure for image input (#4976)**
- **doc: add instruction for `bentoml.IODescriptor` (#4975)**
- **chore: update login error message (#4952)**
- **chore: remove grpc client (#4983)**
- **fix: persist trace across internal requests (#4982)**
- **feat: expose request id and trace id in request scope (#4977)**
- **fix: add secrets in update/apply commands (#4985)**
- **feat: support model loading preheat**
- **feat: lazy model reference**
- **feat: add huggingface endpoint**
- **fix: export members at top  module**
- **feat: save huggingface models to BENTOML_HF_CACHE_DIR**
- **fix: freeze model version when serving a bento**
- **feat: create placeholders for non-bentoml models**
- **fix: add endpoint and url to metadata**
- **fix: append to model info list**
- **feat: drop python 3.8 for the coming EOL (#4948)**
- **fix: switch to questionary**
- **feat: normalize tag for huggingface models**
- **fix: huggingface model push**
- **feat: remote development (#4942)**
- **fix: report upload success for bare bento**
- **feat(cli): support passing env without value (#4967)**
- **fix: clean_bentoml_version in build_requirements**
- **fix: correct the bentoml requirement string**
- **fix: incorrect sync file logic**
- **refactor(1.4): Make the cloud client APIs more structured and aligned (#4972)**
- **feat: add --wait option to deployment terminate**
- **feat(framework): unsloth (#4949)**
- **feat: lazy import context manager (#4978)**
- **fix: filter deployments not by current user**
- **feat: sync editable bentoml to remote (#4981)**
- **feat: remote dependency (#4965)**
- **fix: don't shadow error when pushing models**
- **doc: update quick start to use bentoml importing context manager (#4986)**
- **fix: make spinner optional for backward compatibility (#4987)**
- **fix: don't initialize cloud client until needed (#4989)**
- **doc: fix typo in model composition (#4991)**
- **refactor: unify same schema (#4988)**
- **fix(framework): export unsloth lazily (#4992)**
- **fix: compare bento manifest and dependency client (#4993)**
- **fix: structure bento manifest (#4994)**
- **fix: allow setting timeout for cloud client (#4995)**
- **fix: with_defaults for docker option and show diff report for bento manifest comparison (#4996)**
- **docs: Add ShieldGemma example doc (#4997)**
- **fix: do not initialize cloud client when building bento (#4998)**
- **doc: Update shieldgemma doc name (#4999)**
- **fix: tolerate build error when watching for changes (#5000)**
- **doc: correct the requirements (#5001)**
- **fix: expose errors occurring before the first yield of stream response (#5002)**
- **doc: fix endpoint url related typos (#5007)**
- **docs: Add CUDA version notes (#5004)**
- **docs: Add new project examples (#5010)**
- **docs: Clean up examples (#5011)**
- **docs: Update adaptive batching doc (#5012)**
- **docs: Refactor more examples section (#5014)**
- **ci: pre-commit autoupdate [skip ci] (#5009)**
- **feat: upload setup.sh to the remote dev (#5016)**
- **feat: always make an HTTP call when calling self API methods (#5017)**
- **feat: gradio integration (#5008)**
- **Fix a typo (#5018)**
- **docs: Add quotation marks to python versions (#5019)**
- **fix: add a flag to mark dev bento (#5021)**
- **docs: Fix typo (#5022)**
- **fix: circus graceful shutdown (#5024)**
- **fix: emit deprecation warings for legacy APIs (#5023)**
- **fix: skip safetensor patching if not installed (#5025)**
- **doc: update aws byoc (#5026)**
- **fix: [bug bash] prefetch url (#5028)**
- **fix: trigger reset when system package changes; find dependent (#5027)**
- **fix(decorator): reject wrapper as dunder methods (#5030)**
- **fix: upload a flag file after project ready (#5029)**
- **fix: update spinner with the service readyz status (#5031)**
- **docs: Add IO tables (#5032)**
- **docs: Create secrets for deployment (#5034)**
- **doc: api docs for build and build_bentofile (#5035)**
- **feat: validate required envs when creating deployment (#5033)**
- **docs: fix links (#5036)**
- **docs: Add Gradio integration (#5040)**
- **fix: remove duplicate logs (#5038)**
- **docs: Add byoc request quota (#5037)**
- **feat: Opt-in bento image support (#5039)**
- **feat: support reading build config and dependencies from pyproject.toml (#5042)**
- **docs: Add doc for external deployment dependency (#5043)**
- **docs: Add Base Hyperlint Config (#5041)**
- **fix: reconstruct build config for getting requirement (#5045)**
- **docs: Add LangGraph example doc (#5046)**
- **docs: Add codespaces doc (#5044)**
- **fix: spark usage following API change (#5052)**
- **docs: Add model loading doc (#5049)**
- **doc: suggest to use pip for CUDA first (#5054)**
- **docs: Update build-options.rst (#5055)**
- **fix: use the model revision in bento info for huggingface models (#5053)**
- **feat: Adding SDK support for deployment labels (#5057)**
- **fix: postpone the model id normalization for huggingface models (#5060)**
- **chore: upload descripiton to remote bento store (#5047)**
- **ci: pre-commit autoupdate [skip ci] (#5061)**
- **feat: Add task_id to request inference context (#5059)**
- **chore: copy existing README.md instead of creating a new one (#5063)**
- **feat: allow extending bentoml with extra commands (#5064)**
- **fix: remove the version limit of pynvml (#5068)**
- **fix: correct file response for internal service calling (#5071)**
- **docs: Add explanations for model loading acceleration (#5066)**
- **docs: Refactor examples (#5065)**
- **docs: Update codespaces desc (#5072)**
- **fix: don't ignore empty dirs when unpacking model and bento (#5073)**
- **docs: Remove dead link (#5075)**
- **docs: Add doc canonical link (#5076)**
- **doc: add comfyui example (#5077)**
- **doc: update comfyui to include export instructions (#5078)**
- **doc: update diffusion models to include comfyui (#5079)**
- **docs: Update examples index (#5080)**
- **fix: move monitoring project to tests folder (#5081)**
- **docs: Update example list (#5083)**
- **fix: check dependency close method (#5082) (#5084)**
- **fix: empty doc for bare built bento (#5086)**
- **fix: build git repo with uv (#5085)**
- **fix: use the model_id in bento (#5087)**
- **fix: create dir before move (#5088)**
- **docs: update `buf.yaml` reference (#5090)**
- **fix: read stream before accessing response.text (#5091)**
- **fix: set manifest.dev for bare bento upload (#5092)**
- **fix: pin pydantic to < 2.10 and restore cwd when building bento (#5093)**
- **docs: doc refactoring (WIP) (#5089)**
- **docs: Fix invalid icon images (#5096)**
- **docs: Update readme examples and add distributed service doc (#5097)**
- **fix: protect model repository creation with a lock to avoid a race condition (#5095)**
- **fix: generate schema compatible with pydantic>=2.10 (#5100)**
- **docs: Modify 'metric' menu link on 'observability index' page (#5101)**
- **fix: fix bug of serialization error and runner can't be shutdown (#5103)**
- **feat(cli): Support passing key value pairs from reading a dotenv file (#5104)**
- **fix: calculate readme file path from build ctx rather than cwd (#5106)**
- **ci: pre-commit autoupdate [skip ci] (#5108)**
- **docs: Simplify Adaptive batching docs (#5107)**
- **docs: Update homepage messaging (#5105)**
- **fix: add basic metrics and access logs for websocket (#5109)**
- **fix: ensure all models to exists on deployment (#5110)**
- **fix: enable image spec when image is explictly given (#5114)**
- **fix: drop the redundant parameter for runner_service (#5115)**
- **docs: Fix links (#5111)**
- **feat: support post commands in image spec (#5118)**
- **feat: add `--with-models` option to `bentoml pull` command (#5117)**
- **docs: Update cloud deployment doc (#5119)**
- **docs: Fix typo (#5121)**
- **docs: Fix links (#5122)**
- **fix: calculate bentofile path against cwd if given explicitly (#5123)**
- **docs: Simplify packaging docs (#5116)**
- **docs: Fix links (#5124)**
- **docs: Update API tokens doc (#5125)**
- **fix: image builder log stream doesn't work (#5126)**
- **docs: Add GPU access messaging (#5127)**
- **fix: disable markup and highlight for image log stream (#5129)**
- **fix: don't override built-in function (#5131)**
- **fix: add default install command for image spec (#5130)**
- **docs: Update examples (#5128)**
- **fix: loosen the constraints of opentelemetry dependencies (#5134)**
- **fix: only honor ctx or context parameter with correct annotation (#5135)**
- **fix: temp file is deleted unexpected on Windows (#5133)**
- **docs: Update old comfyui doc (#5137)**
- **feat: install packages into venv and chown (#5136)**
- **docs: Update onboarding docs (#5138)**
- **fix: raise error when certfile is not given but ssl enabled and fix local dep (#5139)**
- **fix: bad file descirptor issue when deploying bento (#5142)**
- **feat: select a subset of files for huggingface models (#5144)**
- **docs: Update example overview (#5143)**
- **docs: Fix images (#5145)**
- **fix: use content hash as the default model version (#5146)**
- **docs: Simplify model composition doc (#5147)**
- **docs: Restructure image folder and add alt for SEO (#5150)**
- **docs: Fix links (#5153)**
- **docs: Merge examples to io type doc (#5152)**
- **fix: permission issue of uv python installation directory (#5151)**
- **fix: lazy safetensor patch (#5149)**
- **docs: Clean up examples folder (#5154)**
- **fix: use kantoku instead of circus (#5155)**
- **fix: Update lock file (#5156)**
- **fix: use emoji code instead of emoji char (#5157)**
- **fix: set model revision correctly (#5158)**
- **fix: add missing secrets params in bentoml sdk (#5159)**
- **fix: expose cloud api to get a single model (#5160)**
- **fix: use the same spinner for bento and model apis (#5161)**
- **fix: closed file descriptior issue (#5162)**
- **fix: turn off build log stream in jupyter notebook (#5165)**
- **docs: Add notes for loading HF private models (#5166)**
- **fix: patch annotations inside a container type (#5167)**
- **Add logging for service cleanup hooks in new-style BentoML services (#5171)**
- **ci: pre-commit autoupdate [skip ci] (#5170)**
- **fix: set the arbiter thread to be daemon thread (#5172)**
- **chore(analytics): use utils `is_jupyter` to determine notebook state (#5173)**
- **docs: Add comfyUI example doc (#5148)**
- **fix: allow building bento without build config file (#5175)**
- **fix: Remove distutils dependency (#5179)**
- **docs: Add streaming and websocket docs (#5180)**
- **docs: Update ASGI decorator (#5182)**
- **fix: allow usage like bentoml deploy service:MyService (#5181)**
- **docs: Update Gradio example link (#5183)**
- **fix: use a specific manylinux version as build platform for better compatibility (#5185)**
- **feat(metrics): init zero for request count of apis (#5186)**
- **docs: correct types for example (#5188)**
- **fix: make all top-level attributes lazy (#5184)**
- **fix: mounted apps don't eagerly match path prefix (#5190)**
- **chore: add spec into bento manifest schema (#5192)**
- **fix: get commit id from requested revision when it is missing (#5193)**
- **feat: add @bentoml.on_startup decorator (#5194)**
- **fix: conditionally include endpoint_urls in deployment dictionary (#5195)**
- **fix: enable image spec by default (#5197)**
- **ci: pre-commit autoupdate [skip ci] (#5200)**
- **docs: update AWS byoc cloudformation template (#5201)**
- **feat: support running scripts in new image spec (#5196)**
- **fix: add line endings for python_packages(...) (#5203)**
- **fix: correct the log for locking platform (#5205)**
- **fix: uv installation in container (#5206)**
- **fix: add cluster option for secrets command (#5209)**
- **fix(build): setattr frozen sets (#5207)**
- **fix:correct context path when serving from bento (#5210)**
- **feat(service): add support for labels definition at service-level**

## What does this PR address?

<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->

Fixes #(issue)

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
