### PR TITLE
test: cover custom base_image without python_version (#5198)

### DIFF
--- a/tests/unit/_internal/container/test_generate.py
+++ b/tests/unit/_internal/container/test_generate.py
@@ -64,3 +64,25 @@ def test_generate_containerfile_normalizes_custom_base_image(tmp_path) -> None:
 
     assert "FROM python:3.11-slim RUN touch /tmp/pwned as base-container" in dockerfile
     assert "\nRUN touch /tmp/pwned" not in dockerfile
+
+
+def test_generate_containerfile_custom_base_image_without_python_version(
+    tmp_path,
+) -> None:
+    # Regression test for #5198: a custom base_image with no python_version must
+    # not emit `uv venv -p None`, which crashes `bentoml containerize`. uv must
+    # also be auto-installed rather than assumed present on the base image.
+    docker = DockerOptions(base_image="custom-base-image:latest").with_defaults()
+    assert docker.python_version is None
+
+    dockerfile = generate_containerfile(
+        docker,
+        str(tmp_path),
+        conda=CondaOptions(),
+        bento_fs=tmp_path,
+    )
+
+    assert "uv venv" in dockerfile
+    assert "-p None" not in dockerfile
+    assert "--python None" not in dockerfile
+    assert "command -v uv >/dev/null || pip install uv" in dockerfile


### PR DESCRIPTION
Adds a regression test for the Dockerfile generation path used by custom `base_image`.

## What

When a custom `docker.base_image` is set without a `python_version`, `generate_containerfile` must not emit `uv venv -p None` (which crashes `bentoml containerize`), and `uv` must be auto-installed rather than assumed present on the base image.

This behavior is currently correct on `main` (the `base.j2` template guards `-p` behind `{% if __options__python_version %}` and runs `command -v uv >/dev/null || pip install uv`), but it was not covered by a test — the scenario originally reported in #5198.

## Test

`test_generate_containerfile_custom_base_image_without_python_version` renders the containerfile for `DockerOptions(base_image=...)` (where `python_version` defaults to `None`) and asserts:

- `uv venv` is present
- `-p None` / `--python None` are absent
- `uv` is auto-installed (`command -v uv >/dev/null || pip install uv`)

Verified as a true regression guard: it fails if the `{% if %}` guard in `base.j2` is removed, and passes with it intact. Full file passes:

```
tests/unit/_internal/container/test_generate.py ......  6 passed
```

Closes #5198.