### PR TITLE
fix(dockerfile): disable followlinks in Jinja2 FileSystemLoader

### DIFF
--- a/src/bentoml/_internal/container/generate.py
+++ b/src/bentoml/_internal/container/generate.py
@@ -126,7 +126,7 @@ def build_environment() -> Environment:
         extensions=["jinja2.ext.loopcontrols"],
         trim_blocks=True,
         lstrip_blocks=True,
-        loader=FileSystemLoader(templates_path, followlinks=True),
+        loader=FileSystemLoader(templates_path, followlinks=False),
     )
     environment.filters["bash_quote"] = shlex.quote
     environment.filters["normalize_line"] = normalize_line
@@ -205,7 +205,7 @@ def generate_containerfile(
         user_templates = os.path.basename(user_templates)
         templates_path.append(dir_path)
         environment = ENVIRONMENT.overlay(
-            loader=FileSystemLoader(templates_path, followlinks=True)
+            loader=FileSystemLoader(templates_path, followlinks=False)
         )
         template = environment.get_template(
             user_templates,


### PR DESCRIPTION
## Why

`generate.py` configures `FileSystemLoader(templates_path, followlinks=True)` in two places (built-in templates loader and user-template overlay loader). Jinja2 default is `followlinks=False`; BentoML explicitly opts in.

The built-in templates path is package-internal and does not need symlink resolution. The user-template overlay path is build-context controlled. If the build context contains symlinks, Jinja2 resolves through them when an `{% include %}` or `{% extends %}` uses a relative path. CVE-2026-40610 fixed the outer build-context symlink traversal but did not address the per-template Jinja2 resolver.

## What

Flip both occurrences to `followlinks=False`. Two-line change. Defense-in-depth on CVE-2026-40610.

## Impact

Any user who currently uses symlinks inside their Dockerfile-template directory would see a `TemplateNotFound` error and need to copy the file directly instead. Search of `gh issues/PRs` shows no reports of this pattern in use; ship with a release-notes line.

## Testing

- `pytest tests/unit/_internal/container/test_generate.py` (existing).
- Manual: build a bento with a `dockerfile_template` field, verify it still renders.