### PR TITLE
Harden standalone runner server host default

### DIFF
--- a/src/bentoml_cli/_internal/start.py
+++ b/src/bentoml_cli/_internal/start.py
@@ -413,8 +413,11 @@ def build_start_command() -> click.Group:
     @click.option(
         "--host",
         type=click.STRING,
-        default=BentoMLContainer.http.host.get(),
-        help="The host to bind for the REST api server [defaults: 127.0.0.1(dev), 0.0.0.0(production)]",
+        default=None,
+        help=(
+            "The host to bind for the runner server. Defaults to 127.0.0.1 "
+            "unless explicitly configured."
+        ),
         envvar="BENTOML_HOST",
     )
     @click.option(

--- a/tests/test_cli_regression.py
+++ b/tests/test_cli_regression.py
@@ -34,3 +34,54 @@ def test_regression(runner: CliRunner):
         )
         finish = time.perf_counter_ns() - start
     assert not ret and finish <= 1.7 * 1e6
+
+
+def test_start_runner_server_uses_localhost_default(
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+):
+    from bentoml import start as start_mod
+    from bentoml_cli._internal.start import start_command
+
+    calls = []
+
+    def fake_start_runner_server(*args: object, **kwargs: object) -> None:
+        calls.append({"args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr(start_mod, "start_runner_server", fake_start_runner_server)
+
+    result = runner.invoke(
+        start_command,
+        ["start-runner-server", "test-bento", "--runner-name", "test-runner"],
+    )
+
+    assert result.exit_code == 0
+    assert calls[0]["kwargs"]["host"] is None
+
+
+def test_start_runner_server_keeps_explicit_host(
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+):
+    from bentoml import start as start_mod
+    from bentoml_cli._internal.start import start_command
+
+    calls = []
+
+    def fake_start_runner_server(*args: object, **kwargs: object) -> None:
+        calls.append({"args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr(start_mod, "start_runner_server", fake_start_runner_server)
+
+    result = runner.invoke(
+        start_command,
+        [
+            "start-runner-server",
+            "test-bento",
+            "--runner-name",
+            "test-runner",
+            "--host",
+            "0.0.0.0",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls[0]["kwargs"]["host"] == "0.0.0.0"


### PR DESCRIPTION
## What changed

This changes the deprecated standalone `start-runner-server` CLI host default from the global HTTP server host configuration to the runner implementation's existing localhost fallback. Explicit `--host` values and `BENTOML_HOST` are still preserved.

## Why

Managed runner servers are already started on `127.0.0.1`, but the standalone CLI option could inherit the global HTTP host default. In v2 config that value is `0.0.0.0`, which is a surprising default for a runner endpoint that is meant to be internal to BentoML serving.

Keeping the CLI value unset unless the user explicitly configures it lets `bentoml.start.start_runner_server()` continue applying its existing `127.0.0.1` fallback, while users who intentionally expose the runner server can still pass `--host 0.0.0.0`.

## Validation

- `python -m py_compile src\bentoml_cli\_internal\start.py tests\test_cli_regression.py`
- `git diff --check`
- `python -m pytest -o addopts= tests\test_cli_regression.py -k "start_runner_server" -q` (`2 passed`)

I also ran `python -m pytest -o addopts= tests\test_cli_regression.py -q`; the two new tests passed, but the pre-existing timing assertion in `test_regression` failed locally on this machine. That timing test is already xfailed on GitHub Actions.