### PR TITLE
chore: locking transformers <4.51 for quickstart tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -16,7 +16,7 @@ PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12"]
 
 FRAMEWORK_DEPENDENCIES = {
     "catboost": ["catboost", "numpy<2"],
-    "diffusers": ["diffusers", "transformers", "tokenizer"],
+    "diffusers": ["diffusers", "transformers<4.51", "tokenizer"],
     "easyocr": ["easyocr"],
     "fastai": ["fastai"],
     "flax": [

--- a/tests/e2e/bento_new_sdk/requirements.txt
+++ b/tests/e2e/bento_new_sdk/requirements.txt
@@ -1,4 +1,4 @@
 scikit-learn
 pydantic>=2
-transformers
+transformers<4.51
 torch

--- a/tests/e2e/fixtures/quickstart/requirements.txt
+++ b/tests/e2e/fixtures/quickstart/requirements.txt
@@ -1,3 +1,3 @@
 bentoml
 torch
-transformers
+transformers<=4.51.0

--- a/tests/e2e/fixtures/quickstart/requirements.txt
+++ b/tests/e2e/fixtures/quickstart/requirements.txt
@@ -1,3 +1,3 @@
 bentoml
 torch
-transformers<=4.51.0
+transformers<4.51.0


### PR DESCRIPTION
https://github.com/huggingface/transformers/issues/37326

Given that we don't need newer version of transformers for quickstart, probably ok to lock the version of transformers
