### PR TITLE
fix: resolve OpenAPI generation crash for Optional/Union model outputs

### DIFF
--- a/src/_bentoml_sdk/method.py
+++ b/src/_bentoml_sdk/method.py
@@ -33,6 +33,16 @@ def _only_include(data: dict[str, t.Any], fields: t.Container[str]) -> dict[str,
     return {k: v for k, v in data.items() if k in fields}
 
 
+def _schema_from_dict(data: dict[str, t.Any]) -> Schema:
+    # A top-level "$ref" (e.g. an ``Optional``/``Union`` of models that has been
+    # collapsed by ``_flatten_field``) must be passed through the renamed ``ref``
+    # field; ``Schema(**{"$ref": ...})`` would fail since ``$ref`` is not a valid
+    # keyword argument.
+    if "$ref" in data:
+        data = {("ref" if k == "$ref" else k): v for k, v in data.items()}
+    return Schema(**data)
+
+
 def _io_descriptor_converter(it: t.Any) -> type[IODescriptor]:
     if not inspect.isclass(it):
         raise ValueError(f"{it} must be a class type")
@@ -222,7 +232,7 @@ class APIMethod(t.Generic[P, R]):
         return {
             "content": {
                 self.input_spec.mime_type(): MediaType(
-                    schema=Schema(**input), encoding=encoding or None
+                    schema=_schema_from_dict(input), encoding=encoding or None
                 )
             },
         }
@@ -244,7 +254,9 @@ class APIMethod(t.Generic[P, R]):
         return {
             "description": SUCCESS_DESCRIPTION,
             "content": {
-                self.output_spec.mime_type(): MediaType(schema=Schema(**output))
+                self.output_spec.mime_type(): MediaType(
+                    schema=_schema_from_dict(output)
+                )
             },
         }
 
@@ -262,8 +274,14 @@ def _flatten_field(
     if max_depth is not None and _depth >= max_depth:
         return schema
     if "$ref" in schema:
-        ref = schema.pop("$ref")[len("#/$defs/") :]
-        schema.update(_flatten_field(defs[ref], defs, max_depth, _depth=_depth + 1))
+        ref = schema["$ref"].rsplit("/", 1)[-1]
+        if ref in defs:
+            # A local definition ("#/$defs/<name>"): inline it.
+            schema.pop("$ref")
+            schema.update(_flatten_field(defs[ref], defs, max_depth, _depth=_depth + 1))
+        # Otherwise the reference points at a registered component schema
+        # (e.g. "#/components/schemas/<name>"). Leave it untouched so it keeps
+        # resolving against components/schemas instead of crashing here.
     elif schema.get("type") == "object" and "properties" in schema:
         for k, v in schema["properties"].items():
             schema["properties"][k] = _flatten_field(

--- a/tests/unit/_bentoml_sdk/test_openapi.py
+++ b/tests/unit/_bentoml_sdk/test_openapi.py
@@ -1,0 +1,85 @@
+import json
+import typing as t
+
+import pytest
+from pydantic import BaseModel
+
+import bentoml
+from _bentoml_sdk.service.openapi import generate_spec
+from bentoml._internal.utils.cattr import bentoml_cattr
+
+
+class Item(BaseModel):
+    a: int
+    b: str
+
+
+class Other(BaseModel):
+    c: float
+
+
+def _collect_dangling_refs(svc: t.Any) -> t.List[str]:
+    """Return the names of every ``#/components/schemas`` reference used in the
+    generated paths that is *not* present under ``components/schemas``."""
+    spec = json.loads(json.dumps(bentoml_cattr.unstructure(generate_spec(svc))))
+    components = set(spec.get("components", {}).get("schemas", {}))
+    refs: t.Set[str] = set()
+
+    def walk(node: t.Any) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "$ref" and isinstance(value, str):
+                    refs.add(value)
+                else:
+                    walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(spec.get("paths", {}))
+    return sorted(
+        name
+        for ref in refs
+        if ref.startswith("#/components/schemas/")
+        and (name := ref.rsplit("/", 1)[-1]) not in components
+    )
+
+
+def _service_returning(annotation: t.Any) -> t.Any:
+    def predict(self: t.Any, x: int = 0) -> t.Any: ...
+
+    # Set the return annotation explicitly so the test keeps working regardless
+    # of ``from __future__ import annotations`` semantics.
+    predict.__annotations__["return"] = annotation
+
+    namespace = {"predict": bentoml.api(predict)}
+    return bentoml.service(type("Svc", (), namespace))
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        t.Optional[Item],
+        t.Union[Item, None],
+        t.Union[Item, Other],
+        t.List[Item],
+        Item,
+    ],
+)
+def test_openapi_spec_has_no_dangling_refs(annotation: t.Any) -> None:
+    # Regression test for OpenAPI generation crashing / emitting dangling
+    # references when an endpoint returns a model wrapped in Optional/Union.
+    svc = _service_returning(annotation)
+    assert _collect_dangling_refs(svc) == []
+
+
+def test_optional_model_output_references_registered_component() -> None:
+    svc = _service_returning(t.Optional[Item])
+    spec = json.loads(json.dumps(bentoml_cattr.unstructure(generate_spec(svc))))
+
+    schema = spec["paths"]["/predict"]["post"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]
+
+    assert schema == {"$ref": "#/components/schemas/Item"}
+    assert "Item" in spec["components"]["schemas"]


### PR DESCRIPTION
An endpoint whose return annotation is a single Pydantic model wrapped in `Optional[...]`, `... | None`, or `Union[...]` made `/docs.json` raise `KeyError: 'ents/schemas/...'`. `_flatten_field` collapses the resulting top-level `anyOf` into a bare `$ref`, then sliced the ref with a hard-coded `#/$defs/` prefix length and looked it up in an (empty) defs map.

Make the ref-name extraction robust (`rsplit('/', 1)[-1]`) and only inline references that exist in the local `$defs`; references to registered component schemas (`#/components/schemas/...`) are now left intact instead of crashing. Also route the request/response schema construction through a helper that maps a top-level `$ref` onto `Schema`'s renamed `ref` field.

Adds regression tests covering Optional/Union/List model outputs.

## What does this PR address?

<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->

No prior issue — bug discovered while testing Optional[Model] return types.

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [x] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [x] Did you write tests to cover your changes?
