### PR TITLE
fix: Allow dockerfile_template access during bentoml containerize

### DIFF
--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -255,7 +255,7 @@ class DockerOptions:
 
         if self.setup_script:
             try:
-                setup_script = resolve_user_filepath(self.setup_script, build_ctx)
+                setup_script = resolve_user_filepath(self.setup_script, build_ctx, secure=False)
             except FileNotFoundError as e:
                 raise InvalidArgument(f"Invalid setup_script file: {e}") from None
             if not os.access(setup_script, os.X_OK):
@@ -271,7 +271,7 @@ class DockerOptions:
         # This template then can be used later to containerize.
         if self.dockerfile_template is not None:
             shutil.copy2(
-                resolve_user_filepath(self.dockerfile_template, build_ctx),
+                resolve_user_filepath(self.dockerfile_template, build_ctx, secure=False),
                 docker_folder / "Dockerfile.template",
             )
 

--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -255,7 +255,9 @@ class DockerOptions:
 
         if self.setup_script:
             try:
-                setup_script = resolve_user_filepath(self.setup_script, build_ctx, secure=False)
+                setup_script = resolve_user_filepath(
+                    self.setup_script, build_ctx, secure=False
+                )
             except FileNotFoundError as e:
                 raise InvalidArgument(f"Invalid setup_script file: {e}") from None
             if not os.access(setup_script, os.X_OK):
@@ -271,7 +273,9 @@ class DockerOptions:
         # This template then can be used later to containerize.
         if self.dockerfile_template is not None:
             shutil.copy2(
-                resolve_user_filepath(self.dockerfile_template, build_ctx, secure=False),
+                resolve_user_filepath(
+                    self.dockerfile_template, build_ctx, secure=False
+                ),
                 docker_folder / "Dockerfile.template",
             )
 

--- a/src/bentoml/_internal/container/generate.py
+++ b/src/bentoml/_internal/container/generate.py
@@ -180,7 +180,7 @@ def generate_containerfile(
 
     user_templates = docker.dockerfile_template
     if user_templates is not None:
-        dir_path = os.path.dirname(resolve_user_filepath(user_templates, build_ctx))
+        dir_path = os.path.dirname(resolve_user_filepath(user_templates, build_ctx, secure=False))
         user_templates = os.path.basename(user_templates)
         TEMPLATES_PATH.append(dir_path)
         environment = ENVIRONMENT.overlay(

--- a/src/bentoml/_internal/container/generate.py
+++ b/src/bentoml/_internal/container/generate.py
@@ -180,7 +180,9 @@ def generate_containerfile(
 
     user_templates = docker.dockerfile_template
     if user_templates is not None:
-        dir_path = os.path.dirname(resolve_user_filepath(user_templates, build_ctx, secure=False))
+        dir_path = os.path.dirname(
+            resolve_user_filepath(user_templates, build_ctx, secure=False)
+        )
         user_templates = os.path.basename(user_templates)
         TEMPLATES_PATH.append(dir_path)
         environment = ENVIRONMENT.overlay(


### PR DESCRIPTION
## What does this PR address?

Fixes #5566

PR #5548 introduced a security fix that added `secure=True` as the default for `resolve_user_filepath()`. This inadvertently broke `bentoml containerize` when using `dockerfile_template` or `setup_script` paths outside the current working directory.

## Root Cause

After the security fix in PR #5548, the `resolve_user_filepath()` function defaults to `secure=True`, which:
1. Rejects absolute paths
2. Rejects paths that resolve outside the current working directory
3. Rejects hidden files

The `dockerfile_template` and `setup_script` options in the bento configuration are user-provided paths that should legitimately be allowed to reference files outside the immediate build context (e.g., shared templates in a parent directory).

## Changes

This fix adds `secure=False` to the `resolve_user_filepath()` calls for:
- `dockerfile_template` in `build_config.py` and `generate.py`
- `setup_script` in `build_config.py`

## Testing

- Ran existing unit tests in `tests/unit/_internal/bento/test_bento.py` - all pass
- Verified the fix allows accessing templates outside the cwd

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md)?

---

I have read the CLA Document and I hereby sign the CLA.
