### PR TITLE
chore: disable progress bar on cloud build

### DIFF
--- a/src/bentoml/_internal/container/frontend/dockerfile/templates/base_v2.j2
+++ b/src/bentoml/_internal/container/frontend/dockerfile/templates/base_v2.j2
@@ -69,6 +69,7 @@ RUN UV_PYTHON_INSTALL_DIR=/app/python/ uv venv --python {{ __options__python_ver
     chown -R {{ bento__user }}:{{ bento__user }} /app/.venv
 ENV VIRTUAL_ENV=/app/.venv
 ENV UV_COMPILE_BYTECODE=1
+ENV UV_NO_PROGRESS=1
 ENV PATH="/app/.venv/bin:$PATH"
 {% set __pip_cache__ = common.mount_cache("/root/.cache/") %}
 {% if __pip_preheat_packages__ %}


### PR DESCRIPTION
This PR addresses the excessive spinner progress bar when installing deps from UV.

It will still show when the dependencies are finished installing

BentoVLLM has been using this for a while now, probably good to include it in the base Dockerfile template.

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
