### PR TITLE
Add adaptive batching dispatch metrics

### DIFF
--- a/docs/source/get-started/adaptive-batching.rst
+++ b/docs/source/get-started/adaptive-batching.rst
@@ -102,6 +102,21 @@ When you specify ``max_batch_size`` and ``max_latency_ms`` parameters, BentoML e
 
     When using a synchronous endpoint in one Service to call a batchable endpoint in another Service, it sends only one request at a time and waits for a response before sending the next. This is due to the default concurrency of 1 for synchronous endpoints. To enable concurrent requests and allow batching, set the ``threads=N`` parameter in the ``@bentoml.service`` decorator.
 
+Observe adaptive batching
+-------------------------
+
+When Prometheus metrics are enabled, BentoML exports adaptive batching signals for both Service and Runner dispatchers. These metrics make it easier to see whether requests are filling batches, waiting on the optimizer window, or spending too long in the queue.
+
+Service metrics use the ``bentoml_service`` namespace. Runner metrics use the ``bentoml_runner`` namespace.
+
+- ``adaptive_batch_size``: Number of queued jobs released in each adaptive batch.
+- ``adaptive_batch_item_count``: Number of input items in each released batch after payload-size aware splitting.
+- ``adaptive_batch_queue_size``: Number of queued jobs seen by the dispatcher at release time.
+- ``adaptive_batch_queue_delay_seconds``: Queue wait for the oldest job in each released batch.
+- ``adaptive_batch_dispatch_total``: Number of batches released by reason. Reasons include ``training``, ``max_batch_size``, and ``optimizer``.
+
+For example, if ``adaptive_batch_queue_delay_seconds`` rises while ``adaptive_batch_item_count`` stays low, the endpoint is waiting without forming useful batches. Lowering ``max_latency_ms`` or increasing upstream concurrency can reduce wasted wait. If ``adaptive_batch_dispatch_total`` is dominated by ``max_batch_size`` and request duration is high, the model may need a smaller ``max_batch_size`` or more workers.
+
 More BentoML examples with batchable APIs: `SentenceTransformers <https://github.com/bentoml/BentoSentenceTransformers>`_, `CLIP <https://github.com/bentoml/BentoClip>`_ and `ColPali <https://github.com/bentoml/BentoColPali>`_.
 
 Handle multiple parameters

--- a/src/_bentoml_impl/server/app.py
+++ b/src/_bentoml_impl/server/app.py
@@ -24,6 +24,7 @@ from _bentoml_sdk import Service
 from _bentoml_sdk.service import set_current_service
 from bentoml._internal.container import BentoMLContainer
 from bentoml._internal.marshal.dispatcher import CorkDispatcher
+from bentoml._internal.marshal.dispatcher import DispatchMetrics
 from bentoml._internal.resource import system_resources
 from bentoml._internal.server.base_app import BaseAppFactory
 from bentoml._internal.server.http_app import log_exception
@@ -133,6 +134,10 @@ class ServiceAppFactory(BaseAppFactory):
                 ),
                 batch_dim=method.batch_dim,
             )
+            if self.enable_metrics:
+                self.dispatchers[name].set_dispatch_observer(
+                    functools.partial(self._observe_adaptive_batch_dispatch, name)
+                )
 
     @functools.cached_property
     def adaptive_batch_size_hist(self) -> Histogram:
@@ -159,6 +164,106 @@ class ServiceAppFactory(BaseAppFactory):
             ],
             buckets=exponential_buckets(1, 2, max_max_batch_size),
         )
+
+    @functools.cached_property
+    def adaptive_batch_item_count_hist(self) -> Histogram:
+        metrics_client = BentoMLContainer.metrics_client.get()
+        return metrics_client.Histogram(
+            namespace="bentoml_service",
+            name="adaptive_batch_item_count",
+            documentation="Service adaptive batch item count after payload-size aware splitting",
+            labelnames=[
+                "runner_name",
+                "worker_index",
+                "method_name",
+                "service_version",
+                "service_name",
+            ],
+            buckets=exponential_buckets(1, 2, self._max_batch_size),
+        )
+
+    @functools.cached_property
+    def adaptive_batch_queue_size_hist(self) -> Histogram:
+        metrics_client = BentoMLContainer.metrics_client.get()
+        return metrics_client.Histogram(
+            namespace="bentoml_service",
+            name="adaptive_batch_queue_size",
+            documentation="Service adaptive batch queued jobs at dispatch time",
+            labelnames=[
+                "runner_name",
+                "worker_index",
+                "method_name",
+                "service_version",
+                "service_name",
+            ],
+            buckets=exponential_buckets(1, 2, self._max_batch_size),
+        )
+
+    @functools.cached_property
+    def adaptive_batch_queue_delay_hist(self) -> Histogram:
+        metrics_client = BentoMLContainer.metrics_client.get()
+        return metrics_client.Histogram(
+            namespace="bentoml_service",
+            name="adaptive_batch_queue_delay_seconds",
+            documentation="Queue wait for the oldest job in each service adaptive batch",
+            labelnames=[
+                "runner_name",
+                "worker_index",
+                "method_name",
+                "service_version",
+                "service_name",
+            ],
+        )
+
+    @functools.cached_property
+    def adaptive_batch_dispatch_total(self) -> t.Any:
+        metrics_client = BentoMLContainer.metrics_client.get()
+        return metrics_client.Counter(
+            namespace="bentoml_service",
+            name="adaptive_batch_dispatch_total",
+            documentation="Service adaptive batch dispatches by release reason",
+            labelnames=[
+                "runner_name",
+                "worker_index",
+                "method_name",
+                "service_version",
+                "service_name",
+                "dispatch_reason",
+            ],
+        )
+
+    @functools.cached_property
+    def _max_batch_size(self) -> int:
+        return max(
+            (
+                method.max_batch_size
+                for method in self.service.apis.values()
+                if method.batchable
+            ),
+            default=100,
+        )
+
+    def _observe_adaptive_batch_dispatch(
+        self, method_name: str, metrics: DispatchMetrics
+    ) -> None:
+        from bentoml._internal.context import server_context
+
+        labels = {
+            "runner_name": self.service.name,
+            "worker_index": server_context.worker_index,
+            "method_name": method_name,
+            "service_version": server_context.bento_version,
+            "service_name": server_context.bento_name,
+        }
+        self.adaptive_batch_size_hist.labels(**labels).observe(metrics.job_count)  # type: ignore
+        self.adaptive_batch_item_count_hist.labels(**labels).observe(metrics.item_count)  # type: ignore
+        self.adaptive_batch_queue_size_hist.labels(**labels).observe(metrics.queue_size)  # type: ignore
+        self.adaptive_batch_queue_delay_hist.labels(**labels).observe(  # type: ignore
+            metrics.oldest_queue_wait_seconds
+        )
+        self.adaptive_batch_dispatch_total.labels(
+            **labels, dispatch_reason=metrics.reason
+        ).inc()
 
     async def index_page(self, _: Request) -> Response:
         from starlette.responses import FileResponse
@@ -674,18 +779,8 @@ class ServiceAppFactory(BaseAppFactory):
         async def inner_infer(
             batches: t.Sequence[t.Any], **kwargs: t.Any
         ) -> t.Sequence[t.Any]:
-            from bentoml._internal.context import server_context
             from bentoml._internal.runner.container import AutoContainer
             from bentoml._internal.utils import is_async_callable
-
-            if self.enable_metrics:
-                self.adaptive_batch_size_hist.labels(  # type: ignore
-                    runner_name=self.service.name,
-                    worker_index=server_context.worker_index,
-                    method_name=name,
-                    service_version=server_context.bento_version,
-                    service_name=server_context.bento_name,
-                ).observe(len(batches))
 
             if len(batches) == 0:
                 return []

--- a/src/bentoml/_internal/marshal/dispatcher.py
+++ b/src/bentoml/_internal/marshal/dispatcher.py
@@ -100,6 +100,19 @@ T_IN = t.TypeVar("T_IN")
 T_OUT = t.TypeVar("T_OUT")
 
 
+@attr.frozen
+class DispatchMetrics:
+    reason: str
+    training: bool
+    queue_size: int
+    job_count: int
+    item_count: int
+    max_batch_size: int
+    oldest_queue_wait_seconds: float
+    newest_queue_wait_seconds: float
+    request_batch_sizes: tuple[int, ...]
+
+
 @attr.define
 class Job(t.Generic[T_IN, T_OUT]):
     enqueue_time: float
@@ -129,6 +142,7 @@ class CorkDispatcher(t.Generic[T_IN, T_OUT]):
         fallback: t.Callable[[], T_OUT],
         get_batch_size: t.Callable[[T_IN], int] = lambda x: x.sample.batch_size,
         batch_dim: tuple[int, int] = (0, 0),
+        dispatch_observer: t.Callable[[DispatchMetrics], None] | None = None,
     ) -> None:
         ...
         """
@@ -153,8 +167,14 @@ class CorkDispatcher(t.Generic[T_IN, T_OUT]):
         )  # TODO(bojiang): maxlen
         self.get_batch_size = get_batch_size
         self.batch_dim = batch_dim
+        self.dispatch_observer = dispatch_observer
         # at most 1 batch can be processed at the same time
         self._sema = shared_sema if shared_sema else NonBlockSema(1)
+
+    def set_dispatch_observer(
+        self, dispatch_observer: t.Callable[[DispatchMetrics], None] | None
+    ) -> None:
+        self.dispatch_observer = dispatch_observer
 
     def shutdown(self) -> None:
         if self._controller is not None:
@@ -246,7 +266,7 @@ class CorkDispatcher(t.Generic[T_IN, T_OUT]):
                 # call
                 self._sema.acquire()
                 inputs_info = tuple(self._get_inputs())
-                self._loop.create_task(self.outbound_call(inputs_info, training=True))
+                self._dispatch(inputs_info, reason="training", training=True)
         except Exception:
             logger.exception("Error in training optimizer")
 
@@ -320,7 +340,12 @@ class CorkDispatcher(t.Generic[T_IN, T_OUT]):
                 # call
                 self._sema.acquire()
                 inputs_info = tuple(self._get_inputs())
-                self._loop.create_task(self.outbound_call(inputs_info))
+                reason = (
+                    "max_batch_size"
+                    if self._get_item_count(inputs_info) >= self.max_batch_size
+                    else "optimizer"
+                )
+                self._dispatch(inputs_info, reason=reason)
             except Exception:
                 logger.exception("Error processing batch requests")
 
@@ -332,6 +357,65 @@ class CorkDispatcher(t.Generic[T_IN, T_OUT]):
         async with self._wake_event:
             self._wake_event.notify_all()
         return await future
+
+    def _dispatch(
+        self,
+        inputs_info: tuple[Job[T_IN, T_OUT], ...],
+        *,
+        reason: str,
+        training: bool = False,
+    ) -> None:
+        dispatch_time = time.time()
+        for input_info in inputs_info:
+            input_info.dispatch_time = dispatch_time
+        self._observe_dispatch(inputs_info, reason, training, dispatch_time)
+        self._loop.create_task(self.outbound_call(inputs_info, training=training))
+
+    def _observe_dispatch(
+        self,
+        inputs_info: tuple[Job[T_IN, T_OUT], ...],
+        reason: str,
+        training: bool,
+        dispatch_time: float,
+    ) -> None:
+        if self.dispatch_observer is None or not inputs_info:
+            return
+
+        batch_sizes = self._get_batch_sizes(inputs_info)
+
+        metrics = DispatchMetrics(
+            reason=reason,
+            training=training,
+            queue_size=len(self._queue) + len(inputs_info),
+            job_count=len(inputs_info),
+            item_count=sum(batch_sizes),
+            max_batch_size=self.max_batch_size,
+            oldest_queue_wait_seconds=max(
+                dispatch_time - inputs_info[0].enqueue_time, 0
+            ),
+            newest_queue_wait_seconds=max(
+                dispatch_time - inputs_info[-1].enqueue_time, 0
+            ),
+            request_batch_sizes=tuple(batch_sizes),
+        )
+        try:
+            self.dispatch_observer(metrics)
+        except Exception:
+            logger.exception("Error in dynamic batching dispatch observer")
+
+    def _get_item_count(self, inputs_info: tuple[Job[T_IN, T_OUT], ...]) -> int:
+        return sum(self._get_batch_sizes(inputs_info))
+
+    def _get_batch_sizes(
+        self, inputs_info: tuple[Job[T_IN, T_OUT], ...]
+    ) -> tuple[int, ...]:
+        batch_sizes: list[int] = []
+        for input_info in inputs_info:
+            try:
+                batch_sizes.append(self.get_batch_size(input_info.data))
+            except Exception:
+                batch_sizes.append(1)
+        return tuple(batch_sizes)
 
     async def outbound_call(
         self, inputs_info: tuple[Job[T_IN, T_OUT], ...], training: bool = False

--- a/src/bentoml/_internal/server/runner_app.py
+++ b/src/bentoml/_internal/server/runner_app.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from starlette.responses import Response
     from starlette.routing import BaseRoute
 
+    from ..marshal.dispatcher import DispatchMetrics
     from ..runner.runner import Runner
     from ..runner.runner import RunnerMethod
     from ..types import LifecycleHook
@@ -103,6 +104,82 @@ class RunnerAppFactory(BaseAppFactory):
             ],
             buckets=exponential_buckets(1, 2, max_max_batch_size),
         )
+        self.adaptive_batch_item_count_hist = metrics_client.Histogram(
+            namespace="bentoml_runner",
+            name="adaptive_batch_item_count",
+            documentation="Runner adaptive batch item count after payload-size aware splitting",
+            labelnames=[
+                "runner_name",
+                "worker_index",
+                "method_name",
+                "service_version",
+                "service_name",
+            ],
+            buckets=exponential_buckets(1, 2, max_max_batch_size),
+        )
+        self.adaptive_batch_queue_size_hist = metrics_client.Histogram(
+            namespace="bentoml_runner",
+            name="adaptive_batch_queue_size",
+            documentation="Runner adaptive batch queued jobs at dispatch time",
+            labelnames=[
+                "runner_name",
+                "worker_index",
+                "method_name",
+                "service_version",
+                "service_name",
+            ],
+            buckets=exponential_buckets(1, 2, max_max_batch_size),
+        )
+        self.adaptive_batch_queue_delay_hist = metrics_client.Histogram(
+            namespace="bentoml_runner",
+            name="adaptive_batch_queue_delay_seconds",
+            documentation="Queue wait for the oldest job in each runner adaptive batch",
+            labelnames=[
+                "runner_name",
+                "worker_index",
+                "method_name",
+                "service_version",
+                "service_name",
+            ],
+        )
+        self.adaptive_batch_dispatch_total = metrics_client.Counter(
+            namespace="bentoml_runner",
+            name="adaptive_batch_dispatch_total",
+            documentation="Runner adaptive batch dispatches by release reason",
+            labelnames=[
+                "runner_name",
+                "worker_index",
+                "method_name",
+                "service_version",
+                "service_name",
+                "dispatch_reason",
+            ],
+        )
+
+        for method_name, dispatcher in self.dispatchers.items():
+            dispatcher.set_dispatch_observer(
+                functools.partial(self._observe_adaptive_batch_dispatch, method_name)
+            )
+
+    def _observe_adaptive_batch_dispatch(
+        self, method_name: str, metrics: DispatchMetrics
+    ) -> None:
+        labels = {
+            "runner_name": self.runner.name,
+            "worker_index": self.worker_index,
+            "method_name": method_name,
+            "service_version": server_context.bento_version,
+            "service_name": server_context.bento_name,
+        }
+        self.adaptive_batch_size_hist.labels(**labels).observe(metrics.job_count)  # type: ignore
+        self.adaptive_batch_item_count_hist.labels(**labels).observe(metrics.item_count)  # type: ignore
+        self.adaptive_batch_queue_size_hist.labels(**labels).observe(metrics.queue_size)  # type: ignore
+        self.adaptive_batch_queue_delay_hist.labels(**labels).observe(  # type: ignore
+            metrics.oldest_queue_wait_seconds
+        )
+        self.adaptive_batch_dispatch_total.labels(
+            **labels, dispatch_reason=metrics.reason
+        ).inc()
 
     @property
     def on_startup(self) -> list[LifecycleHook]:
@@ -227,14 +304,6 @@ class RunnerAppFactory(BaseAppFactory):
                 async def infer_batch(
                     params_list: t.Sequence[Params[t.Any]],
                 ) -> list[Payload] | list[tuple[Payload, ...]]:
-                    self.adaptive_batch_size_hist.labels(  # type: ignore
-                        runner_name=self.runner.name,
-                        worker_index=self.worker_index,
-                        method_name=runner_method.name,
-                        service_version=server_context.bento_version,
-                        service_name=server_context.bento_name,
-                    ).observe(len(params_list))
-
                     if not params_list:
                         return []
 

--- a/tests/unit/_internal/test_dispatcher_metrics.py
+++ b/tests/unit/_internal/test_dispatcher_metrics.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from bentoml._internal.marshal.dispatcher import CorkDispatcher
+from bentoml._internal.marshal.dispatcher import Job
+
+
+def test_dispatch_observer_receives_queue_and_batch_shape() -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        observed = []
+        dispatcher = CorkDispatcher(
+            max_latency_in_ms=100,
+            max_batch_size=8,
+            fallback=lambda: None,
+            get_batch_size=len,
+            dispatch_observer=observed.append,
+        )
+        jobs = (
+            Job(10.0, [1, 2, 3], loop.create_future()),
+            Job(12.0, [4, 5], loop.create_future()),
+        )
+
+        dispatcher._observe_dispatch(
+            jobs,
+            reason="max_batch_size",
+            training=False,
+            dispatch_time=15.0,
+        )
+
+        assert len(observed) == 1
+        metrics = observed[0]
+        assert metrics.reason == "max_batch_size"
+        assert metrics.training is False
+        assert metrics.queue_size == 2
+        assert metrics.job_count == 2
+        assert metrics.item_count == 5
+        assert metrics.max_batch_size == 8
+        assert metrics.oldest_queue_wait_seconds == 5.0
+        assert metrics.newest_queue_wait_seconds == 3.0
+        assert metrics.request_batch_sizes == (3, 2)
+    finally:
+        loop.close()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_observer_runs_on_real_dispatch() -> None:
+    observed = []
+    dispatcher = CorkDispatcher(
+        max_latency_in_ms=100,
+        max_batch_size=4,
+        fallback=lambda: None,
+        get_batch_size=len,
+        dispatch_observer=observed.append,
+    )
+
+    async def callback(items: tuple[list[int], ...]) -> list[str]:
+        return [str(sum(item)) for item in items]
+
+    dispatcher.callback = callback
+    loop = asyncio.get_running_loop()
+    jobs = (
+        Job(loop.time(), [1, 2], loop.create_future()),
+        Job(loop.time(), [3], loop.create_future()),
+    )
+
+    dispatcher._dispatch(jobs, reason="optimizer")
+
+    assert await jobs[0].future == "3"
+    assert await jobs[1].future == "3"
+    assert jobs[0].dispatch_time > 0
+    assert jobs[1].dispatch_time == jobs[0].dispatch_time
+    assert observed[0].reason == "optimizer"
+    assert observed[0].item_count == 3
+
+
+def test_dispatch_observer_error_does_not_break_dispatch_metrics() -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        dispatcher = CorkDispatcher(
+            max_latency_in_ms=100,
+            max_batch_size=4,
+            fallback=lambda: None,
+            get_batch_size=len,
+            dispatch_observer=lambda _: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        jobs = (Job(10.0, [1], loop.create_future()),)
+
+        dispatcher._observe_dispatch(
+            jobs,
+            reason="optimizer",
+            training=False,
+            dispatch_time=11.0,
+        )
+    finally:
+        loop.close()


### PR DESCRIPTION
### Summary

This adds dispatcher-level metrics for adaptive batching so operators can see why batches are released and how much queue wait they are paying.

Today BentoML exposes batch size, but it is hard to tell whether an endpoint is filling batches, waiting on the optimizer window, or sitting with low item counts under load. This PR adds a lightweight observer on CorkDispatcher and wires it into both Service and Runner serving paths.

New Prometheus signals include dispatch reason, queued jobs at release time, item count after payload-size aware splitting, and oldest request queue delay. The existing batch-size metric is kept and moved to the same dispatch observer so it is recorded from one place.

### Validation

- `python3 -m ruff check src/bentoml/_internal/marshal/dispatcher.py src/bentoml/_internal/server/runner_app.py src/_bentoml_impl/server/app.py tests/unit/_internal/test_dispatcher_metrics.py`
- `python3 -m compileall -q src/bentoml/_internal/marshal/dispatcher.py src/bentoml/_internal/server/runner_app.py src/_bentoml_impl/server/app.py tests/unit/_internal/test_dispatcher_metrics.py`
- `git diff --check`
- `/Users/ritwij/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/unit/_internal/test_dispatcher_metrics.py -q`