### PR TITLE
docs: add Model API reference

### DIFF
--- a/docs/source/reference/bentoml/stores.rst
+++ b/docs/source/reference/bentoml/stores.rst
@@ -31,6 +31,11 @@ Load models
 Manage models
 -------------
 
+.. autoclass:: bentoml.Model
+    :members: tag, info, custom_objects, creation_time, path, path_of, file_size, save, from_path, import_from, export, to_runner, to_runnable, load_model, with_options
+    :inherited-members:
+    :show-inheritance:
+
 .. autofunction:: bentoml.models.create
 .. autofunction:: bentoml.models.list
 .. autofunction:: bentoml.models.get


### PR DESCRIPTION
Closes #3369

Adds `bentoml.Model` to the Bento/model API reference page so SDK methods such as `export` and `import_from` are discoverable from the generated reference docs.

Verification:

- Confirmed `bentoml.Model` imports from an editable local BentoML install and exposes `export`, `import_from`, `load_model`, and `with_options`.
- Ran `git diff --check`.
- Ran a Sphinx dummy build with a temp config that skips the local spelling extension because this machine does not have the `enchant` C library installed. The build completed with existing docs warnings.