### PR TITLE
feat: add native pylock.toml support for container dependency resolution

### DIFF
--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -443,6 +443,11 @@ class PythonOptions:
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str)),
     )
+    pylock_toml: t.Optional[str] = attr.field(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str)),
+    )
+
     packages: t.Optional[t.List[str]] = attr.field(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(ListStr)),
@@ -493,7 +498,7 @@ class PythonOptions:
             )
 
     def is_empty(self) -> bool:
-        return not self.requirements_txt and not self.packages
+        return not self.requirements_txt and not self.packages and not self.pylock_toml
 
     @property
     def _jinja_environment(self) -> jinja2.Environment:
@@ -531,6 +536,11 @@ class PythonOptions:
             for whl_file in self.wheels:  # pylint: disable=not-an-iterable
                 whl_file = resolve_user_filepath(whl_file, build_ctx)
                 shutil.copy2(whl_file, wheels_folder)
+
+        # Move over pylock.toml if specified
+        if self.pylock_toml is not None:
+            pylock_path = resolve_user_filepath(self.pylock_toml, build_ctx)
+            shutil.copy2(pylock_path, py_folder / "pylock.toml")
 
         pip_compile_compat: list[str] = []
         if self.index_url:

--- a/src/bentoml/_internal/container/frontend/dockerfile/templates/base.j2
+++ b/src/bentoml/_internal/container/frontend/dockerfile/templates/base.j2
@@ -73,8 +73,13 @@ ENV PATH="/app/.venv/bin:$PATH"
 
 COPY --chown={{ bento__user }}:{{ bento__user }} ./env/python ./env/python/
 {% set __install_python_scripts__ = expands_bento_path("env", "python", "install.sh", bento_path=bento__path) %}
+{% if _has_pylock %}
+# sync python packages directly from pylock.toml
+{% call common.RUN(__enable_buildkit__) -%} {{ __pip_cache__ }} {% endcall -%} uv pip sync {{ expands_bento_path("env", "python", "pylock.toml", bento_path=bento_path) }}
+{% else %}
 # install python packages with install.sh
 {% call common.RUN(__enable_buildkit__) -%} {{ __pip_cache__ }} {% endcall -%} bash -euxo pipefail {{ __install_python_scripts__ }}
+{% endif %}
 COPY --chown={{ bento__user }}:{{ bento__user }} . ./
 {% if __options__setup_script is not none %}
 {% set __setup_script__ = expands_bento_path("env", "docker", "setup_script", bento_path=bento__path) %}

--- a/src/bentoml/_internal/container/generate.py
+++ b/src/bentoml/_internal/container/generate.py
@@ -220,6 +220,9 @@ def generate_containerfile(
     else:
         python_packages = {}
 
+    # Check if pylock_toml option was passed in configuration context
+    pylock_file = bento_fs.joinpath("env/python/pylock.toml")
+
     return template.render(
         **get_templates_variables(
             docker,
@@ -227,9 +230,11 @@ def generate_containerfile(
             bento_fs,
             python_packages=python_packages,
             _is_cuda=release_type == "cuda",
+            _has_pylock=pylock_file.exists(),
             **override_bento_env,
         )
     )
+
 
 
 def resolve_package_versions(requirement: str) -> dict[str, str]:

--- a/src/bentoml/_internal/container/generate.py
+++ b/src/bentoml/_internal/container/generate.py
@@ -236,7 +236,6 @@ def generate_containerfile(
     )
 
 
-
 def resolve_package_versions(requirement: str) -> dict[str, str]:
     from pip_requirements_parser import RequirementsFile
 


### PR DESCRIPTION
## What does this PR address?

Fixes #5466

This PR introduces native support for `pylock.toml` in the Bento containerization build process, allowing users to strictly lock down and resolve Python dependencies using `uv` (bypassing current limitations with `requirements.txt` extra-index-urls).

**Implementation Details:**
1. **Configuration Schema (`build_config.py`)**: Added `pylock_toml` to the `PythonOptions` schema and implemented the file copy logic to stage the lockfile in the `env/python/` build context.
2. **Container Generation (`generate.py`)**: Injected a `_has_pylock` boolean flag into the Jinja templating context by evaluating the existence of the staged lockfile.
3. **Dockerfile Templates (`base.j2`)**: Updated the base Dockerfile template to conditionally execute `uv pip sync /home/bentoml/bento/env/python/pylock.toml` when `_has_pylock` is true, safely falling back to the standard `install.sh` pipeline if no lockfile is present.

This ensures that deployments requiring complex or isolated package indexes can rely entirely on standard lockfiles during the Docker build step without breaking existing backwards compatibility.