### PR TITLE
fix: add sharing=locked to BuildKit cache mounts for multi-arch builds

### DIFF
--- a/src/bentoml/_internal/container/frontend/dockerfile/templates/_macros.j2
+++ b/src/bentoml/_internal/container/frontend/dockerfile/templates/_macros.j2
@@ -1,4 +1,4 @@
-{%- macro mount_cache(target, extra_args="") -%}--mount=type=cache,target={{ target }}{{ extra_args }}{%- endmacro -%}
+{%- macro mount_cache(target, extra_args="") -%}--mount=type=cache,sharing=locked,target={{ target }}{{ extra_args }}{%- endmacro -%}
 
 {%- macro RUN(enable_buildkit=True) -%}
 {% if not enable_buildkit %}RUN {% else -%}RUN {{ caller() }} {%- endif -%}

--- a/tests/unit/_internal/container/test_generate.py
+++ b/tests/unit/_internal/container/test_generate.py
@@ -18,3 +18,24 @@ def test_generate_containerfile_quotes_system_packages(tmp_path) -> None:
     )
 
     assert "libpq-dev 'package name' 'foo$(touch /tmp/pwned)'" in dockerfile
+
+
+def test_generate_containerfile_cache_mounts_use_sharing_locked(tmp_path) -> None:
+    dockerfile = generate_containerfile(
+        DockerOptions(
+            distro="debian",
+            python_version="3.11",
+        ),
+        str(tmp_path),
+        conda=CondaOptions(),
+        bento_fs=tmp_path,
+    )
+
+    import re
+
+    cache_mounts = re.findall(r"--mount=type=cache[^ ]+", dockerfile)
+    assert len(cache_mounts) > 0, "expected at least one cache mount"
+    for mount in cache_mounts:
+        assert "sharing=locked" in mount, (
+            f"cache mount missing sharing=locked: {mount}"
+        )

--- a/tests/unit/_internal/container/test_generate.py
+++ b/tests/unit/_internal/container/test_generate.py
@@ -36,6 +36,4 @@ def test_generate_containerfile_cache_mounts_use_sharing_locked(tmp_path) -> Non
     cache_mounts = re.findall(r"--mount=type=cache[^ ]+", dockerfile)
     assert len(cache_mounts) > 0, "expected at least one cache mount"
     for mount in cache_mounts:
-        assert "sharing=locked" in mount, (
-            f"cache mount missing sharing=locked: {mount}"
-        )
+        assert "sharing=locked" in mount, f"cache mount missing sharing=locked: {mount}"


### PR DESCRIPTION
Fixes #5229

## Problem

When using `bentoml containerize` with `docker buildx` for multi-arch builds (`--platform=linux/amd64,linux/arm64`), concurrent platform builds contend on package manager lock files inside shared BuildKit cache mounts, causing `apt-get` (and potentially `yum`/`apk`) to fail:

```
E: Could not get lock /var/lib/apt/lists/lock. It is held by process 0
E: Unable to lock directory /var/lib/apt/lists/
```

## Cause

The `mount_cache` Jinja2 macro generates `--mount=type=cache,target=...` without specifying a `sharing` mode. BuildKit defaults to `sharing=shared`, which allows concurrent access to the mount from multiple parallel builders. Package managers use advisory locks that don't work across BuildKit's namespaced filesystem views, so parallel platform builds contend on the same lock files.

## Fix

Add `sharing=locked` to the `mount_cache` macro. This causes BuildKit to serialize access to cache mounts at the daemon level, so concurrent platform builds wait for each other instead of failing. This is the documented BuildKit mechanism for this exact scenario.

- For single-arch builds, `sharing=locked` has zero impact (no contention).
- `sharing=private` was not chosen because it would create separate caches per platform, defeating the purpose of caching.
- The change applies to all cache mounts (apt, yum, apk, conda, pip/uv) since all are susceptible to the same contention.

## Validation

- Existing test `test_generate_containerfile_quotes_system_packages` passes.
- Added regression test `test_generate_containerfile_cache_mounts_use_sharing_locked` verifying all cache mounts include `sharing=locked`.