### PR TITLE
build: Smaller docker images

### DIFF
--- a/src/bentoml/_internal/container/frontend/dockerfile/templates/base.j2
+++ b/src/bentoml/_internal/container/frontend/dockerfile/templates/base.j2
@@ -63,7 +63,8 @@ WORKDIR $BENTO_PATH
 {% block SETUP_BENTO_COMPONENTS %}
 
 RUN command -v uv >/dev/null || pip install uv
-RUN UV_PYTHON_INSTALL_DIR=/app/python/ uv venv {% if __options__python_version %}-p {{ __options__python_version }}{% endif %} /app/.venv
+RUN UV_PYTHON_INSTALL_DIR=/app/python/ uv venv {% if __options__python_version %}-p {{ __options__python_version }}{% endif %} /app/.venv && \
+    chown -R {{ bento__user }}:{{ bento__user }} /app/.venv
 ENV VIRTUAL_ENV=/app/.venv
 ENV UV_COMPILE_BYTECODE=1
 
@@ -96,7 +97,6 @@ EXPOSE 3000
 EXPOSE {{ __prometheus_port__ }}
 
 RUN chmod +x {{ bento__entrypoint }}
-RUN chown {{ bento__user }}:{{ bento__user }} -R $VIRTUAL_ENV
 
 USER bentoml
 

--- a/src/bentoml/_internal/container/frontend/dockerfile/templates/base_v2.j2
+++ b/src/bentoml/_internal/container/frontend/dockerfile/templates/base_v2.j2
@@ -60,7 +60,8 @@ COPY --chown={{ bento__user }}:{{ bento__user }} ./env/docker ./env/docker/
 RUN {{ command }}
 {% endfor %}
 RUN command -v uv >/dev/null || pip install uv
-RUN UV_PYTHON_INSTALL_DIR=/app/python/ uv venv --python {{ __options__python_version }} /app/.venv
+RUN UV_PYTHON_INSTALL_DIR=/app/python/ uv venv --python {{ __options__python_version }} /app/.venv && \
+    chown -R {{ bento__user }}:{{ bento__user }} /app/.venv
 ENV VIRTUAL_ENV=/app/.venv
 ENV UV_COMPILE_BYTECODE=1
 {% set __pip_cache__ = common.mount_cache("/root/.cache/") %}
@@ -90,7 +91,6 @@ EXPOSE 3000
 EXPOSE {{ __prometheus_port__ }}
 
 RUN chmod +x {{ bento__entrypoint }}
-RUN chown {{ bento__user }}:{{ bento__user }} -R $VIRTUAL_ENV
 
 USER {{ bento__user }}
 


### PR DESCRIPTION
## What does this PR address?

In the dockerfile templates, I've chown'd the venv directories as they are created and deleted the chown that happens after the python dependencies are installed. The post-install chown creates a docker layer that's the size of all the files in the venv, which, if it contains pytorch, could be 5 gb or more. For me, this change cuts the image size from 12gb to 6.