### PR TITLE
fix: Set SQLite busy_timeout and WAL mode to prevent 'database is locked' under concurrency

### DIFF
--- a/src/_bentoml_impl/tasks/result.py
+++ b/src/_bentoml_impl/tasks/result.py
@@ -104,11 +104,15 @@ class Sqlite3Store(ResultStore[Request, Response]):
         import aiosqlite
 
         return aiosqlite.connect(
-            db_file, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES
+            db_file,
+            detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
+            timeout=30.0,
         )
 
     async def __aenter__(self) -> "t.Self":
         self._conn = await self._conn
+        await self._conn.execute("PRAGMA journal_mode=WAL")
+        await self._conn.execute("PRAGMA busy_timeout=5000")
         return self
 
     async def __aexit__(self, *_: t.Any) -> None:
@@ -119,7 +123,9 @@ class Sqlite3Store(ResultStore[Request, Response]):
         import sqlite3
 
         with sqlite3.connect(
-            db_file, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES
+            db_file,
+            detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
+            timeout=30.0,
         ) as conn:
             conn.execute(
                 textwrap.dedent("""\


### PR DESCRIPTION
## Summary
Fixes the intermittent `sqlite3.OperationalError: database is locked` error reported in #5525, which occurs under async concurrency in long-running BentoML services using the SQLite-based `ResultStore`.

**Root cause:** The `aiosqlite.connect()` call used default timeout (5s) and the default journal mode (DELETE), both of which are poor choices for concurrent access. Under moderate concurrency, multiple async tasks contend for the same SQLite database, and the short timeout causes immediate failures.

**Changes:**
- Set `timeout=30.0` on both the async (`aiosqlite`) and sync (`sqlite3`) connections to give SQLite time to wait for locks
- Enable WAL (Write-Ahead Logging) journal mode via `PRAGMA journal_mode=WAL`, which allows concurrent readers alongside a writer
- Set `PRAGMA busy_timeout=5000` as an additional SQLite-level retry mechanism

## Test plan
- [ ] Verify `aiosqlite` connection accepts `timeout` parameter
- [ ] Verify WAL mode is enabled after `__aenter__`
- [ ] Stress test with concurrent task submissions to confirm no more "database is locked" errors

Fixes #5525
