### PR TITLE
fix: apply timeout to mounted ASGI apps (#5246)

### DIFF
--- a/src/_bentoml_impl/server/app.py
+++ b/src/_bentoml_impl/server/app.py
@@ -25,6 +25,7 @@ from _bentoml_sdk.service import set_current_service
 from bentoml._internal.container import BentoMLContainer
 from bentoml._internal.marshal.dispatcher import CorkDispatcher
 from bentoml._internal.resource import system_resources
+from bentoml._internal.server.http.traffic import TimeoutMiddleware
 from bentoml._internal.server.base_app import BaseAppFactory
 from bentoml._internal.server.http_app import log_exception
 from bentoml._internal.types import LazyType
@@ -190,6 +191,8 @@ class ServiceAppFactory(BaseAppFactory):
             self.service.mount_asgi_app(create_proxy_app(self.service), name="proxy")
 
         for mount_app, path, name in self.service.mount_apps:
+            if self.timeout is not None:
+                mount_app = TimeoutMiddleware(mount_app, timeout=self.timeout)
             app.router.routes.append(PassiveMount(path, mount_app, name=name))
 
         if self.is_main:

--- a/src/_bentoml_impl/server/app.py
+++ b/src/_bentoml_impl/server/app.py
@@ -25,8 +25,8 @@ from _bentoml_sdk.service import set_current_service
 from bentoml._internal.container import BentoMLContainer
 from bentoml._internal.marshal.dispatcher import CorkDispatcher
 from bentoml._internal.resource import system_resources
-from bentoml._internal.server.http.traffic import TimeoutMiddleware
 from bentoml._internal.server.base_app import BaseAppFactory
+from bentoml._internal.server.http.traffic import TimeoutMiddleware
 from bentoml._internal.server.http_app import log_exception
 from bentoml._internal.types import LazyType
 from bentoml._internal.utils import is_async_callable


### PR DESCRIPTION
Closes #5246

## Problem
`traffic={"timeout": N}` was applied to native BentoML API routes
but ignored for apps mounted via `@bentoml.asgi_app`. Mounted routes
ran under the default 60s timeout regardless of config.

## Fix
Wrap each mounted app with `TimeoutMiddleware` at mount time in
`ServiceAppFactory.__call__`, using the existing `self.timeout`
value from the base class.

## Test
Start service with `traffic={"timeout": 10}`, hit a mounted FastAPI
route that sleeps 15s — now returns 504 after 10s.