### PR TITLE
build: Use python3.10 package that exists on Ubuntu22.04

### DIFF
--- a/src/bentoml/_internal/container/frontend/dockerfile/templates/cuda_debian.j2
+++ b/src/bentoml/_internal/container/frontend/dockerfile/templates/cuda_debian.j2
@@ -8,7 +8,7 @@
     # add deadsnakes ppa to install python
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends --allow-remove-essential {% if "ubuntu22.04" in __base_image__ and __options__python_version == "3.10" %}python{{ __options__python_version }}-jammy{% else %}python{{ __options__python_version }}{% endif %} python{{ __options__python_version }}-dev
+    apt-get install -y --no-install-recommends --allow-remove-essential python{{ __options__python_version }} python{{ __options__python_version }}-dev
 
 RUN ln -sf /usr/bin/python{{ __options__python_version }} /usr/bin/python3 && \
     ln -sf /usr/bin/pip{{ __options__python_version }} /usr/bin/pip3


### PR DESCRIPTION
## What does this PR address?

Historically a specially named python3.10 package was needed on Ubuntu 22.04.
This special package no longer exists so we can now install the same package
name used on other Ubuntu versions.

Fixes #5402

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.