### PR TITLE
feat(serve): add `--env` and inject service-defined envs to serving environment

### DIFF
--- a/src/_bentoml_impl/server/serving.py
+++ b/src/_bentoml_impl/server/serving.py
@@ -263,7 +263,7 @@ def serve_http(
                         backlog,
                         allocator,
                         str(bento_path.absolute()),
-                        env=dependency_env,
+                        env={k: str(v) for k,v in dependency_env.items()},
                     )
                     watchers.append(new_watcher)
                     sockets.append(new_socket)
@@ -341,7 +341,7 @@ def serve_http(
                 working_dir=str(bento_path.absolute()),
                 numprocesses=num_workers,
                 close_child_stdin=not development_mode,
-                env=env,
+                env={k: str(v) for k,v in env.items()},
             )
         )
 

--- a/src/_bentoml_impl/server/serving.py
+++ b/src/_bentoml_impl/server/serving.py
@@ -180,6 +180,7 @@ def serve_http(
     from bentoml._internal.utils import reserve_free_port
     from bentoml._internal.utils.analytics.usage_stats import track_serve
     from bentoml._internal.utils.circus import create_standalone_arbiter
+    from bentoml.exceptions import BentoMLException
     from bentoml.serving import construct_ssl_args
     from bentoml.serving import construct_timeouts_args
     from bentoml.serving import create_watcher
@@ -200,6 +201,19 @@ def serve_http(
     bento_identifier = svc.import_string
     bento_path = pathlib.Path(svc.working_dir)
 
+    # Process environment variables from the service
+    for env_var in svc.envs:
+        if env_var.value:
+            env[env_var.name] = env_var.value
+        elif env_var.name in os.environ:
+            env[env_var.name] = os.environ[env_var.name]
+        else:
+            # Raise an error if a required environment variable is not set
+            raise BentoMLException(
+                f"Environment variable '{env_var.name}' is required but not set. "
+                f"Either set it in the environment or provide a default value in the service definition."
+            )
+
     watchers: list[Watcher] = []
     sockets: list[CircusSocket] = []
     allocator = ResourceAllocator()
@@ -218,6 +232,20 @@ def serve_http(
                         continue
                     if name in dependency_map:
                         continue
+
+                    # Process environment variables for dependency services
+                    dependency_env = env.copy()
+                    for env_var in dep_svc.envs:
+                        if env_var.value:
+                            dependency_env[env_var.name] = env_var.value
+                        elif env_var.name in os.environ:
+                            dependency_env[env_var.name] = os.environ[env_var.name]
+                        else:
+                            raise BentoMLException(
+                                f"Environment variable '{env_var.name}' is required for service '{name}' but not set. "
+                                f"Either set it in the environment or provide a default value in the service definition."
+                            )
+
                     new_watcher, new_socket, uri = create_dependency_watcher(
                         bento_identifier,
                         dep_svc,
@@ -226,7 +254,7 @@ def serve_http(
                         backlog,
                         allocator,
                         str(bento_path.absolute()),
-                        env=env,
+                        env=dependency_env,
                     )
                     watchers.append(new_watcher)
                     sockets.append(new_socket)

--- a/src/_bentoml_impl/server/serving.py
+++ b/src/_bentoml_impl/server/serving.py
@@ -173,7 +173,6 @@ def serve_http(
     dependency_map: dict[str, str] | None = None,
     service_name: str = "",
     threaded: bool = False,
-    command_env_vars: list[dict[str, str]] | None = None,
 ) -> Server:
     from circus.sockets import CircusSocket
 
@@ -201,9 +200,6 @@ def serve_http(
         svc = load(bento_identifier, working_dir)
     bento_identifier = svc.import_string
     bento_path = pathlib.Path(svc.working_dir)
-
-    if command_env_vars:
-        env.update({env_var["name"]: env_var["value"] for env_var in command_env_vars})
 
     # Process environment variables from the service
     for env_var in svc.envs:

--- a/src/_bentoml_impl/server/serving.py
+++ b/src/_bentoml_impl/server/serving.py
@@ -263,7 +263,7 @@ def serve_http(
                         backlog,
                         allocator,
                         str(bento_path.absolute()),
-                        env={k: str(v) for k,v in dependency_env.items()},
+                        env={k: str(v) for k, v in dependency_env.items()},
                     )
                     watchers.append(new_watcher)
                     sockets.append(new_socket)
@@ -341,7 +341,7 @@ def serve_http(
                 working_dir=str(bento_path.absolute()),
                 numprocesses=num_workers,
                 close_child_stdin=not development_mode,
-                env={k: str(v) for k,v in env.items()},
+                env={k: str(v) for k, v in env.items()},
             )
         )
 

--- a/src/bentoml_cli/serve.py
+++ b/src/bentoml_cli/serve.py
@@ -8,8 +8,6 @@ import typing as t
 import click
 import rich
 
-from .deployment import convert_env_to_dict
-
 if t.TYPE_CHECKING:
     P = t.ParamSpec("P")
     F = t.Callable[P, t.Any]
@@ -52,6 +50,7 @@ def build_serve_command() -> click.Group:
     from bentoml._internal.configuration.containers import BentoMLContainer
     from bentoml._internal.log import configure_server_logging
     from bentoml.grpc.utils import LATEST_PROTOCOL_VERSION
+    from bentoml_cli.env_manager import env_manager
     from bentoml_cli.utils import AliasCommand
     from bentoml_cli.utils import BentoMLCommandGroup
 
@@ -193,12 +192,7 @@ def build_serve_command() -> click.Group:
         show_default=True,
         hidden=True,
     )
-    @click.option(
-        "--env",
-        type=click.STRING,
-        help="List of environment variables pass by --env key[=value] --env ...",
-        multiple=True,
-    )
+    @env_manager
     def serve(  # type: ignore (unused warning)
         bento: str,
         development: bool,
@@ -218,7 +212,6 @@ def build_serve_command() -> click.Group:
         ssl_ciphers: str | None,
         timeout_keep_alive: int | None,
         timeout_graceful_shutdown: int | None,
-        env: tuple[str] | None,
         **attrs: t.Any,
     ) -> None:
         """Start a HTTP BentoServer from a given 🍱
@@ -335,7 +328,6 @@ def build_serve_command() -> click.Group:
                 reload=reload,
                 timeout_keep_alive=timeout_keep_alive,
                 timeout_graceful_shutdown=timeout_graceful_shutdown,
-                command_env_vars=convert_env_to_dict(env),
             )
 
     @cli.command(name="serve-grpc", hidden=True)
@@ -455,12 +447,6 @@ def build_serve_command() -> click.Group:
         default=LATEST_PROTOCOL_VERSION,
         show_default=True,
     )
-    @click.option(
-        "--env",
-        type=click.STRING,
-        help="List of environment variables pass by --env key[=value] --env ...",
-        multiple=True,
-    )
     def serve_grpc(  # type: ignore (unused warning)
         bento: str,
         development: bool,
@@ -477,7 +463,6 @@ def build_serve_command() -> click.Group:
         enable_channelz: bool,
         max_concurrent_streams: int | None,
         protocol_version: str,
-        env: tuple[str] | None,
         **attrs: t.Any,
     ):
         """Start a gRPC BentoServer from a given 🍱

--- a/src/bentoml_cli/serve.py
+++ b/src/bentoml_cli/serve.py
@@ -8,6 +8,8 @@ import typing as t
 import click
 import rich
 
+from .deployment import convert_env_to_dict
+
 if t.TYPE_CHECKING:
     P = t.ParamSpec("P")
     F = t.Callable[P, t.Any]
@@ -192,6 +194,12 @@ def build_serve_command() -> click.Group:
         show_default=True,
         hidden=True,
     )
+    @click.option(
+        "--env",
+        type=click.STRING,
+        help="List of environment variables pass by --env key[=value] --env ...",
+        multiple=True,
+    )
     @env_manager
     def serve(  # type: ignore (unused warning)
         bento: str,
@@ -212,6 +220,7 @@ def build_serve_command() -> click.Group:
         ssl_ciphers: str | None,
         timeout_keep_alive: int | None,
         timeout_graceful_shutdown: int | None,
+        env: tuple[str] | None,
         **attrs: t.Any,
     ) -> None:
         """Start a HTTP BentoServer from a given 🍱
@@ -328,6 +337,7 @@ def build_serve_command() -> click.Group:
                 reload=reload,
                 timeout_keep_alive=timeout_keep_alive,
                 timeout_graceful_shutdown=timeout_graceful_shutdown,
+                command_env_vars=convert_env_to_dict(env),
             )
 
     @cli.command(name="serve-grpc", hidden=True)
@@ -447,6 +457,12 @@ def build_serve_command() -> click.Group:
         default=LATEST_PROTOCOL_VERSION,
         show_default=True,
     )
+    @click.option(
+        "--env",
+        type=click.STRING,
+        help="List of environment variables pass by --env key[=value] --env ...",
+        multiple=True,
+    )
     @env_manager
     def serve_grpc(  # type: ignore (unused warning)
         bento: str,
@@ -464,6 +480,7 @@ def build_serve_command() -> click.Group:
         enable_channelz: bool,
         max_concurrent_streams: int | None,
         protocol_version: str,
+        env: tuple[str] | None,
         **attrs: t.Any,
     ):
         """Start a gRPC BentoServer from a given 🍱

--- a/src/bentoml_cli/serve.py
+++ b/src/bentoml_cli/serve.py
@@ -52,7 +52,6 @@ def build_serve_command() -> click.Group:
     from bentoml._internal.configuration.containers import BentoMLContainer
     from bentoml._internal.log import configure_server_logging
     from bentoml.grpc.utils import LATEST_PROTOCOL_VERSION
-    from bentoml_cli.env_manager import env_manager
     from bentoml_cli.utils import AliasCommand
     from bentoml_cli.utils import BentoMLCommandGroup
 
@@ -200,7 +199,6 @@ def build_serve_command() -> click.Group:
         help="List of environment variables pass by --env key[=value] --env ...",
         multiple=True,
     )
-    @env_manager
     def serve(  # type: ignore (unused warning)
         bento: str,
         development: bool,
@@ -463,7 +461,6 @@ def build_serve_command() -> click.Group:
         help="List of environment variables pass by --env key[=value] --env ...",
         multiple=True,
     )
-    @env_manager
     def serve_grpc(  # type: ignore (unused warning)
         bento: str,
         development: bool,


### PR DESCRIPTION
## What does this PR address?

Inject env defined under `@bentoml.service` similar to behaviour as `bentoml deploy`

this PR also remove `env_manager` (given that we barely have any data pointers on people actually using this, or we might have to think of a better way to run serve in an isolated environment)

env_manager only used in conda, so idk, good to also remove this.
