### PR TITLE
fix: avoid FileSchema string payload fallthrough

### DIFF
--- a/src/_bentoml_sdk/validators.py
+++ b/src/_bentoml_sdk/validators.py
@@ -128,12 +128,12 @@ class FileSchema:
 
         media_type: str | None = None
 
+        if isinstance(obj, PurePath):
+            return Path(obj)
         if isinstance(obj, str):
             body = obj.encode("utf-8")
             filename = None
-        if isinstance(obj, PurePath):
-            return Path(obj)
-        if isinstance(obj, UploadFile):
+        elif isinstance(obj, UploadFile):
             body = obj.file.read()
             filename = obj.filename
             media_type = obj.content_type

--- a/tests/unit/_bentoml_sdk/test_validators.py
+++ b/tests/unit/_bentoml_sdk/test_validators.py
@@ -25,3 +25,16 @@ def test_file_schema_decode_with_path_separator_in_filename(tmp_path: Path):
     assert result.exists()
     assert result.read_bytes() == file_content
     assert result.suffix == ".pdf"
+
+
+def test_file_schema_decode_with_string_payload(tmp_path: Path):
+    file_content = "test content"
+
+    with patch(
+        "bentoml._internal.context.request_temp_dir", return_value=str(tmp_path)
+    ):
+        result = FileSchema().decode(file_content)
+
+    assert isinstance(result, Path)
+    assert result.exists()
+    assert result.read_text() == file_content


### PR DESCRIPTION
## What does this PR address?

`FileSchema.decode()` accepts `str` inputs and starts handling them as UTF-8 file content, but the next branch was a separate `if` instead of an `elif`. As a result, string payloads still fell through to the final invalid-file-type error instead of being written to a temporary file.

This keeps `PurePath` inputs as paths, handles `str` payloads as file content, and adds a regression test for that behavior.

## Validation

- `.venv/bin/python -m pytest tests/unit/_bentoml_sdk/test_validators.py -q` -> `2 passed in 0.42s`
- `.venv/bin/python -m pytest tests/unit/_bentoml_sdk -q` -> `3 passed in 2.64s`
- `uvx ruff check src/_bentoml_sdk/validators.py tests/unit/_bentoml_sdk/test_validators.py` -> `All checks passed!`
- `uvx ruff format --check src/_bentoml_sdk/validators.py tests/unit/_bentoml_sdk/test_validators.py` -> `2 files already formatted`

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming?
- [x] Does the code follow BentoML code style? Targeted `ruff check` and `ruff format --check` passed for the changed files.
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [x] Did your changes require updates to the documentation? No documentation changes needed for this bug fix.
- [x] Did you write tests to cover your changes?
