### PR TITLE
fix(sdk): check generic args length on bare iterator return annotations to avoid IndexError

### DIFF
--- a/src/_bentoml_sdk/io_models.py
+++ b/src/_bentoml_sdk/io_models.py
@@ -432,7 +432,8 @@ class IODescriptor(IOMixin, BaseModel):
             )
         media_type: str | None = None
         if is_iterator_type(return_annotation):
-            return_annotation = get_args(return_annotation)[0]
+            args = get_args(return_annotation)
+            return_annotation = args[0] if args else t.Any
         elif is_annotated(return_annotation):
             content_type = next(
                 (a for a in get_args(return_annotation) if isinstance(a, ContentType)),

--- a/tests/unit/_bentoml_sdk/test_io_models.py
+++ b/tests/unit/_bentoml_sdk/test_io_models.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import typing as t
+from _bentoml_sdk.io_models import IODescriptor
+
+def test_from_output_with_bare_iterator():
+    def bare_iterator_fn() -> t.Iterator:
+        yield 1
+
+    descriptor = IODescriptor.from_output(bare_iterator_fn)
+    assert descriptor is not None
+
+
+def test_from_output_with_bare_generator():
+    def bare_generator_fn() -> t.Generator:
+        yield 1
+
+    descriptor = IODescriptor.from_output(bare_generator_fn)
+    assert descriptor is not None

--- a/tests/unit/_bentoml_sdk/test_io_models.py
+++ b/tests/unit/_bentoml_sdk/test_io_models.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import typing as t
+
 from _bentoml_sdk.io_models import IODescriptor
+
 
 def test_from_output_with_bare_iterator():
     def bare_iterator_fn() -> t.Iterator:


### PR DESCRIPTION
IODescriptor.from_output() currently crashes with an IndexError when a service method's return annotation is an unparameterized iterator type (e.g. t.Iterator, t.Generator, etc.) because it unconditionally indexes get_args(return_annotation)[0].

This PR fixes it by checking if generic arguments exist first, and defaulting the annotation to t.Any if get_args() returns an empty tuple.

I have added regression unit tests to verify the fix works correctly for bare iterators and generators.

Closes #5625