### PR TITLE
Fix run_in_spark crash with new-style services (APIMethod)

### DIFF
--- a/src/bentoml/_internal/batch/spark.py
+++ b/src/bentoml/_internal/batch/spark.py
@@ -10,8 +10,6 @@ from bentoml._internal.utils import reserve_free_port
 
 from ...bentos import import_bento
 from ...bentos import serve
-from ...client import Client
-from ...client import HTTPClient
 from ...exceptions import BentoMLException
 from ...exceptions import MissingDependencyException
 from ..bento import Bento
@@ -34,6 +32,13 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _is_legacy_service(svc: t.Any) -> bool:
+    """Check if the service uses the legacy InferenceAPI interface."""
+    from ..service.service import Service
+
+    return isinstance(svc, Service)
 
 
 def _distribute_bento(spark: pyspark.sql.session.SparkSession, bento: Bento) -> str:
@@ -60,6 +65,38 @@ def _load_bento_spark(bento_tag: Tag):
         return load_bento(bento_tag)
 
 
+def _result_to_record_batch(result: t.Any) -> t.Any:
+    """Convert an API result to a pyarrow RecordBatch."""
+    import numpy as np
+    import pandas as pd
+    import pyarrow
+
+    if isinstance(result, pyarrow.RecordBatch):
+        return result
+    elif isinstance(result, pyarrow.Table):
+        return result.to_batches()[0]
+    elif isinstance(result, pd.DataFrame):
+        return pyarrow.RecordBatch.from_pandas(result)
+    elif isinstance(result, pd.Series):
+        return pyarrow.RecordBatch.from_pandas(result.to_frame())
+    elif isinstance(result, np.ndarray):
+        return pyarrow.RecordBatch.from_arrays(
+            [pyarrow.array(result)], names=["output"]
+        )
+    elif isinstance(result, (list, tuple)):
+        return pyarrow.RecordBatch.from_arrays(
+            [pyarrow.array(result)], names=["output"]
+        )
+    elif isinstance(result, dict):
+        arrays = [pyarrow.array(v) if not isinstance(v, pyarrow.Array) else v
+                  for v in result.values()]
+        return pyarrow.RecordBatch.from_arrays(arrays, names=list(result.keys()))
+    else:
+        return pyarrow.RecordBatch.from_arrays(
+            [pyarrow.array([result])], names=["output"]
+        )
+
+
 def _get_process(
     bento_tag: Tag, api_name: str
 ) -> t.Callable[[t.Iterable[RecordBatch]], t.Generator[RecordBatch, None, None]]:
@@ -71,21 +108,62 @@ def _get_process(
         assert api_name in svc.apis, (
             "An error occurred transferring the Bento to the Spark worker."
         )
-        inference_api = svc.apis[api_name]
-        assert inference_api.func is not None, "Inference API function not defined"
+        api = svc.apis[api_name]
 
         # start bento server
         with reserve_free_port() as port:
             pass
 
         server = serve(bento_tag, port=port)
-        Client.wait_until_server_ready("localhost", port, 30)
-        client = HTTPClient(svc, server.url)
 
-        for batch in iterator:
-            func_input = inference_api.input.from_arrow(batch)
-            func_output = client.call(api_name, func_input)
-            yield inference_api.output.to_arrow(func_output)
+        if _is_legacy_service(svc):
+            # Legacy service using InferenceAPI with IO descriptors
+            from ...client import Client
+            from ...client import HTTPClient
+
+            assert api.func is not None, "Inference API function not defined"
+            Client.wait_until_server_ready("localhost", port, 30)
+            client = HTTPClient(svc, server.url)
+
+            for batch in iterator:
+                func_input = api.input.from_arrow(batch)
+                func_output = client.call(api_name, func_input)
+                yield api.output.to_arrow(func_output)
+        else:
+            # New-style service using @bentoml.service() with APIMethod
+            from _bentoml_impl.client import SyncHTTPClient
+
+            client = SyncHTTPClient(server.url, server_ready_timeout=30)
+            try:
+                for batch in iterator:
+                    df = batch.to_pandas()
+                    input_fields = list(api.input_spec.model_fields.keys())
+
+                    if len(input_fields) == 1:
+                        # Single input parameter: pass the whole DataFrame
+                        # converted to the appropriate type
+                        field_name = input_fields[0]
+                        func_output = client.call(
+                            api_name, **{field_name: df.to_numpy()}
+                        )
+                    else:
+                        # Multiple input parameters: map DataFrame columns to
+                        # function parameter names
+                        kwargs = {}
+                        for field in input_fields:
+                            if field in df.columns:
+                                kwargs[field] = df[field].tolist()
+                            else:
+                                raise BentoMLException(
+                                    f"Column '{field}' required by API '{api_name}' "
+                                    f"not found in input DataFrame. Available columns: "
+                                    f"{list(df.columns)}"
+                                )
+                        func_output = client.call(api_name, **kwargs)
+
+                    yield _result_to_record_batch(func_output)
+            finally:
+                client.close()
 
     return process
 
@@ -114,7 +192,8 @@ def run_in_spark(
             in the bento; that API will be run.
         output_schema:
             The Spark schema of the output DataFrame. If not provided, BentoML will attempt to infer the
-            schema from the output descriptor of the inference API.
+            schema from the output descriptor of the inference API. For new-style services using
+            ``@bentoml.service()``, this parameter is required.
 
     Returns:
         The result of the inference API run on the input ``df``.
@@ -166,6 +245,13 @@ def run_in_spark(
     process = _get_process(bento.tag, api_name)
 
     if output_schema is None:
-        output_schema = api.output.spark_schema()
+        if _is_legacy_service(svc):
+            output_schema = api.output.spark_schema()
+        else:
+            raise BentoMLException(
+                "output_schema is required when using run_in_spark with new-style "
+                "services (using @bentoml.service() decorator). Please provide a "
+                "pyspark StructType schema for the output DataFrame."
+            )
 
     return df.mapInArrow(process, output_schema)

--- a/src/bentoml/_internal/batch/spark.py
+++ b/src/bentoml/_internal/batch/spark.py
@@ -88,8 +88,10 @@ def _result_to_record_batch(result: t.Any) -> t.Any:
             [pyarrow.array(result)], names=["output"]
         )
     elif isinstance(result, dict):
-        arrays = [pyarrow.array(v) if not isinstance(v, pyarrow.Array) else v
-                  for v in result.values()]
+        arrays = [
+            pyarrow.array(v) if not isinstance(v, pyarrow.Array) else v
+            for v in result.values()
+        ]
         return pyarrow.RecordBatch.from_arrays(arrays, names=list(result.keys()))
     else:
         return pyarrow.RecordBatch.from_arrays(


### PR DESCRIPTION
## Summary

Fixes #5524.

`bentoml.batch.run_in_spark()` crashes with `AttributeError: 'APIMethod' object has no attribute 'input'` when used with services defined via the `@bentoml.service()` decorator. The Spark batch code was written for the legacy `InferenceAPI` interface and wasn't updated after the service API refactor.

### Changes

- **Detect service style at runtime** — added `_is_legacy_service()` to distinguish between legacy `Service` (with `InferenceAPI`) and new-style services (with `APIMethod`).
- **Legacy services** continue to use `InferenceAPI.input/output` IO descriptors and the existing `HTTPClient`, preserving full backward compatibility.
- **New-style services** use `SyncHTTPClient` from `_bentoml_impl.client` (which auto-discovers endpoints from the running server's `/schema.json`) and convert Arrow RecordBatches through pandas. A `_result_to_record_batch()` helper handles converting common return types (ndarray, list, dict, DataFrame, etc.) back to Arrow RecordBatch format.
- **`output_schema` is now required** for new-style services, since `APIMethod` doesn't expose `spark_schema()`. A clear error message is raised if it's missing.

### Testing

Verified the fix against the reproduction case from the issue (service with `@bentoml.task` taking `np.ndarray` input, called via `run_in_spark` with an explicit `output_schema`).