### PR TITLE
docs(security): document default deployment trust model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,34 @@ If you discover a potential security vulnerability, we kindly request that you r
 
 Alternatively, you can [open a security advisory](https://github.com/bentoml/BentoML/security/advisories/new) on GitHub.
 
+## Default deployment trust model
+
+A BentoML service started with `bentoml serve` listens on `0.0.0.0:3000`
+by default. The HTTP and gRPC endpoints accept all requests, and the
+inference routes are reachable without authentication.
+
+BentoML does not ship an opinionated authentication layer. The bento
+author is expected to add their own protection before exposing the
+service to an untrusted network:
+
+- HTTP: mount Starlette middleware that validates an API key, JWT, or
+  upstream identity header. Example:
+
+  ```python
+  from starlette.middleware import Middleware
+  from my_auth import APIKeyMiddleware
+
+  svc.add_asgi_middleware(APIKeyMiddleware, header="x-api-key")
+  ```
+
+- gRPC: add an interceptor that enforces the same check at
+  `bentoml.grpc.interceptors`.
+
+Reports describing "the default service accepts unauthenticated
+requests" therefore match the documented design and will not be
+treated as a vulnerability. Reports describing an auth-middleware
+bypass once the middleware is in place are in scope.
+
 ## Exceptions
 
 The following reports are out of scope and will not be accepted as


### PR DESCRIPTION
## Why

`SECURITY.md` does not document the default authentication posture of a deployed BentoML service. A bento started with `bentoml serve` listens on `0.0.0.0:3000` and accepts HTTP and gRPC requests without authentication; there is no built-in API-key validation, JWT check, or OAuth flow.

A search of past issues (#1273, #2768, #2809, #1031) shows that the "add auth to bentoml" question keeps coming up and getting closed without a documented design answer. Peer projects (HuggingFace transformers, NVIDIA Triton, vLLM) document their default-auth posture up front and route the responsibility to the operator. This PR brings BentoML in line with that practice.

## What

Adds a new section "Default deployment trust model" to `SECURITY.md`, between "Reporting a Vulnerability" and "Exceptions". The section:

- States that the default deployment has no built-in authentication.
- Names the bento author's responsibility: add Starlette middleware (HTTP) or a gRPC interceptor before exposing to an untrusted network.
- Provides a 5-line example using the public API `svc.add_asgi_middleware(...)` (defined at `src/bentoml/_internal/service/service.py:445`).
- References the gRPC interceptors package at `bentoml.grpc.interceptors`.
- Scopes the threat model: "default has no auth" reports are out of scope; auth-middleware bypass once enabled is in scope.

No code change. No behavior change. No backwards compatibility risk.

## Impact

- Operators reading the security policy see the boundary up front.
- Security inbox can triage "no default auth" reports against a written design choice instead of re-arguing per advisory.
- New BentoML deployers understand they need to add auth before going public.

## Testing

Pure docs PR; no automated test applies. Verification:

- GitHub markdown preview confirms section renders between "Reporting a Vulnerability" and "Exceptions".
- Code block syntax-highlights as Python.
- Internal API reference checked: `svc.add_asgi_middleware` exists on HEAD `e570eb2b` (grep verified).
- `bentoml.grpc.interceptors` package exists (verified).

## References

- Related issues that asked variants of "how do I add auth to my bento?": #1273, #2768, #2809.
- Related network-config issue: #1031.
- Peer-project precedent: HuggingFace transformers SECURITY.md, NVIDIA Triton README Security section, vLLM published GHSA cluster.

## Checklist

- [x] No code change.
- [x] No behavior change.
- [x] No backwards compatibility break.
- [x] Aligned with peer-project security policies.