### PR TITLE
fix: correct typo 'seperators' to 'separators'

### DIFF
--- a/src/bentoml_cli/utils.py
+++ b/src/bentoml_cli/utils.py
@@ -77,7 +77,7 @@ def _validate_docker_tag(tag: str) -> str:
         r"""
         ^(
         [a-z0-9]+      # alphanumeric
-        (.|_{1,2}|-+)? # seperators
+        (.|_{1,2}|-+)? # separators
         )*$
         """,
         re.VERBOSE,


### PR DESCRIPTION
Fixed typo in regex comment in src/bentoml_cli/utils.py.