### PR TITLE
fix(serve-grpc): clearer error when given a new-SDK service

### DIFF
--- a/src/bentoml/serving.py
+++ b/src/bentoml/serving.py
@@ -590,6 +590,18 @@ def serve_grpc_production(
     svc = load(bento_identifier, working_dir=working_dir)
 
     if not isinstance(svc, Service):
+        try:
+            from _bentoml_sdk import Service as NewService
+        except ImportError:
+            NewService = None  # type: ignore[assignment]
+        if NewService is not None and isinstance(svc, NewService):
+            raise BentoMLException(
+                "gRPC serving is not supported for services defined with the "
+                "`@bentoml.service` decorator (the bentoml>=1.2 programming "
+                "model). Use `bentoml serve` to run the service over HTTP, or "
+                "rewrite it using the legacy `bentoml.Service` API if gRPC is "
+                "required."
+            )
         raise BentoMLException(f"{type(svc)} type doesn't support gRPC serving")
 
     from circus.sockets import CircusSocket  # type: ignore

--- a/tests/unit/test_serve_grpc_new_sdk_error.py
+++ b/tests/unit/test_serve_grpc_new_sdk_error.py
@@ -1,0 +1,50 @@
+"""Regression test for bentoml#5607.
+
+`serve-grpc` used to fail with the unhelpful message::
+
+    <class '_bentoml_sdk.service.factory.Service'> type doesn't support gRPC serving
+
+when pointed at a service defined with the `@bentoml.service` decorator
+(the bentoml>=1.2 programming model). gRPC is only implemented for the
+legacy `bentoml.Service` API, so this case should raise a clear error
+that tells the user what to do instead.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bentoml.exceptions import BentoMLException
+from bentoml.serving import serve_grpc_production
+
+NEW_SDK_SERVICE = """
+from __future__ import annotations
+
+import bentoml
+
+
+@bentoml.service(name="grpc_smoke")
+class Supervisor:
+    @bentoml.api
+    def greet(self, name: str = "world") -> str:
+        return f"hello {name}"
+"""
+
+
+def test_serve_grpc_rejects_new_sdk_service_with_clear_message(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "service.py").write_text(NEW_SDK_SERVICE)
+
+    with pytest.raises(BentoMLException) as exc_info:
+        serve_grpc_production(
+            "service.py:Supervisor",
+            working_dir=str(tmp_path),
+        )
+
+    message = str(exc_info.value)
+    assert "gRPC serving is not supported" in message
+    assert "@bentoml.service" in message
+    assert "bentoml serve" in message


### PR DESCRIPTION
## What does this PR address?

Fixes #5607

`bentoml serve-grpc` accepts any importable target, including services defined with the `@bentoml.service` decorator (the bentoml>=1.2 programming model). gRPC is only implemented for the legacy `bentoml.Service` API, so pointing `serve-grpc` at a new-SDK service fails with:

```
Error: [serve] `serve-grpc` failed: <class '_bentoml_sdk.service.factory.Service'> type doesn't support gRPC serving
```

The message is correct but unhelpful. The user has no way to tell from it that the new programming model has no gRPC path and that the fix is to switch transports or APIs.

### Repro

```python
# service.py
import bentoml

@bentoml.service(name="grpc_smoke")
class Supervisor:
    @bentoml.api
    def greet(self, name: str = "world") -> str:
        return f"hello {name}"
```

```
$ bentoml serve-grpc service.py:Supervisor --port 9098
Error: [serve] `serve-grpc` failed: <class '_bentoml_sdk.service.factory.Service'> type doesn't support gRPC serving
```

### After this PR

```
$ bentoml serve-grpc service.py:Supervisor --port 9098
Error: [serve] `serve-grpc` failed: gRPC serving is not supported for services defined with the `@bentoml.service` decorator (the bentoml>=1.2 programming model). Use `bentoml serve` to run the service over HTTP, or rewrite it using the legacy `bentoml.Service` API if gRPC is required.
```

### Changes

- `src/bentoml/serving.py`: in `serve_grpc_production`, detect `_bentoml_sdk.Service` instances explicitly and raise a `BentoMLException` that names the programming model and points at the two viable workarounds. Any other unrecognised type still falls through to the existing generic message.
- `tests/unit/test_serve_grpc_new_sdk_error.py`: writes a minimal `@bentoml.service` definition into a tmp dir and asserts `serve_grpc_production` raises the new wording.

I did not implement gRPC for the new SDK in this PR. That is a feature, not a bug fix, and the `serve-grpc` CLI is already `hidden=True` which suggests it is being phased out for new-style services.

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Yes (`fix:` prefix)
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed? Yes, ran on changed files.
- [x] Did you read through contribution guidelines and follow development guidelines?
- [ ] Did your changes require updates to the documentation? No, error message change only.
- [x] Did you write tests to cover your changes?