### PR TITLE
Fix RunPod unhashable model error by converting svc.models to hashable ids

### DIFF
--- a/src/bentoml/_internal/utils/analytics/usage_stats.py
+++ b/src/bentoml/_internal/utils/analytics/usage_stats.py
@@ -175,7 +175,8 @@ def _track_serve_init(
                 if svc.name in seen:
                     return set()
                 seen.add(svc.name)
-                models = set(svc.models)
+                # Fix: Ensure models are hashable by using id()
+                models = {id(model) for model in svc.models} if isinstance(svc.models, list) else {id(svc.models)}
                 for dep in svc.dependencies.values():
                     if dep.on is not None:
                         models.update(_get_models(dep.on, seen))

--- a/src/bentoml/_internal/utils/analytics/usage_stats.py
+++ b/src/bentoml/_internal/utils/analytics/usage_stats.py
@@ -176,7 +176,11 @@ def _track_serve_init(
                     return set()
                 seen.add(svc.name)
                 # Fix: Ensure models are hashable by using id()
-                models = {id(model) for model in svc.models} if isinstance(svc.models, list) else {id(svc.models)}
+                models = (
+                    {id(model) for model in svc.models}
+                    if isinstance(svc.models, list)
+                    else {id(svc.models)}
+                )
                 for dep in svc.dependencies.values():
                     if dep.on is not None:
                         models.update(_get_models(dep.on, seen))

--- a/src/bentoml/_internal/utils/analytics/usage_stats.py
+++ b/src/bentoml/_internal/utils/analytics/usage_stats.py
@@ -167,20 +167,13 @@ def _track_serve_init(
                 )
             )
         else:
-            from _bentoml_sdk.models import Model
 
-            def _get_models(
-                svc: NewService[t.Any], seen: set[str]
-            ) -> t.Set[Model[t.Any]]:
+            def _get_models(svc: NewService[t.Any], seen: set[str]) -> set[int]:
                 if svc.name in seen:
                     return set()
                 seen.add(svc.name)
                 # Fix: Ensure models are hashable by using id()
-                models = (
-                    {id(model) for model in svc.models}
-                    if isinstance(svc.models, list)
-                    else {id(svc.models)}
-                )
+                models = {id(model) for model in svc.models}
                 for dep in svc.dependencies.values():
                     if dep.on is not None:
                         models.update(_get_models(dep.on, seen))


### PR DESCRIPTION
✅ Issue: TypeError: unhashable type: 'list'
✅ Cause: svc.models returned a list, which set() cannot handle.
✅ Fix: Convert each model to id(model), making it hashable.
✅ Branch Name: fix-runpod-unhashable-model-error
✅ Commit Message: "Fix RunPod unhashable model error by converting svc.models to hashable IDs"