### PR TITLE
Clarify Transformers API reference note

### DIFF
--- a/docs/source/reference/bentoml/frameworks/transformers.rst
+++ b/docs/source/reference/bentoml/frameworks/transformers.rst
@@ -4,9 +4,9 @@ Transformers
 
 .. admonition:: About this page
 
-   This is an API reference for 🤗 Transformers in BentoML. Please refer to
-   :doc:`Transformers guide </reference/bentoml/frameworks/transformers>` for more information about how to use
-   Hugging Face Transformers in BentoML.
+   This is an API reference for 🤗 Transformers in BentoML. It covers the
+   BentoML APIs for saving, loading, retrieving, and importing Hugging Face
+   Transformers models.
 
 .. currentmodule:: bentoml.transformers
 


### PR DESCRIPTION
Fixes #4541

## Summary
- Removes the self-referential "Transformers guide" link from the Transformers API reference note.
- Rewords the note to describe the API reference content directly.

## Verification
- Not run; documentation-only change.