### PR TITLE
fix(io): drop pickle dispatch from PandasDataFrame.from_sample

### DIFF
--- a/src/bentoml/_internal/io_descriptors/pandas.py
+++ b/src/bentoml/_internal/io_descriptors/pandas.py
@@ -414,7 +414,6 @@ class PandasDataFrame(
                                 "xlsx": "read_excel",
                                 "hdf5": "read_hdf",
                                 "parquet": "read_parquet",
-                                "pickle": "read_pickle",
                                 "sql": "read_sql",
                             }[ext],
                         )(sample)


### PR DESCRIPTION
## Why

`PandasDataFrame.from_sample(str_path)` dispatches on file extension and maps `.pickle` to `pd.read_pickle`. A bento author who points `from_sample` at an untrusted pickle file (HuggingFace cache, shared NFS, etc.) executes arbitrary Python at descriptor construction.

This is build-time, not runtime. `SECURITY.md`'s pickle exception ("pickle-related vulnerabilities in the runner service or dependency service") does not cover this build-time path.

## What

Delete one line from the dispatch table at `_internal/io_descriptors/pandas.py:417`:

```python
"pickle": "read_pickle",
```

The `from_sample` string overload is already deprecated. Authors who want pickle can `pd.read_pickle()` explicitly.

## Impact

Bentos calling `PandasDataFrame.from_sample("file.pickle")` will hit `InvalidArgument("Unsupported sample '...' format.")`. Acceptable: the function is already deprecated for string input.

## Testing

- `pytest tests/unit/_internal/io_descriptors/test_pandas.py`