### PR TITLE
fix: validate symlink targets in safe_extract_tarfile

### DIFF
--- a/src/bentoml/_internal/utils/filesystem.py
+++ b/src/bentoml/_internal/utils/filesystem.py
@@ -104,8 +104,7 @@ def safe_extract_tarfile(tar: tarfile.TarFile, destination: str) -> None:
             real_path = os.path.realpath(path)
             if not Path(real_path).is_relative_to(dest):
                 logger.warning(
-                    "The tar file has a file (%s) resolving outside"
-                    " target directory",
+                    "The tar file has a file (%s) resolving outside target directory",
                     fn,
                 )
                 fp.close()


### PR DESCRIPTION
Validate that symlink targets resolve within the destination directory before extraction, preventing arbitrary file write via symlink path traversal.

Changes:
- Resolve destination to its real path to handle symlinks in the base path
- Check symlink targets against the destination boundary before extracting
- Verify the real path of regular files before writing to catch writes through symlinks

Fixes GHSA-m6w7-qv66-g3mf