### PR TITLE
fix: format substitution

### DIFF
--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -512,7 +512,7 @@ class PythonOptions:
     def __attrs_post_init__(self):
         if self.requirements_txt and self.packages:
             logger.warning(
-                "Build option python: 'requirements_txt={self.requirements_txt}' found, will ignore the option: 'packages=%s'.",
+                "Build option python: 'requirements_txt=%s' found, will ignore the option: 'packages=%s'.",
                 self.requirements_txt,
                 self.packages,
             )


### PR DESCRIPTION
## What does this PR address?

When setting `requirements_txt` in the bento configuration and packages (maybe from pyproject.toml) exist, this logging statement throws an exception and building the bento fails.

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.