### PR TITLE
docs: add API method mocking example

### DIFF
--- a/docs/source/build-with-bentoml/testing.rst
+++ b/docs/source/build-with-bentoml/testing.rst
@@ -87,6 +87,50 @@ This unit test does the following:
 
     When the output is fixed and known (for example, a function that returns a constant value or a predictable result based on the input), you can write tests that directly assert the expected output. In such cases, mocking might still be used to isolate the function from any dependencies it has, but the focus of the test can be on asserting that the function returns the exact expected value.
 
+Mock API method bodies
+^^^^^^^^^^^^^^^^^^^^^^
+
+In most unit tests, it is better to mock the model, client, or helper function called by a
+Service method, as shown above. If you need to replace the decorated API method itself,
+patch the underlying ``APIMethod.func`` on ``Service.inner``. The replacement function
+should keep the same ``self`` parameter as the original method.
+
+.. code-block:: python
+    :caption: `test_mock_api_method.py`
+
+    import bentoml
+
+
+    @bentoml.service
+    class Summarization:
+        @bentoml.api
+        def summarize(self, text: str) -> str:
+            return f"real summary: {text}"
+
+
+    def test_mock_decorated_api_method(monkeypatch):
+        def fake_summarize(self, text: str) -> str:
+            return f"mock summary: {text}"
+
+        monkeypatch.setattr(
+            Summarization.inner.summarize,
+            "func",
+            fake_summarize,
+        )
+
+        service = Summarization()
+
+        assert service.summarize("BentoML testing") == "mock summary: BentoML testing"
+
+The same pattern works with a dotted path if that is more convenient for the test:
+
+.. code-block:: python
+
+    monkeypatch.setattr(
+        "service.Summarization.inner.summarize.func",
+        fake_summarize,
+    )
+
 Run the unit test:
 
 .. code-block:: bash


### PR DESCRIPTION
Closes #4902

Adds a focused unit-testing example for replacing a decorated BentoML API method body with pytest's monkeypatch.

The new section explains that most tests should mock the dependency under the Service method, but when the decorated API method itself needs to be replaced, the underlying `APIMethod.func` lives on `Service.inner.<api_name>`. The example keeps the replacement function signature compatible with the original method and also shows the dotted-path form.

Verification:

- Confirmed the documented `Summarization.inner.summarize.func` path works against an editable local BentoML install.
- Ran `git diff --check`.
- Ran a Sphinx dummy build with a temp config that skips the local spelling extension because this machine does not have the `enchant` C library installed. The build completed with existing docs warnings.