### PR TITLE
fix(pytorch): load saved models with weights_only=False (#5365)

### DIFF
--- a/src/bentoml/_internal/frameworks/pytorch.py
+++ b/src/bentoml/_internal/frameworks/pytorch.py
@@ -77,6 +77,13 @@ def load_model(
         )
 
     weight_file = bentoml_model.path_of(MODEL_FILENAME)
+    # `save_model` serializes the whole model object (not just a state dict) via
+    # `torch.load`'s pickle path, so it must be loaded with `weights_only=False`.
+    # PyTorch >= 2.6 flipped the default to `weights_only=True`, which cannot
+    # unpickle arbitrary classes and breaks loading. The model store is a trusted,
+    # BentoML-produced artifact, so default to `weights_only=False` while still
+    # allowing the caller to override it through `torch_load_args`.
+    torch_load_args.setdefault("weights_only", False)
     with Path(weight_file).open("rb") as file:
         model: "torch.nn.Module" = torch.load(
             file, map_location=device_id, **torch_load_args

--- a/tests/integration/frameworks/test_pytorch_unit.py
+++ b/tests/integration/frameworks/test_pytorch_unit.py
@@ -3,8 +3,20 @@ from __future__ import annotations
 import pytest
 import torch
 
+import bentoml
+from bentoml._internal.configuration.containers import BentoMLContainer
 from bentoml._internal.frameworks.pytorch import PyTorchTensorContainer
+from bentoml._internal.models import ModelStore
 from bentoml._internal.runner.container import AutoContainer
+
+
+class _Net(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = torch.nn.Linear(4, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc(x)
 
 
 @pytest.mark.parametrize("batch_axis", [0, 1])
@@ -39,3 +51,22 @@ def test_pytorch_container(batch_axis: int):
         AutoContainer.from_payload(AutoContainer.to_payload(one_batch, batch_dim=0))
         == one_batch
     ).all()
+
+
+def test_load_model_defaults_to_weights_only_false(tmp_path):
+    # Regression test for #5365: PyTorch >= 2.6 defaults `torch.load` to
+    # `weights_only=True`, which cannot unpickle the whole-model artifact that
+    # `save_model` writes via cloudpickle. `load_model` must default to
+    # `weights_only=False` so a trusted, BentoML-produced model loads correctly,
+    # while still honoring an explicit override passed by the caller.
+    BentoMLContainer.model_store.set(ModelStore(str(tmp_path)))
+    try:
+        saved = bentoml.pytorch.save_model("weights_only_model", _Net())
+
+        loaded = bentoml.pytorch.load_model(saved)
+        assert isinstance(loaded, torch.nn.Module)
+
+        with pytest.raises(Exception):
+            bentoml.pytorch.load_model(saved, weights_only=True)
+    finally:
+        BentoMLContainer.model_store.reset()


### PR DESCRIPTION
Fixes loading of models saved with the `bentoml.pytorch` framework on PyTorch >= 2.6.

## Problem

`bentoml.pytorch.save_model` serializes the **whole model object** (not a state dict) via `torch.save(model, file, pickle_module=cloudpickle)`. Loading such a file requires `torch.load(..., weights_only=False)`.

PyTorch 2.6 changed the default of `torch.load` from `weights_only=False` to `weights_only=True`. `weights_only=True` cannot unpickle arbitrary classes, so loading **any** model saved with `bentoml.pytorch` now fails:

```
_pickle.UnpicklingError: Weights only load failed. ...
WeightsUnpickler error: Unsupported global: GLOBAL <YourModel> was not an allowed global by default.
```

This breaks both `bentoml.pytorch.load_model(...)` and the legacy runner serving path (`_internal/frameworks/common/pytorch.py`), which calls `load_model` with no way for the user to pass `torch_load_args`. Reported in #5365.

## Fix

Default `weights_only` to `False` in `load_model` via `setdefault`, since the model store is a trusted, BentoML-produced artifact (consistent with torch's guidance to only disable `weights_only` for trusted sources). Callers can still override it through `**torch_load_args`.

```python
torch_load_args.setdefault("weights_only", False)
model = torch.load(file, map_location=device_id, **torch_load_args)
```

Only `pytorch.py` is affected; `pytorch_lightning` and `torchscript` use `torch.jit.load`, which is unaffected.

## Test

Adds `test_load_model_defaults_to_weights_only_false` (isolated temp model store):
- saving + loading a custom `nn.Module` succeeds by default
- an explicit `weights_only=True` override is still honored

Verified as a true regression guard: the test fails without the fix (`UnpicklingError`) and passes with it. Full file:

```
tests/integration/frameworks/test_pytorch_unit.py ...  3 passed
```

Closes #5365.