### PR TITLE
fix(io_models): guard against IndexError for bare iterator return annotations

### DIFF
--- a/src/_bentoml_sdk/io_models.py
+++ b/src/_bentoml_sdk/io_models.py
@@ -432,7 +432,8 @@ class IODescriptor(IOMixin, BaseModel):
             )
         media_type: str | None = None
         if is_iterator_type(return_annotation):
-            return_annotation = get_args(return_annotation)[0]
+            args = get_args(return_annotation)
+            return_annotation = args[0] if args else t.Any
         elif is_annotated(return_annotation):
             content_type = next(
                 (a for a in get_args(return_annotation) if isinstance(a, ContentType)),

--- a/tests/unit/_bentoml_sdk/test_io_models.py
+++ b/tests/unit/_bentoml_sdk/test_io_models.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import typing as t
+
+from _bentoml_sdk.io_models import IODescriptor
+
+
+def test_from_output_bare_iterator_does_not_raise():
+    """Bare Iterator/Generator with no type args must not raise IndexError."""
+
+    def fn() -> t.Iterator:
+        yield 1
+
+    spec = IODescriptor.from_output(fn)
+    assert spec is not None


### PR DESCRIPTION
## What's broken

`IODescriptor.from_output()` raises `IndexError: tuple index out of range` whenever a service method is annotated with an unparameterized iterator type (`t.Iterator`, `t.Generator`, `t.AsyncIterator`, `t.AsyncGenerator`, or their `collections.abc` equivalents). Service startup crashes before any request is served.

## Why it happens

`is_iterator_type()` correctly returns `True` for bare generics, but `get_args()` returns an empty tuple `()` for types with no type parameters. Line 435 unconditionally indexes position 0 without a bounds check. The surrounding `try/except` only catches `ValueError` and `TypeError`, so the `IndexError` escapes.

## Fix

Added a one-line guard: `args = get_args(return_annotation); return_annotation = args[0] if args else t.Any`. When no type argument is present the descriptor defaults to `t.Any`, which is the same behaviour used when the return annotation is absent entirely.

## Test

Added `tests/unit/_bentoml_sdk/test_io_models.py::test_from_output_bare_iterator_does_not_raise` which calls `IODescriptor.from_output()` with a `-> t.Iterator` annotated function and asserts it returns without raising.

Fixes #5625