### PR TITLE
feat: Allow bento description to be passed to service decorator

### DIFF
--- a/src/_bentoml_sdk/service/factory.py
+++ b/src/_bentoml_sdk/service/factory.py
@@ -85,6 +85,7 @@ class Service(t.Generic[T]):
     config: Config = attrs.field(factory=Config)
     inner: type[T] = _DummyService
     image: t.Optional[Image] = None
+    description: t.Optional[str] = None
     envs: t.List[BentoEnvSchema] = attrs.field(factory=list, converter=convert_envs)
     labels: t.Dict[str, str] = attrs.field(factory=dict)
     models: list[Model[t.Any]] = attrs.field(factory=list)
@@ -541,6 +542,7 @@ def service(
     *,
     name: str | None = None,
     image: Image | None = None,
+    description: str | None = None,
     envs: list[dict[str, str]] | None = None,
     labels: dict[str, str] | None = None,
     cmd: list[str] | None = None,
@@ -567,6 +569,7 @@ def service(
             config=config,
             inner=inner,
             image=image,
+            description=description,
             envs=envs or [],
             labels=labels or {},
             cmd=cmd,

--- a/src/bentoml/_internal/bento/bento.py
+++ b/src/bentoml/_internal/bento/bento.py
@@ -264,6 +264,8 @@ class Bento(StoreItem):
             )
             build_config.envs.extend(svc.envs)
             build_config.labels.update(svc.labels)
+            if build_config.description is None and svc.description is not None:
+                object.__setattr__(build_config, "description", svc.description)
             if svc.image is not None:
                 image = svc.image
         if not disable_image:


### PR DESCRIPTION
## What does this PR address?

While migrating to the python sdk released in `v1.3.20` I noticed that there was a regression in the ability to set Bento Descriptions which feed directly into the OpenAPI docs. 

Previously in the `bentofile.yaml` the description could be set either via a file or a str/markdown like below:

```
service: "service:svc"
description: |
    ## Description For My Bento 🍱

    Use **any markdown syntax** here!

    > BentoML is awesome!
```

```
service: "service:svc"
description: "file: ./README.md"
```

Using the pure python sdk:
- Doesn't allow you to define where the README.md file is 
- Will use the README in the same directory as the service.py file if it exists

Both are behaviour that is sub-optimal

This PR:
- Adds an optional `description` to the service class and decorator
- If the description has been populated, as part of the bento build it will copy it over to the `build_config` (Missing step currently) which then allows the description creation process to continue

The optional description parameter supports both:
- str/markdown 
- via a file path "file: <<PATH_TO_MY_FILE>>/README.md"

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [x] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?
