### PR TITLE
Fix keras version comparison

### DIFF
--- a/src/bentoml/_internal/frameworks/keras.py
+++ b/src/bentoml/_internal/frameworks/keras.py
@@ -7,6 +7,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING
 
 import attr
+from packaging import version
 
 import bentoml
 from bentoml import Tag
@@ -269,7 +270,7 @@ def save_model(
         metadata=metadata,
         signatures=signatures,
     ) as bento_model:
-        if keras.__version__ >= "3.4.0":
+        if version.parse(keras.__version__) >= version.parse("3.4.0"):
             model.save(
                 bento_model.path,
                 zipped=False,


### PR DESCRIPTION
## What does this PR address?

Fix keras framework version comparison. A Keras 3 compatibility fix has been introduced previously in #4922. However, the version check that was added is sloppy: a string comparison is done lexicographically, not numerically, which make it breaks with the Keras version 3.10.0 release last May.

This introduce proper version comparison.

Fixes #4922

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
