### PR TITLE
feat: native support for src-layout projects

### DIFF
--- a/src/bentoml/_internal/bento/bento.py
+++ b/src/bentoml/_internal/bento/bento.py
@@ -323,6 +323,7 @@ class Bento(StoreItem):
             with target_fs.joinpath("bentofile.yaml").open("w") as bentofile_yaml:
                 build_config.to_yaml(bentofile_yaml)
 
+            is_src_layout = build_config.python.is_src_layout
             for root, _, files in os.walk(ctx_path):
                 for f in files:
                     dir_path = os.path.relpath(root, ctx_path)
@@ -330,9 +331,13 @@ class Bento(StoreItem):
                     if specs.includes(path):
                         if ctx_path.joinpath(path).stat().st_size > 10 * 1024 * 1024:
                             logger.warning("File size is larger than 10MiB: %s", path)
-                        target_fs.joinpath(dir_path).mkdir(parents=True, exist_ok=True)
+                        dest_path = path
+                        if is_src_layout and path.startswith("src/"):
+                            dest_path = path[4:]
+                        dest_dir = os.path.dirname(dest_path)
+                        target_fs.joinpath(dest_dir).mkdir(parents=True, exist_ok=True)
                         src_file = ctx_path.joinpath(path)
-                        dst_file = target_fs.joinpath(path)
+                        dst_file = target_fs.joinpath(dest_path)
                         shutil.copy(src_file, dst_file)
             if image is None:
                 # NOTE: we need to generate both Python and Conda

--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -477,6 +477,7 @@ class PythonOptions:
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(ListStr)),
     )
+    is_src_layout: t.Optional[bool] = None
 
     def __attrs_post_init__(self):
         if self.requirements_txt and self.packages:
@@ -606,7 +607,6 @@ class PythonOptions:
                     f.write(f"{bentoml_req}\n")
                 elif sdist_name:
                     f.write(f"./wheels/{sdist_name}\n")
-
             is_empty = f.tell() == 0
 
         if self.lock_packages and not is_empty:
@@ -673,6 +673,8 @@ class PythonOptions:
             new_attrs["lock_packages"] = self.pack_git_packages is not False
         if self.pack_git_packages is None:
             new_attrs["pack_git_packages"] = True
+        if self.is_src_layout is None:
+            new_attrs["is_src_layout"] = False
         return attr.evolve(self, **new_attrs) if new_attrs else self
 
     @staticmethod
@@ -906,7 +908,9 @@ class BentoBuildConfig:
         return cls.load(yaml_content)
 
     @classmethod
-    def from_pyproject(cls, stream: t.BinaryIO) -> BentoBuildConfig:
+    def from_pyproject(
+        cls, stream: t.BinaryIO, base_dir: str | None = None
+    ) -> BentoBuildConfig:
         if sys.version_info >= (3, 11):
             import tomllib
         else:
@@ -920,13 +924,17 @@ class BentoBuildConfig:
         python_packages = build_config.python.packages or []
         python_packages.extend(dependencies)
         object.__setattr__(build_config.python, "packages", python_packages)
+        if build_config.python.is_src_layout is None:
+            # Default auto-discovery: if src/ exists in the same directory as pyproject.toml
+            if base_dir and os.path.isdir(os.path.join(base_dir, "src")):
+                object.__setattr__(build_config.python, "is_src_layout", True)
         return build_config
 
     @classmethod
     def from_file(cls, path: str) -> BentoBuildConfig:
         if os.path.basename(path) == "pyproject.toml":
             with open(path, "rb") as f:
-                return cls.from_pyproject(f)
+                return cls.from_pyproject(f, base_dir=os.path.dirname(path))
         else:
             with open(path, encoding="utf-8") as f:
                 return cls.from_yaml(f)

--- a/tests/unit/_internal/bento/test_bento.py
+++ b/tests/unit/_internal/bento/test_bento.py
@@ -133,6 +133,7 @@ python:
   extra_index_url: null
   pip_args: null
   wheels: null
+  is_src_layout: false
 conda:
   environment_yml: null
   channels: null

--- a/tests/unit/_internal/bento/test_src_layout.py
+++ b/tests/unit/_internal/bento/test_src_layout.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+from bentoml._internal.bento.build_config import BentoBuildConfig
+from bentoml._internal.bento.build_config import BentoPathSpec
+
+
+def test_src_layout_autodiscovery(tmp_path: Path):
+    pyproject_toml = """
+[project]
+name = "my_service"
+version = "0.1.0"
+"""
+    pyproject_file = tmp_path / "pyproject.toml"
+    pyproject_file.write_text(pyproject_toml)
+    (tmp_path / "src").mkdir()
+
+    with open(pyproject_file, "rb") as f:
+        build_config = BentoBuildConfig.from_pyproject(f, base_dir=str(tmp_path))
+
+    assert build_config.python.is_src_layout is True
+
+
+def test_src_layout_not_detected_without_src_dir(tmp_path: Path):
+    pyproject_toml = """
+[project]
+name = "my_service"
+version = "0.1.0"
+"""
+    pyproject_file = tmp_path / "pyproject.toml"
+    pyproject_file.write_text(pyproject_toml)
+
+    with open(pyproject_file, "rb") as f:
+        build_config = BentoBuildConfig.from_pyproject(f, base_dir=str(tmp_path))
+
+    assert build_config.python.is_src_layout is None
+
+
+def test_src_layout_strips_src_prefix_during_copy(tmp_path: Path):
+    """Verify that files under src/ are copied with the src/ prefix stripped
+    when is_src_layout is True, so imports work correctly in the bento."""
+    build_ctx = tmp_path / "project"
+    build_ctx.mkdir()
+    (build_ctx / "src" / "mypackage").mkdir(parents=True)
+    (build_ctx / "src" / "mypackage" / "__init__.py").write_text("# init")
+    (build_ctx / "src" / "mypackage" / "model.py").write_text("# model code")
+    (build_ctx / "service.py").write_text("# service code")
+    (build_ctx / "bentofile.yaml").write_text("service: service:svc")
+
+    build_config = BentoBuildConfig(
+        service="service:svc",
+        python={"is_src_layout": True},
+    ).with_defaults()
+
+    ctx_path = build_ctx.resolve()
+    specs = BentoPathSpec(build_config.include, build_config.exclude, str(build_ctx))
+
+    target_fs = tmp_path / "bento" / "src"
+    target_fs.mkdir(parents=True)
+
+    is_src_layout = build_config.python.is_src_layout
+    for root, _, files in os.walk(ctx_path):
+        for f in files:
+            dir_path = os.path.relpath(root, ctx_path)
+            path = os.path.join(dir_path, f).replace(os.sep, "/")
+            if specs.includes(path):
+                dest_path = path
+                if is_src_layout and path.startswith("src/"):
+                    dest_path = path[4:]
+                dest_dir = os.path.dirname(dest_path)
+                target_fs.joinpath(dest_dir).mkdir(parents=True, exist_ok=True)
+                shutil.copy(ctx_path / path, target_fs / dest_path)
+
+    assert (target_fs / "mypackage" / "__init__.py").exists()
+    assert (target_fs / "mypackage" / "model.py").exists()
+    assert (target_fs / "service.py").exists()
+    assert not (target_fs / "src" / "mypackage").exists(), (
+        "src/ prefix should be stripped, not nested"
+    )
+
+
+def test_no_src_layout_preserves_src_directory(tmp_path: Path):
+    """Without is_src_layout, files under src/ keep their path."""
+    build_ctx = tmp_path / "project"
+    build_ctx.mkdir()
+    (build_ctx / "src" / "mypackage").mkdir(parents=True)
+    (build_ctx / "src" / "mypackage" / "__init__.py").write_text("# init")
+    (build_ctx / "service.py").write_text("# service code")
+
+    build_config = BentoBuildConfig(
+        service="service:svc",
+        python={"is_src_layout": False},
+    ).with_defaults()
+
+    ctx_path = build_ctx.resolve()
+    specs = BentoPathSpec(build_config.include, build_config.exclude, str(build_ctx))
+
+    target_fs = tmp_path / "bento" / "src"
+    target_fs.mkdir(parents=True)
+
+    is_src_layout = build_config.python.is_src_layout
+    for root, _, files in os.walk(ctx_path):
+        for f in files:
+            dir_path = os.path.relpath(root, ctx_path)
+            path = os.path.join(dir_path, f).replace(os.sep, "/")
+            if specs.includes(path):
+                dest_path = path
+                if is_src_layout and path.startswith("src/"):
+                    dest_path = path[4:]
+                dest_dir = os.path.dirname(dest_path)
+                target_fs.joinpath(dest_dir).mkdir(parents=True, exist_ok=True)
+                shutil.copy(ctx_path / path, target_fs / dest_path)
+
+    assert (target_fs / "src" / "mypackage" / "__init__.py").exists(), (
+        "Without is_src_layout, src/ should be preserved"
+    )
+
+
+def test_src_layout_in_requirements(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        "bentoml._internal.configuration.is_editable_bentoml", lambda: False
+    )
+    monkeypatch.setattr(
+        "bentoml._internal.configuration.get_bentoml_requirement",
+        lambda: "bentoml==1.3.0",
+    )
+    monkeypatch.setattr(
+        "bentoml._internal.bento.bentoml_builder.is_editable_bentoml", lambda: False
+    )
+    monkeypatch.setattr(
+        "bentoml._internal.bento.build_config.get_bentoml_requirement",
+        lambda: "bentoml==1.3.0",
+    )
+    monkeypatch.setattr(
+        "bentoml._internal.bento.build_config.clean_bentoml_version", lambda: "1.3.0"
+    )
+
+    bento_fs = tmp_path / "bento"
+    bento_fs.mkdir()
+
+    build_ctx = tmp_path / "project"
+    build_ctx.mkdir()
+    (build_ctx / "src").mkdir()
+
+    build_config = BentoBuildConfig(
+        service="my_service.service:svc",
+        python={"is_src_layout": True, "lock_packages": False},
+    ).with_defaults()
+
+    build_config.python.write_to_bento(bento_fs, str(build_ctx))
+
+    requirements_file = bento_fs / "env" / "python" / "requirements.txt"
+    assert requirements_file.exists()
+
+    content = requirements_file.read_text()
+    assert "bentoml==1.3.0" in content
+    assert "src" not in content, "src should not appear in requirements"


### PR DESCRIPTION
## Description
Adds native support for Python projects using the src-layout pattern. During `bentoml build`, when a project's source code resides in `src/package_name/`, the `src/` prefix is stripped so the package is importable at runtime without editable installs.

## Changes
- **`bento.py`**: Strip `src/` prefix from file paths during the copy loop when `is_src_layout` is enabled
- **`build_config.py`**: Add `is_src_layout` option to `PythonOptions`; auto-detect by checking if `src/` directory exists alongside `pyproject.toml`
- **`test_src_layout.py`**: Tests for auto-discovery, prefix stripping, and requirements generation

## How it works
1. **Auto-detection**: When loading config from `pyproject.toml`, checks if a `src/` directory exists in the project root
2. **Manual override**: Set `is_src_layout: true` in `bentofile.yaml` under `python:`
3. **Build behavior**: Files under `src/` are copied with the prefix stripped (`src/mypackage/foo.py` → `mypackage/foo.py`)

No packaging or editable installs are involved — this is purely a file-copy path adjustment, consistent with how `bentoml build` works as a regular import mechanism.

Fixes #5537