### PR TITLE
refactor: move legacy APIs to a separate module

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -213,7 +213,7 @@ extension to include documentation from docstring. For example, a `.rst` documen
 create a section made from a Python Class's docstring, using the following syntax:
 
 ```rst
-.. autoclass:: bentoml.Service
+.. autoclass:: bentoml.Bento
     :members: api
 ```
 

--- a/docs/source/build-with-bentoml/snippets/metrics/runner_impl.py
+++ b/docs/source/build-with-bentoml/snippets/metrics/runner_impl.py
@@ -1,11 +1,14 @@
-class NLTKSentimentAnalysisRunnable(bentoml.Runnable):
+import bentoml
+
+
+class NLTKSentimentAnalysisRunnable(bentoml.legacy.Runnable):
     SUPPORTED_RESOURCES = ("cpu",)
     SUPPORTS_CPU_MULTI_THREADING = False
 
     def __init__(self):
         self.sia = SentimentIntensityAnalyzer()
 
-    @bentoml.Runnable.method(batchable=False)
+    @bentoml.legacy.Runnable.method(batchable=False)
     def is_positive(self, input_text: str) -> bool:
         start = time.perf_counter()
         scores = [

--- a/src/_bentoml_impl/frameworks/catboost.py
+++ b/src/_bentoml_impl/frameworks/catboost.py
@@ -200,12 +200,12 @@ def save_model(
 
 
 @deprecated(suggestion="Use `get_service` instead.")
-def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
+def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.legacy.Runnable]:
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
 
-    class CatBoostRunnable(bentoml.Runnable):
+    class CatBoostRunnable(bentoml.legacy.Runnable):
         SUPPORTED_RESOURCES = ("nvidia.com/gpu", "cpu")
         SUPPORTS_CPU_MULTI_THREADING = True
 

--- a/src/_bentoml_impl/frameworks/lightgbm.py
+++ b/src/_bentoml_impl/frameworks/lightgbm.py
@@ -204,12 +204,12 @@ def save_model(
 
 
 @deprecated(suggestion="Use `get_service` instead.")
-def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
+def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.legacy.Runnable]:
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
 
-    class LightGBMRunnable(bentoml.Runnable):
+    class LightGBMRunnable(bentoml.legacy.Runnable):
         # LightGBM only supports GPU during training, not for inference.
         SUPPORTED_RESOURCES = ("cpu",)
         SUPPORTS_CPU_MULTI_THREADING = True

--- a/src/_bentoml_impl/frameworks/mlflow.py
+++ b/src/_bentoml_impl/frameworks/mlflow.py
@@ -213,14 +213,14 @@ def import_model(
 
 
 @deprecated(suggestion="Use `get_service` instead.")
-def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
+def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.legacy.Runnable]:
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
     assert "predict" in bento_model.info.signatures
     predict_signature = bento_model.info.signatures["predict"]
 
-    class MLflowPyfuncRunnable(bentoml.Runnable):
+    class MLflowPyfuncRunnable(bentoml.legacy.Runnable):
         # The only case that multi-threading may not be supported is when user define a
         # custom python_function MLflow model with pure python code, but there's no way
         # of telling that from the MLflow model metadata. It should be a very rare case,
@@ -233,7 +233,7 @@ def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
             super().__init__()
             self.model = load_model(bento_model)
 
-        @bentoml.Runnable.method(
+        @bentoml.legacy.Runnable.method(
             batchable=predict_signature.batchable,
             batch_dim=predict_signature.batch_dim,
             input_spec=None,

--- a/src/_bentoml_impl/frameworks/sklearn.py
+++ b/src/_bentoml_impl/frameworks/sklearn.py
@@ -92,7 +92,7 @@ def save_model(
         name: Name for given model instance. This should pass Python identifier check.
         model: Instance of model to be saved.
         signatures: Methods to expose for running inference on the target model. Signatures are
-                    used for creating Runner instances when serving model with bentoml.Service
+                    used for creating Runner instances when serving model with bentoml.legacy.Service
         labels: user-defined labels for managing models, e.g. team=nlp, stage=dev
         custom_objects: user-defined additional python objects to be saved alongside the model,
                         e.g. a tokenizer instance, preprocessor function, model configuration json
@@ -164,7 +164,7 @@ def get_runnable(bento_model: Model):
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
 
-    class SklearnRunnable(bentoml.Runnable):
+    class SklearnRunnable(bentoml.legacy.Runnable):
         SUPPORTED_RESOURCES = ("cpu",)
         SUPPORTS_CPU_MULTI_THREADING = True
 

--- a/src/_bentoml_impl/frameworks/xgboost.py
+++ b/src/_bentoml_impl/frameworks/xgboost.py
@@ -217,12 +217,12 @@ def save_model(
 
 
 @deprecated(suggestion="Use `get_service` instead.")
-def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
+def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.legacy.Runnable]:
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
 
-    class XGBoostRunnable(bentoml.Runnable):
+    class XGBoostRunnable(bentoml.legacy.Runnable):
         SUPPORTED_RESOURCES = ("nvidia.com/gpu", "cpu")
         SUPPORTS_CPU_MULTI_THREADING = True
 

--- a/src/_bentoml_sdk/service/factory.py
+++ b/src/_bentoml_sdk/service/factory.py
@@ -18,7 +18,6 @@ from simple_di import inject
 from starlette.applications import Starlette
 from typing_extensions import Unpack
 
-from bentoml import Runner
 from bentoml._internal.bento.bento import Bento
 from bentoml._internal.bento.build_config import BentoEnvSchema
 from bentoml._internal.configuration.containers import BentoMLContainer
@@ -28,6 +27,7 @@ from bentoml._internal.utils import deprecated
 from bentoml._internal.utils import dict_filter_none
 from bentoml.exceptions import BentoMLConfigException
 from bentoml.exceptions import BentoMLException
+from bentoml.legacy import Runner
 
 from ..images import Image
 from ..method import APIMethod

--- a/src/bentoml/__init__.py
+++ b/src/bentoml/__init__.py
@@ -32,11 +32,6 @@ MODULE_ATTRS = {
     "server_context": "._internal.context:server_context",
     "Model": "._internal.models:Model",
     "monitor": "._internal.monitoring:monitor",
-    "Resource": "._internal.resource:Resource",
-    "Runnable": "._internal.runner:Runnable",
-    "Runner": "._internal.runner:Runner",
-    "Strategy": "._internal.runner.strategy:Strategy",
-    "Service": "._internal.service:Service",
     "Tag": "._internal.tag:Tag",
     "load": "._internal.service.loader:load",
     "Cookie": "._internal.utils.http:Cookie",
@@ -50,9 +45,6 @@ MODULE_ATTRS = {
     "pull": ".bentos:pull",
     "push": ".bentos:push",
     "serve": ".bentos:serve",
-    # Legacy APIs
-    "HTTPServer": ".server:HTTPServer",
-    "GrpcServer": ".server:GrpcServer",
     # New SDK
     "service": "_bentoml_sdk:service",
     "runner_service": "_bentoml_sdk:runner_service",
@@ -83,6 +75,7 @@ if TYPE_CHECKING:
     from _bentoml_impl.frameworks import xgboost
 
     from . import bentos
+    from . import legacy
 
     # BentoML built-in types
     from ._internal.bento import Bento
@@ -94,11 +87,6 @@ if TYPE_CHECKING:
     from ._internal.context import server_context
     from ._internal.models import Model
     from ._internal.monitoring import monitor
-    from ._internal.resource import Resource
-    from ._internal.runner import Runnable
-    from ._internal.runner import Runner
-    from ._internal.runner.strategy import Strategy
-    from ._internal.service import Service
     from ._internal.service.loader import load
     from ._internal.tag import Tag
     from ._internal.utils.args import use_arguments
@@ -176,6 +164,7 @@ else:
     FrameworkImporter.install()
 
     bentos = _LazyLoader("bentoml.bentos", globals(), "bentoml.bentos")
+    legacy = _LazyLoader("bentoml.legacy", globals(), "bentoml.legacy")
 
     # ML Frameworks
     catboost = _LazyLoader(
@@ -301,22 +290,33 @@ else:
     del _LazyLoader, FrameworkImporter
 
     def __getattr__(name: str) -> Any:
+        import bentoml.legacy as legacy
+
         if name in MODULE_ATTRS:
             from importlib import import_module
 
             module_name, attr_name = MODULE_ATTRS[name].split(":")
             module = import_module(module_name, __package__)
             return getattr(module, attr_name)
-        raise AttributeError(f"module {__name__} has no attribute {name}")
+        elif name in legacy.__all__:
+            from ._internal.utils import warn_deprecated
+
+            warn_deprecated(
+                f"`bentoml.{name}` is moved to `bentoml.legacy.{name}` "
+                "and will be removed in a future version.",
+            )
+            return getattr(legacy, name)
+        else:
+            raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
 __all__ = [
     "__version__",
     "Context",
     "Cookie",
-    "Service",
     "bentos",
     "models",
+    "legacy",
     "batch",
     "metrics",
     "container",
@@ -326,8 +326,6 @@ __all__ = [
     "io",
     "Tag",
     "Model",
-    "Runner",
-    "Runnable",
     "monitoring",
     "BentoCloudClient",  # BentoCloud REST API Client
     # bento APIs
@@ -374,8 +372,6 @@ __all__ = [
     "load_config",
     "save_config",
     "set_serialization_strategy",
-    "Strategy",
-    "Resource",
     # new SDK
     "service",
     "runner_service",

--- a/src/bentoml/_internal/frameworks/common/pytorch.py
+++ b/src/bentoml/_internal/frameworks/common/pytorch.py
@@ -56,7 +56,7 @@ def partial_class(
     return NewClass
 
 
-class PytorchModelRunnable(bentoml.Runnable):
+class PytorchModelRunnable(bentoml.legacy.Runnable):
     SUPPORTED_RESOURCES = ("nvidia.com/gpu", "cpu")
     SUPPORTS_CPU_MULTI_THREADING = True
 

--- a/src/bentoml/_internal/frameworks/detectron.py
+++ b/src/bentoml/_internal/frameworks/detectron.py
@@ -146,7 +146,7 @@ def save_model(
         name: Name for given model instance. This should pass Python identifier check.
         checkpointables: The model instance to be saved. Could be a ``detectron2.engine.DefaultPredictor`` or a ``torch.nn.Module``.
         config: Optional ``CfgNode`` for the model. Required when checkpointables is a ``torch.nn.Module``.
-        signatures: Methods to expose for running inference on the target model. Signatures are used for creating :obj:`~bentoml.Runner` instances when serving model with :obj:`~bentoml.Service`
+        signatures: Methods to expose for running inference on the target model. Signatures are used for creating :obj:`~bentoml.legacy.Runner` instances when serving model with :obj:`~bentoml.legacy.Service`
         labels: User-defined labels for managing models, e.g. ``team=nlp``, ``stage=dev``.
         custom_objects: Custom objects to be saved with the model. An example is ``{"my-normalizer": normalizer}``.
                         Custom objects are currently serialized with cloudpickle, but this implementation is subject to change.
@@ -259,7 +259,7 @@ def save_model(
         return bento_model
 
 
-def get_runnable(bento_model: bentoml.Model) -> type[bentoml.Runnable]:
+def get_runnable(bento_model: bentoml.Model) -> type[bentoml.legacy.Runnable]:
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
@@ -267,7 +267,7 @@ def get_runnable(bento_model: bentoml.Model) -> type[bentoml.Runnable]:
     is_predictor = bento_model.info.metadata.get("_is_predictor", True)
     partial_kwargs = t.cast(ModelOptions, bento_model.info.options).partial_kwargs
 
-    class Detectron2Runnable(bentoml.Runnable):
+    class Detectron2Runnable(bentoml.legacy.Runnable):
         SUPPORTED_RESOURCES = ("nvidia.com/gpu", "cpu")
         SUPPORTS_CPU_MULTI_THREADING = True
 

--- a/src/bentoml/_internal/frameworks/diffusers.py
+++ b/src/bentoml/_internal/frameworks/diffusers.py
@@ -638,7 +638,7 @@ def save_model(
         return bento_model
 
 
-def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
+def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.legacy.Runnable]:
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
@@ -699,7 +699,7 @@ def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
             "Try using `bento_model.with_options(pipeline_class=diffusers.StableDiffusionPipeline) to specify the pipeline's class"
         )
 
-    class DiffusersRunnable(bentoml.Runnable):
+    class DiffusersRunnable(bentoml.legacy.Runnable):
         SUPPORTED_RESOURCES = ("nvidia.com/gpu", "cpu")
         SUPPORTS_CPU_MULTI_THREADING = True
 
@@ -742,7 +742,7 @@ def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
                 load_pretrained_extra_kwargs=load_pretrained_extra_kwargs,
             )
 
-        @bentoml.Runnable.method(batchable=False)
+        @bentoml.legacy.Runnable.method(batchable=False)
         def _replace_scheduler(self, scheduler_txt: str):
             try:
                 scheduler_cls = _str2cls(scheduler_txt)

--- a/src/bentoml/_internal/frameworks/diffusers_runners/stable_diffusion.py
+++ b/src/bentoml/_internal/frameworks/diffusers_runners/stable_diffusion.py
@@ -51,7 +51,7 @@ def create_runner(
     textual_inversions: (
         TextualInversionOptionType | list[TextualInversionOptionType] | None
     ) = None,
-) -> bentoml.Runner:
+) -> bentoml.legacy.Runner:
     if isinstance(pipeline_class, str):
         pipeline_class = resolve_pipeline_class(pipeline_class, PIPELINE_MAPPING)
 

--- a/src/bentoml/_internal/frameworks/diffusers_runners/stable_diffusion_xl.py
+++ b/src/bentoml/_internal/frameworks/diffusers_runners/stable_diffusion_xl.py
@@ -52,7 +52,7 @@ def create_runner(
     textual_inversions: (
         TextualInversionOptionType | list[TextualInversionOptionType] | None
     ) = None,
-) -> bentoml.Runner:
+) -> bentoml.legacy.Runner:
     if isinstance(pipeline_class, str):
         pipeline_class = resolve_pipeline_class(pipeline_class, PIPELINE_MAPPING)
 

--- a/src/bentoml/_internal/frameworks/easyocr.py
+++ b/src/bentoml/_internal/frameworks/easyocr.py
@@ -116,7 +116,7 @@ def save_model(
         name: Name for given model instance. This should pass Python identifier check.
         reader: The EasyOCR model to be saved. Currently only supports pre-trained models from easyocr.
                 Custom models are not yet supported.
-        signatures: Methods to expose for running inference on the target model. Signatures are used for creating :obj:`~bentoml.Runner` instances when serving model with :obj:`~bentoml.Service`
+        signatures: Methods to expose for running inference on the target model. Signatures are used for creating :obj:`~bentoml.legacy.Runner` instances when serving model with :obj:`~bentoml.legacy.Service`
         labels: User-defined labels for managing models, e.g. ``team=nlp``, ``stage=dev``.
         custom_objects: Custom objects to be saved with the model. An example is ``{"my-normalizer": normalizer}``.
                         Custom objects are currently serialized with cloudpickle, but this implementation is subject to change.
@@ -171,12 +171,12 @@ def save_model(
         return bento_model
 
 
-def get_runnable(bento_model: bentoml.Model) -> type[bentoml.Runnable]:
+def get_runnable(bento_model: bentoml.Model) -> type[bentoml.legacy.Runnable]:
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
 
-    class EasyOCRRunnable(bentoml.Runnable):
+    class EasyOCRRunnable(bentoml.legacy.Runnable):
         SUPPORTED_RESOURCES = ("nvidia.com/gpu", "cpu")
         SUPPORTS_CPU_MULTI_THREADING = True
 

--- a/src/bentoml/_internal/frameworks/fastai.py
+++ b/src/bentoml/_internal/frameworks/fastai.py
@@ -224,7 +224,7 @@ def save_model(
         return bento_model
 
 
-def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
+def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.legacy.Runnable]:
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
@@ -232,7 +232,7 @@ def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
         "Runners created from FastAIRunnable will not be optimized for performance. If performance is critical to your usecase, please access the PyTorch model directly via 'learn.model' and use 'bentoml.pytorch.get_runnable()' instead."
     )
 
-    class FastAIRunnable(bentoml.Runnable):
+    class FastAIRunnable(bentoml.legacy.Runnable):
         # fastai only supports GPU during training, not for inference.
         SUPPORTED_RESOURCES = ("cpu",)
         SUPPORTS_CPU_MULTI_THREADING = True

--- a/src/bentoml/_internal/frameworks/flax.py
+++ b/src/bentoml/_internal/frameworks/flax.py
@@ -257,11 +257,11 @@ def save_model(
         return bento_model
 
 
-def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
+def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.legacy.Runnable]:
     """Private API: use :obj:`~bentoml.Model.to_runnable` instead."""
     partial_kwargs: dict[str, t.Any] = bento_model.info.options.partial_kwargs
 
-    class FlaxRunnable(bentoml.Runnable):
+    class FlaxRunnable(bentoml.legacy.Runnable):
         SUPPORTED_RESOURCES = ("tpu", "nvidia.com/gpu", "cpu")
         SUPPORTS_CPU_MULTI_THREADING = True
 

--- a/src/bentoml/_internal/frameworks/keras.py
+++ b/src/bentoml/_internal/frameworks/keras.py
@@ -9,10 +9,10 @@ from typing import TYPE_CHECKING
 import attr
 
 import bentoml
-from bentoml import Runnable
 from bentoml import Tag
 from bentoml.exceptions import MissingDependencyException
 from bentoml.exceptions import NotFound
+from bentoml.legacy import Runnable
 from bentoml.models import ModelContext
 
 from ..models.model import ModelSignature

--- a/src/bentoml/_internal/frameworks/onnx.py
+++ b/src/bentoml/_internal/frameworks/onnx.py
@@ -318,7 +318,7 @@ def save_model(
         return bento_model
 
 
-def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
+def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.legacy.Runnable]:
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
@@ -341,7 +341,7 @@ def get_runnable(bento_model: bentoml.Model) -> t.Type[bentoml.Runnable]:
             output_specs = {"run": run_output_specs}
             bento_model = bento_model.with_options(output_specs=output_specs)
 
-    class ONNXRunnable(bentoml.Runnable):
+    class ONNXRunnable(bentoml.legacy.Runnable):
         SUPPORTED_RESOURCES = ("nvidia.com/gpu", "cpu")
         SUPPORTS_CPU_MULTI_THREADING = True
 

--- a/src/bentoml/_internal/frameworks/picklable_model.py
+++ b/src/bentoml/_internal/frameworks/picklable_model.py
@@ -148,7 +148,7 @@ def get_runnable(bento_model: Model):
 
     partial_kwargs: t.Dict[str, t.Any] = bento_model.info.options.partial_kwargs  # type: ignore
 
-    class PicklableRunnable(bentoml.Runnable):
+    class PicklableRunnable(bentoml.legacy.Runnable):
         SUPPORTED_RESOURCES = ("cpu",)
         SUPPORTS_CPU_MULTI_THREADING = False
 

--- a/src/bentoml/_internal/frameworks/tensorflow.py
+++ b/src/bentoml/_internal/frameworks/tensorflow.py
@@ -9,10 +9,10 @@ from types import ModuleType
 from typing import TYPE_CHECKING
 
 import bentoml
-from bentoml import Runnable
 from bentoml import Tag
 from bentoml.exceptions import MissingDependencyException
 from bentoml.exceptions import NotFound
+from bentoml.legacy import Runnable
 from bentoml.models import ModelContext
 
 from ..models.model import ModelSignature

--- a/src/bentoml/_internal/frameworks/transformers.py
+++ b/src/bentoml/_internal/frameworks/transformers.py
@@ -965,7 +965,7 @@ def save_model(
                             }
 
                         See module `src/transformers/pipelines/__init__.py <https://github.com/huggingface/transformers/blob/main/src/transformers/pipelines/__init__.py#L129>`_ for more details.
-        signatures: Methods to expose for running inference on the target model. Signatures are used for creating :obj:`~bentoml.Runner` instances when serving model with :obj:`~bentoml.Service`
+        signatures: Methods to expose for running inference on the target model. Signatures are used for creating :obj:`~bentoml.legacy.Runner` instances when serving model with :obj:`~bentoml.legacy.Service`
         labels: User-defined labels for managing models, e.g. ``team=nlp``, ``stage=dev``.
         custom_objects: Custom objects to be saved with the model. An example is ``{"my-normalizer": normalizer}``.
 
@@ -1167,12 +1167,12 @@ def save_model(
             return bento_model
 
 
-def get_runnable(bento_model: bentoml.Model) -> type[bentoml.Runnable]:
+def get_runnable(bento_model: bentoml.Model) -> type[bentoml.legacy.Runnable]:
     """
     Private API: use :obj:`~bentoml.Model.to_runnable` instead.
     """
 
-    class TransformersRunnable(bentoml.Runnable):
+    class TransformersRunnable(bentoml.legacy.Runnable):
         SUPPORTED_RESOURCES = ("nvidia.com/gpu", "cpu")
         SUPPORTS_CPU_MULTI_THREADING = True
 

--- a/src/bentoml/_internal/io_descriptors/base.py
+++ b/src/bentoml/_internal/io_descriptors/base.py
@@ -73,7 +73,7 @@ class _OpenAPIMeta:
 class IODescriptor(ABC, _OpenAPIMeta, t.Generic[IOType]):
     """
     IODescriptor describes the input/output data format of an InferenceAPI defined
-    in a :code:`bentoml.Service`. This is an abstract base class for extending new HTTP
+    in a :code:`bentoml.legacy.Service`. This is an abstract base class for extending new HTTP
     endpoint IO descriptor types in BentoServer.
     """
 

--- a/src/bentoml/_internal/io_descriptors/file.py
+++ b/src/bentoml/_internal/io_descriptors/file.py
@@ -67,7 +67,7 @@ class File(
 
        runner = bentoml.tensorflow.get('image-classification:latest').to_runner()
 
-       svc = bentoml.Service("vit-pdf-classifier", runners=[runner])
+       svc = bentoml.legacy.Service("vit-pdf-classifier", runners=[runner])
 
        @svc.api(input=File(), output=NumpyNdarray(dtype="float32"))
        async def predict(input_pdf: io.BytesIO[Any]) -> NDArray[Any]:

--- a/src/bentoml/_internal/io_descriptors/image.py
+++ b/src/bentoml/_internal/io_descriptors/image.py
@@ -108,7 +108,7 @@ class Image(
 
        runner = bentoml.tensorflow.get('image-classification:latest').to_runner()
 
-       svc = bentoml.Service("vit-object-detection", runners=[runner])
+       svc = bentoml.legacy.Service("vit-object-detection", runners=[runner])
 
        @svc.api(input=Image(), output=NumpyNdarray(dtype="float32"))
        async def predict_image(f: Image) -> NDArray[Any]:

--- a/src/bentoml/_internal/io_descriptors/json.py
+++ b/src/bentoml/_internal/io_descriptors/json.py
@@ -109,7 +109,7 @@ class JSON(
 
        iris_clf_runner = bentoml.sklearn.get("iris_clf_with_feature_names:latest").to_runner()
 
-       svc = bentoml.Service("iris_classifier_pydantic", runners=[iris_clf_runner])
+       svc = bentoml.legacy.Service("iris_classifier_pydantic", runners=[iris_clf_runner])
 
        class IrisFeatures(BaseModel):
            sepal_len: float

--- a/src/bentoml/_internal/io_descriptors/multipart.py
+++ b/src/bentoml/_internal/io_descriptors/multipart.py
@@ -63,7 +63,7 @@ class Multipart(
 
        runner = bentoml.sklearn.get("sklearn_model_clf").to_runner()
 
-       svc = bentoml.Service("iris-classifier", runners=[runner])
+       svc = bentoml.legacy.Service("iris-classifier", runners=[runner])
 
        input_spec = Multipart(arr=NumpyNdarray(), annotations=JSON())
        output_spec = Multipart(output=NumpyNdarray(), result=JSON())

--- a/src/bentoml/_internal/io_descriptors/numpy.py
+++ b/src/bentoml/_internal/io_descriptors/numpy.py
@@ -188,7 +188,7 @@ class NumpyNdarray(
 
        runner = bentoml.sklearn.get("sklearn_model_clf").to_runner()
 
-       svc = bentoml.Service("iris-classifier", runners=[runner])
+       svc = bentoml.legacy.Service("iris-classifier", runners=[runner])
 
        @svc.api(input=NumpyNdarray(), output=NumpyNdarray())
        def predict(input_arr: NDArray[Any]) -> NDArray[Any]:

--- a/src/bentoml/_internal/io_descriptors/pandas.py
+++ b/src/bentoml/_internal/io_descriptors/pandas.py
@@ -225,7 +225,7 @@ class PandasDataFrame(
 
        runner = bentoml.sklearn.get("sklearn_model_clf").to_runner()
 
-       svc = bentoml.Service("iris-classifier", runners=[runner])
+       svc = bentoml.legacy.Service("iris-classifier", runners=[runner])
 
        @svc.api(input=input_spec, output=PandasDataFrame())
        def predict(input_arr):
@@ -800,7 +800,7 @@ class PandasSeries(
 
         runner = bentoml.sklearn.get("sklearn_model_clf").to_runner()
 
-        svc = bentoml.Service("iris-classifier", runners=[runner])
+        svc = bentoml.legacy.Service("iris-classifier", runners=[runner])
 
         @svc.api(input=PandasSeries(), output=PandasSeries())
         def predict(input_arr):

--- a/src/bentoml/_internal/io_descriptors/text.py
+++ b/src/bentoml/_internal/io_descriptors/text.py
@@ -42,7 +42,7 @@ class Text(IODescriptor[str], descriptor_id="bentoml.io.Text", proto_fields=("te
 
        runner = bentoml.tensorflow.get('gpt2:latest').to_runner()
 
-       svc = bentoml.Service("gpt2-generation", runners=[runner])
+       svc = bentoml.legacy.Service("gpt2-generation", runners=[runner])
 
        @svc.api(input=Text(), output=Text())
        def predict(text: str) -> str:

--- a/src/bentoml/_internal/ray/__init__.py
+++ b/src/bentoml/_internal/ray/__init__.py
@@ -32,7 +32,7 @@ except ImportError:  # pragma: no cover
 
 
 def _get_runner_deployment(
-    svc: bentoml.Service,
+    svc: bentoml.legacy.Service,
     runner_name: str,
     runner_deployment_config: dict[str, t.Any],
     enable_batching: bool,
@@ -86,7 +86,7 @@ def _get_runner_deployment(
     )
 
 
-def _get_service_deployment(svc: bentoml.Service, **kwargs) -> Deployment:
+def _get_service_deployment(svc: bentoml.legacy.Service, **kwargs: t.Any) -> Deployment:
     @serve.deployment(name=f"bento-svc-{svc.name}", **kwargs)
     class BentoDeployment:
         def __init__(self, **runner_deployments: dict[str, Deployment]):
@@ -118,7 +118,7 @@ def get_bento_runtime_env(bento_tag: str | Tag) -> RuntimeEnv:
 
 
 def _deploy_bento_runners(
-    svc: bentoml.Service,
+    svc: bentoml.legacy.Service,
     runners_deployment_config_map: dict | None = None,
     enable_batching: bool = False,
     batching_config: dict | None = None,
@@ -145,17 +145,17 @@ def _deploy_bento_runners(
 
 
 def deployment(
-    target: str | Tag | bentoml.Bento | bentoml.Service,
+    target: str | Tag | bentoml.Bento | bentoml.legacy.Service,
     service_deployment_config: dict[str, t.Any] | None = None,
     runners_deployment_config_map: dict[str, dict[str, t.Any]] | None = None,
     enable_batching: bool = False,
     batching_config: dict[str, dict[str, dict[str, float | int]]] | None = None,
 ) -> Deployment:
     """
-    Deploy a Bento or bentoml.Service to Ray
+    Deploy a Bento or bentoml.legacy.Service to Ray
 
     Args:
-        target: A bentoml.Service instance, Bento tag string, or Bento object
+        target: A bentoml.legacy.Service instance, Bento tag string, or Bento object
         service_deployment_config: Ray deployment config for BentoML API server
         runners_deployment_config_map: Ray deployment config map for all Runners
         enable_batching: Enable Ray Serve batching for RunnerMethods with batchable=True
@@ -207,7 +207,7 @@ def deployment(
     # TODO: validate Ray deployment options
     service_deployment_config = service_deployment_config or {}
 
-    svc = target if isinstance(target, bentoml.Service) else bentoml.load(target)
+    svc = target if isinstance(target, bentoml.legacy.Service) else bentoml.load(target)
 
     runner_deployments = _deploy_bento_runners(
         svc, runners_deployment_config_map, enable_batching, batching_config

--- a/src/bentoml/_internal/runner/runner.py
+++ b/src/bentoml/_internal/runner/runner.py
@@ -199,7 +199,7 @@ class Runner(AbstractRunner):
             method_configs: A dictionary per method config for this given Runner signatures.
 
         Returns:
-            :obj:`bentoml.Runner`: A Runner instance.
+            :obj:`bentoml.legacy.Runner`: A Runner instance.
         """
 
         if name is None:

--- a/src/bentoml/_internal/server/README.md
+++ b/src/bentoml/_internal/server/README.md
@@ -9,7 +9,7 @@ Create a sample Servie in `hello.py`:
 import bentoml
 from bentoml.io import JSON
 
-svc = bentoml.Service("bento-server-test")
+svc = bentoml.legacy.Service("bento-server-test")
 
 @svc.api(input=JSON(), output=JSON())
 def predict(input_json):

--- a/src/bentoml/_internal/service/service.py
+++ b/src/bentoml/_internal/service/service.py
@@ -78,7 +78,9 @@ def get_valid_service_name(user_provided_svc_name: str) -> str:
     return lower_name
 
 
-@deprecated("bentoml.Service", suggestion="Please upgrade to @bentoml.service().")
+@deprecated(
+    "bentoml.legacy.Service", suggestion="Please upgrade to @bentoml.service()."
+)
 @attr.define(frozen=False, init=False)
 class Service:
     """The service definition is the manifestation of the Service Oriented Architecture
@@ -134,7 +136,7 @@ class Service:
 
     def __reduce__(self):
         """
-        Make bentoml.Service pickle serializable
+        Make bentoml.legacy.Service pickle serializable
         """
         import fs
 
@@ -203,7 +205,7 @@ class Service:
         runners: list[AbstractRunner] | None = None,
         models: list[Model] | None = None,
     ):
-        """Service definition itself. Runners and models can be optionally pass into a ``bentoml.Service``.
+        """Service definition itself. Runners and models can be optionally pass into a ``bentoml.legacy.Service``.
 
         Args:
             name: name of the service
@@ -217,7 +219,7 @@ class Service:
             runner_names: t.Set[str] = set()
             for r in runners:
                 assert isinstance(r, AbstractRunner), (
-                    f'Service runners list can only contain bentoml.Runner instances, type "{type(r)}" found.'
+                    f'Service runners list can only contain bentoml.legacy.Runner instances, type "{type(r)}" found.'
                 )
 
                 if r.name in runner_names:
@@ -258,12 +260,13 @@ class Service:
                     import_module = sys.modules["__main__"].__file__
                 else:
                     raise BentoMLException(
-                        "Failed to get service import origin, bentoml.Service object defined interactively in console or notebook is not supported"
+                        "Failed to get service import origin, bentoml.legacy.Service object defined interactively"
+                        " in console or notebook is not supported"
                     )
 
             if self._caller_module not in sys.modules:
                 raise BentoMLException(
-                    "Failed to get service import origin, bentoml.Service object must be defined in a module"
+                    "Failed to get service import origin, bentoml.legacy.Service object must be defined in a module"
                 )
 
             for name, value in vars(sys.modules[self._caller_module]).items():
@@ -273,7 +276,7 @@ class Service:
 
             if not self._import_str:
                 raise BentoMLException(
-                    "Failed to get service import origin, bentoml.Service object must be assigned to a variable at module level"
+                    "Failed to get service import origin, bentoml.legacy.Service object must be assigned to a variable at module level"
                 )
 
         assert self._working_dir is not None

--- a/src/bentoml/_internal/utils/analytics/usage_stats.py
+++ b/src/bentoml/_internal/utils/analytics/usage_stats.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from prometheus_client.samples import Sample
 
     from _bentoml_sdk import Service as NewService
-    from bentoml import Service
+    from bentoml.legacy import Service
 
     from ...server.metrics.prometheus import PrometheusClient
 
@@ -134,7 +134,7 @@ def _track_serve_init(
     from_server_api: bool,
     serve_info: ServeInfo = Provide[BentoMLContainer.serve_info],
 ):
-    from bentoml import Service
+    from bentoml.legacy import Service
 
     is_legacy = isinstance(svc, Service)
 

--- a/src/bentoml/legacy.py
+++ b/src/bentoml/legacy.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+
+MODULE_ATTRS = {
+    "Resource": "._internal.resource:Resource",
+    "Runnable": "._internal.runner:Runnable",
+    "Runner": "._internal.runner:Runner",
+    "Strategy": "._internal.runner.strategy:Strategy",
+    "Service": "._internal.service:Service",
+    "HTTPServer": ".server:HTTPServer",
+    "GrpcServer": ".server:GrpcServer",
+}
+
+__all__ = [
+    "Resource",
+    "Runnable",
+    "Runner",
+    "Strategy",
+    "Service",
+    "HTTPServer",
+    "GrpcServer",
+]
+
+if TYPE_CHECKING:
+    from ._internal.resource import Resource
+    from ._internal.runner import Runnable
+    from ._internal.runner import Runner
+    from ._internal.runner.strategy import Strategy
+    from ._internal.service import Service
+    from .server import GrpcServer
+    from .server import HTTPServer
+
+else:
+
+    def __getattr__(name: str) -> Any:
+        if name in MODULE_ATTRS:
+            from importlib import import_module
+
+            module_name, attr_name = MODULE_ATTRS[name].split(":")
+            module = import_module(module_name, __package__)
+            return getattr(module, attr_name)
+        raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/bentoml/server.py
+++ b/src/bentoml/server.py
@@ -98,7 +98,7 @@ class Server(ABC, t.Generic[ClientType]):
         elif isinstance(servable, Service):
             if not servable.is_service_importable():
                 raise UnservableException(
-                    "Cannot use 'bentoml.Service' as a server if it is defined in interactive session or Jupyter Notebooks."
+                    "Cannot use 'bentoml.legacy.Service' as a server if it is defined in interactive session or Jupyter Notebooks."
                 )
             bento_str, working_dir = servable.get_service_import_origin()
         elif not isinstance(servable, str):

--- a/src/bentoml_cli/_internal/start.py
+++ b/src/bentoml_cli/_internal/start.py
@@ -150,8 +150,8 @@ def build_start_command() -> click.Group:
         """
         Start a HTTP API server standalone. This will be used inside Yatai.
         """
-        from bentoml import Service
         from bentoml._internal.service.loader import load
+        from bentoml.legacy import Service
 
         if working_dir is None:
             if os.path.isdir(os.path.expanduser(bento)):

--- a/src/bentoml_cli/serve.py
+++ b/src/bentoml_cli/serve.py
@@ -249,8 +249,8 @@ def build_serve_command() -> click.Group:
         - when specified, respect 'include' and 'exclude' under 'bentofile.yaml' as well as the '.bentoignore' file in '--working-dir', for code and file changes
         - all model store changes will also trigger a restart (new model saved or existing model removed)
         """
-        from bentoml import Service
         from bentoml._internal.service.loader import load
+        from bentoml.legacy import Service
 
         configure_server_logging()
         if working_dir is None:

--- a/tests/e2e/bento_server_grpc/service.py
+++ b/tests/e2e/bento_server_grpc/service.py
@@ -29,11 +29,12 @@ if TYPE_CHECKING:
     from bentoml._internal.runner.runner import RunnerMethod
     from bentoml._internal.types import FileLike
     from bentoml._internal.types import JSONSerializable
-    from bentoml.picklable_model import get_runnable
 
-    RunnableImpl = get_runnable(bentoml.picklable_model.get("py_model.case-1.grpc.e2e"))
+    RunnableImpl = bentoml.picklable_model.get_runnable(
+        bentoml.picklable_model.get("py_model.case-1.grpc.e2e")
+    )
 
-    class PythonModelRunner(bentoml.Runner):
+    class PythonModelRunner(bentoml.legacy.Runner):
         predict_file: RunnerMethod[RunnableImpl, [list[FileLike[bytes]]], list[bytes]]
         echo_json: RunnerMethod[
             RunnableImpl, [list[JSONSerializable]], list[JSONSerializable]
@@ -62,7 +63,7 @@ py_model = t.cast(
     bentoml.picklable_model.get("py_model.case-1.grpc.e2e").to_runner(),
 )
 
-svc = bentoml.Service(name="general_grpc_service.case-1.e2e", runners=[py_model])
+svc = bentoml.legacy.Service(name="general_grpc_service.case-1.e2e", runners=[py_model])
 
 svc.add_grpc_interceptor(AsyncContextInterceptor, usage="NLP", accuracy_score=0.8247)
 

--- a/tests/e2e/bento_server_http/service.py
+++ b/tests/e2e/bento_server_http/service.py
@@ -41,20 +41,20 @@ py_model = (
 )
 
 
-class StreamRunnable(bentoml.Runnable):
+class StreamRunnable(bentoml.legacy.Runnable):
     SUPPORTED_RESOURCES = ("cpu",)
     SUPPORTS_CPU_MULTI_THREADING = True
 
-    @bentoml.Runnable.method()
+    @bentoml.legacy.Runnable.method()
     async def count_text_stream(self, input_text: str) -> t.AsyncGenerator[str, None]:
         for i in range(10):
             await asyncio.sleep(0.1)
             yield f"{input_text} {i}"
 
 
-stream_runner = bentoml.Runner(StreamRunnable)
+stream_runner = bentoml.legacy.Runner(StreamRunnable)
 
-svc = bentoml.Service(
+svc = bentoml.legacy.Service(
     name="general_http_service.case-1.e2e", runners=[py_model, stream_runner]
 )
 

--- a/tests/e2e/bento_server_http/tests/test_meta.py
+++ b/tests/e2e/bento_server_http/tests/test_meta.py
@@ -150,18 +150,20 @@ def test_service_init_checks():
         name="invalid"
     )
     with pytest.raises(ValueError) as excinfo:
-        _ = bentoml.Service(name="duplicates_runners", runners=[py_model1, py_model2])
+        _ = bentoml.legacy.Service(
+            name="duplicates_runners", runners=[py_model1, py_model2]
+        )
     assert "Found duplicate name" in str(excinfo.value)
 
     with pytest.raises(AssertionError) as excinfo:
-        _ = bentoml.Service(name="invalid_model_type", models=[1])
+        _ = bentoml.legacy.Service(name="invalid_model_type", models=[1])
     assert "Service models list can only" in str(excinfo.value)
 
 
 def test_dunder_string():
     runner = bentoml.picklable_model.get("py_model.case-1.http.e2e").to_runner()
 
-    svc = bentoml.Service(name="dunder_string", runners=[runner])
+    svc = bentoml.legacy.Service(name="dunder_string", runners=[runner])
 
     assert (
         str(svc)

--- a/tests/integration/frameworks/test_frameworks.py
+++ b/tests/integration/frameworks/test_frameworks.py
@@ -188,8 +188,8 @@ def test_get_runnable(
     assert isinstance(runnable, t.Type), (
         "get_runnable for {bento_model.info.name} does not return a type"
     )
-    assert issubclass(runnable, bentoml.Runnable), (
-        "get_runnable for {bento_model.info.name} doesn't return a subclass of bentoml.Runnable"
+    assert issubclass(runnable, bentoml.legacy.Runnable), (
+        "get_runnable for {bento_model.info.name} doesn't return a subclass of bentoml.legacy.Runnable"
     )
     assert len(runnable.bentoml_runnable_methods__) > 0, (
         "get_runnable for {bento_model.info.name} gives a runnable with no methods"
@@ -305,7 +305,9 @@ def test_runner_cpu_multi_threading(
     for config in test_model.configurations:
         model_with_options = saved_model.with_options(**config.load_kwargs)
 
-        runnable: t.Type[bentoml.Runnable] = framework.get_runnable(model_with_options)
+        runnable: t.Type[bentoml.legacy.Runnable] = framework.get_runnable(
+            model_with_options
+        )
         if "cpu" not in runnable.SUPPORTED_RESOURCES:
             continue
 
@@ -353,7 +355,9 @@ def test_runner_cpu(
     for config in test_model.configurations:
         model_with_options = saved_model.with_options(**config.load_kwargs)
 
-        runnable: t.Type[bentoml.Runnable] = framework.get_runnable(model_with_options)
+        runnable: t.Type[bentoml.legacy.Runnable] = framework.get_runnable(
+            model_with_options
+        )
         if not runnable.SUPPORTS_CPU_MULTI_THREADING:
             continue
 
@@ -403,7 +407,9 @@ def test_runner_nvidia_gpu(
     for config in test_model.configurations:
         model_with_options = saved_model.with_options(**config.load_kwargs)
 
-        runnable: t.Type[bentoml.Runnable] = framework.get_runnable(model_with_options)
+        runnable: t.Type[bentoml.legacy.Runnable] = framework.get_runnable(
+            model_with_options
+        )
         if "nvidia.com/gpu" not in runnable.SUPPORTED_RESOURCES:
             continue
 

--- a/tests/monitoring/task_classification/README.md
+++ b/tests/monitoring/task_classification/README.md
@@ -46,7 +46,7 @@ from bentoml.io import NumpyNdarray
 CLASS_NAMES = ["setosa", "versicolor", "virginica"]
 
 iris_clf_runner = bentoml.sklearn.get("iris_clf:latest").to_runner()
-svc = bentoml.Service("iris_classifier", runners=[iris_clf_runner])
+svc = bentoml.legacy.ervice("iris_classifier", runners=[iris_clf_runner])
 
 
 @svc.api(

--- a/tests/unit/_internal/io/test_custom.py
+++ b/tests/unit/_internal/io/test_custom.py
@@ -100,7 +100,7 @@ class CustomDescriptor(IODescriptor[str]):
 
 
 def test_custom_io_descriptor():
-    svc = bentoml.Service("test")
+    svc = bentoml.legacy.Service("test")
 
     @svc.api(input=CustomDescriptor(), output=CustomDescriptor())
     def descriptor_test_api(inp):

--- a/tests/unit/_internal/runner/test_runner.py
+++ b/tests/unit/_internal/runner/test_runner.py
@@ -6,8 +6,8 @@ import bentoml
 from bentoml._internal.runner import Runner
 
 
-class DummyRunnable(bentoml.Runnable):
-    @bentoml.Runnable.method
+class DummyRunnable(bentoml.legacy.Runnable):
+    @bentoml.legacy.Runnable.method
     def dummy_runnable_method(self):
         pass
 

--- a/tests/unit/_internal/runner/test_strategy.py
+++ b/tests/unit/_internal/runner/test_strategy.py
@@ -13,16 +13,16 @@ from bentoml._internal.runner import strategy
 from bentoml._internal.runner.strategy import DefaultStrategy
 
 
-class GPURunnable(bentoml.Runnable):
+class GPURunnable(bentoml.legacy.Runnable):
     SUPPORTED_RESOURCES = ("nvidia.com/gpu",)
 
 
-class SingleThreadRunnable(bentoml.Runnable):
+class SingleThreadRunnable(bentoml.legacy.Runnable):
     SUPPORTED_RESOURCES = ("cpu",)
     SUPPORTS_CPU_MULTI_THREADING = False
 
 
-class MultiThreadRunnable(bentoml.Runnable):
+class MultiThreadRunnable(bentoml.legacy.Runnable):
     SUPPORTED_RESOURCES = ("cpu",)
     SUPPORTS_CPU_MULTI_THREADING = True
 

--- a/tests/unit/_internal/service_loader/bento_service_in_module/multi_service.py
+++ b/tests/unit/_internal/service_loader/bento_service_in_module/multi_service.py
@@ -1,4 +1,4 @@
 import bentoml
 
-svc_i = bentoml.Service("test-bento-service-in-module-i")
-svc_ii = bentoml.Service("test-bento-service-in-module-ii")
+svc_i = bentoml.legacy.Service("test-bento-service-in-module-i")
+svc_ii = bentoml.legacy.Service("test-bento-service-in-module-ii")

--- a/tests/unit/_internal/service_loader/bento_service_in_module/single_service.py
+++ b/tests/unit/_internal/service_loader/bento_service_in_module/single_service.py
@@ -1,3 +1,3 @@
 import bentoml
 
-svc = bentoml.Service("test-bento-service-in-module-single")
+svc = bentoml.legacy.Service("test-bento-service-in-module-single")

--- a/tests/unit/_internal/service_loader/bento_with_models/service.py
+++ b/tests/unit/_internal/service_loader/bento_with_models/service.py
@@ -3,6 +3,6 @@ import bentoml
 test_model = bentoml.models.get("testmodel")
 # get by alias
 another_model = bentoml.models.get("another")
-svc = bentoml.Service(
+svc = bentoml.legacy.Service(
     "test-bento-service-with-models", models=[test_model, another_model]
 )

--- a/tests/unit/_internal/service_loader/multi_service_in_package/__init__.py
+++ b/tests/unit/_internal/service_loader/multi_service_in_package/__init__.py
@@ -1,4 +1,4 @@
 import bentoml
 
-svc_i = bentoml.Service("test-multi-service-in-package-i")
-svc_ii = bentoml.Service("test-multi-service-in-package-ii")
+svc_i = bentoml.legacy.Service("test-multi-service-in-package-i")
+svc_ii = bentoml.legacy.Service("test-multi-service-in-package-ii")

--- a/tests/unit/_internal/service_loader/single_service_in_package/__init__.py
+++ b/tests/unit/_internal/service_loader/single_service_in_package/__init__.py
@@ -1,3 +1,3 @@
 import bentoml
 
-svc = bentoml.Service("test-bento-service-in-package")
+svc = bentoml.legacy.Service("test-bento-service-in-package")

--- a/tests/unit/_internal/test_service_api.py
+++ b/tests/unit/_internal/test_service_api.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
 
 
-svc = bentoml.Service(name="general_features_routes")
+svc = bentoml.legacy.Service(name="general_features_routes")
 
 
 @svc.api(input=Text(), output=Text(), route="api/v1/test_without_prefix")
@@ -34,7 +34,7 @@ def test_routes_prefix():
 
 
 def test_invalid_api_naming():
-    svc = bentoml.Service(name="invalid_api_naming")
+    svc = bentoml.legacy.Service(name="invalid_api_naming")
 
     @svc.api(name="similar", input=Text(), output=Text())
     def r1(obj: str) -> int:

--- a/tests/unit/_internal/utils/test_analytics.py
+++ b/tests/unit/_internal/utils/test_analytics.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
     from prometheus_client.metrics_core import Metric
 
-    from bentoml import Service
+    from bentoml.legacy import Service
 
 SCHEMA = Schema(
     {
@@ -182,7 +182,7 @@ def test_track_serve_init_no_bento(
 
     with caplog.at_level(logging.INFO):
         analytics.usage_stats._track_serve_init(  # type: ignore (private warning)
-            bentoml.Service("test"),
+            bentoml.legacy.Service("test"),
             production=False,
             serve_info=analytics.usage_stats.get_serve_info(),
             serve_kind="http",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -102,7 +102,7 @@ def reload_directory(
 
 
 @pytest.fixture(scope="session")
-def simple_service() -> bentoml.Service:
+def simple_service() -> bentoml.legacy.Service:
     """
     This fixture create a simple service implementation that implements a noop runnable with two APIs:
 
@@ -126,20 +126,20 @@ def simple_service() -> bentoml.Service:
 
     model_ref = bentoml.models.get("python_function")
 
-    class NoopRunnable(bentoml.Runnable):
+    class NoopRunnable(bentoml.legacy.Runnable):
         SUPPORTED_RESOURCES = ("cpu",)
         SUPPORTS_CPU_MULTI_THREADING = True
 
         def __init__(self):
             self._model: NoopModel = bentoml.picklable_model.load_model(model_ref)
 
-        @bentoml.Runnable.method(batchable=True)
+        @bentoml.legacy.Runnable.method(batchable=True)
         def predict(self, data: t.Any) -> t.Any:
             return self._model.predict(data)
 
-    svc = bentoml.Service(
+    svc = bentoml.legacy.Service(
         name="simple_service",
-        runners=[bentoml.Runner(NoopRunnable, models=[model_ref])],
+        runners=[bentoml.legacy.Runner(NoopRunnable, models=[model_ref])],
     )
 
     @svc.api(input=Text(), output=Text())

--- a/tests/unit/grpc/interceptors/test_access.py
+++ b/tests/unit/grpc/interceptors/test_access.py
@@ -28,13 +28,13 @@ if TYPE_CHECKING:
     from google.protobuf import wrappers_pb2
     from grpc import aio
 
-    from bentoml import Service
     from bentoml.grpc.types import AsyncHandlerMethod
     from bentoml.grpc.types import BentoServicerContext
     from bentoml.grpc.types import HandlerCallDetails
     from bentoml.grpc.types import Request
     from bentoml.grpc.types import Response
     from bentoml.grpc.types import RpcMethodHandler
+    from bentoml.legacy import Service
 else:
     grpc, aio = import_grpc()
     wrappers_pb2 = LazyLoader("wrappers_pb2", globals(), "google.protobuf.wrappers_pb2")

--- a/tests/unit/grpc/interceptors/test_prometheus.py
+++ b/tests/unit/grpc/interceptors/test_prometheus.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     import grpc
     from google.protobuf import wrappers_pb2
 
-    from bentoml import Service
+    from bentoml.legacy import Service
 else:
     wrappers_pb2 = LazyLoader("wrappers_pb2", globals(), "google.protobuf.wrappers_pb2")
     grpc, aio = import_grpc()


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

## What does this PR address?

We plan to export the new service type in the top-level namespace, which conflict with the legacy service with the same name. Therefore, as a preliminary step, this PR moves all deprecated APIs to a new module `bentoml.legacy` while keeping the references in `bentoml` for a while.

Any references to `bentoml.<legacy_api>` will emit a deprecation warning to let users migrate ASAP.
