### PR TITLE
fix(build_config): validate envs[*].name against POSIX env-var regex

### DIFF
--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -776,11 +776,25 @@ def _model_spec_structure_hook(
 
 EnvStage = t.Literal["all", "build", "runtime"]
 
+# POSIX env-var name (IEEE Std 1003.1, section 3.231): starts with letter or
+# underscore, followed by letters, digits, or underscores. Catching malformed
+# names at parse time gives a clear bentofile error and is defense-in-depth
+# on CVE-2026-44346, where Dockerfile command injection via envs[*].name was
+# fixed at template render time via shell-quote.
+_POSIX_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_posix_env_name(instance: t.Any, attribute: t.Any, value: str) -> None:
+    if not _POSIX_ENV_NAME_RE.match(value):
+        raise ValueError(
+            f"envs[*].name {value!r} must match {_POSIX_ENV_NAME_RE.pattern} (POSIX env-var)"
+        )
+
 
 @attr.define(eq=True)
 class BentoEnvSchema:
     __forbid_extra_keys__ = False
-    name: str
+    name: str = attr.field(validator=_validate_posix_env_name)
     value: str = ""
     stage: EnvStage = attr.field(
         default="all",


### PR DESCRIPTION
## Why

CVE-2026-44346 (GHSA-w2pm-x38x-jp44) fixed Dockerfile command injection via `envs[*].name` by shell-quoting at template render time. The field is still accepted as an arbitrary string at parse time; the protection relies entirely on downstream Dockerfile escape.

POSIX env-var names match `^[A-Za-z_][A-Za-z0-9_]*$` (IEEE Std 1003.1, section 3.231). Catching malformed names at parse time produces a clear bentofile error and is a layered defense if any future template path accidentally bypasses escape.

## What

Add an `attr.field` validator on `BentoEnvSchema.name` that requires the POSIX regex. Reject malformed names with a clear `ValueError` at parse.

## Impact

- Defense-in-depth on CVE-2026-44346.
- Bentos with non-POSIX env-var names (e.g. hyphens) fail at parse with a clear message. Docker/Kubernetes/POSIX shells already reject such names downstream; affected configs are broken upstream too.

## Testing

`pytest tests/unit/_internal/bento/test_build_config.py` (existing test suite).
Add a regression test asserting `BentoEnvSchema(name="FOO-BAR")` raises if maintainer requests.