### PR TITLE
Fix typo: happend -> happen

### DIFF
--- a/src/bentoml/exceptions.py
+++ b/src/bentoml/exceptions.py
@@ -55,7 +55,7 @@ class InternalServerError(BentoMLException):
     Request, or python API function parameters, but got internal issues while
     processing.
 
-    * Note to BentoML developers: raise this exception only when exceptions happend
+    * Note to BentoML developers: raise this exception only when exceptions happen
     in the users' code (runner or service) and want to surface it to the user.
     """
 


### PR DESCRIPTION
Tiny typo in a docstring comment in [src/bentoml/exceptions.py:58](src/bentoml/exceptions.py#L58). Comment only, no behavior change.