### PR TITLE
fix(security): block CGNAT range in SSRF connection guard (#5644)

### DIFF
--- a/src/bentoml/_internal/utils/uri.py
+++ b/src/bentoml/_internal/utils/uri.py
@@ -71,6 +71,13 @@ def is_unsafe_address(
     (e.g. when fetching a user-supplied URL). Covers private, loopback, link-local,
     and reserved ranges, plus the IPv4 CGNAT range which `ipaddress` does not
     classify as any of the above."""
+    # Canonicalize IPv4-mapped IPv6 addresses (e.g. ::ffff:100.64.1.1) to their
+    # embedded IPv4 form before checking. `is_private`/`is_loopback`/etc already
+    # see through the mapping on CPython >= 3.10, but the CGNAT range below is a
+    # manual membership check that doesn't, so a mapped CGNAT address would
+    # otherwise slip past this guard.
+    if ip.version == 6 and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
     return bool(
         ip.is_private
         or ip.is_loopback

--- a/src/bentoml/_internal/utils/uri.py
+++ b/src/bentoml/_internal/utils/uri.py
@@ -58,6 +58,27 @@ def is_http_url(url: str) -> bool:
 
 original_create_connection = None
 
+# RFC 6598 Shared Address Space (CGNAT), e.g. used for carrier-grade NAT and internal
+# cloud load balancers. Not classified as private/loopback/link-local/reserved by
+# ipaddress, so it must be checked explicitly (GHSA-mrmq-3q62-6cc8 follow-up).
+_CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+
+
+def is_unsafe_address(
+    ip: "ipaddress.IPv4Address | ipaddress.IPv6Address",
+) -> bool:
+    """Whether `ip` must be blocked from outbound connections initiated by BentoML
+    (e.g. when fetching a user-supplied URL). Covers private, loopback, link-local,
+    and reserved ranges, plus the IPv4 CGNAT range which `ipaddress` does not
+    classify as any of the above."""
+    return bool(
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or (ip.version == 4 and ip in _CGNAT_NETWORK)
+    )
+
 
 @contextlib.contextmanager
 def make_safe_connect():
@@ -91,7 +112,7 @@ def make_safe_connect():
             except ValueError:
                 raise socket.gaierror(f"Blocked invalid IP address {host}")
             else:
-                if ip.is_private or ip.is_loopback or ip.is_link_local:
+                if is_unsafe_address(ip):
                     raise socket.gaierror(f"Blocked private IP address {host}")
         return await original_create_connection(
             self, protocol_factory, host=host, port=port, **kwargs

--- a/tests/unit/_internal/utils/test_uri.py
+++ b/tests/unit/_internal/utils/test_uri.py
@@ -1,3 +1,4 @@
+import ipaddress
 import os
 import typing as t
 
@@ -32,3 +33,40 @@ def test_uri_path_conversion(
     for path in example_paths:
         restored = uri_to_path(path_to_uri(path))
         assert restored == path or restored == os.path.abspath(path)
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "100.64.0.1",  # CGNAT lower bound
+        "100.100.0.1",  # CGNAT (the reported SSRF bypass, GHSA-mrmq-3q62-6cc8 follow-up)
+        "100.127.255.255",  # CGNAT upper bound
+        "192.168.0.1",  # private
+        "10.0.0.1",  # private
+        "127.0.0.1",  # loopback
+        "169.254.1.1",  # link-local
+        "240.0.0.1",  # reserved
+        "::1",  # IPv6 loopback
+        "fc00::1",  # IPv6 unique local (private)
+    ],
+)
+def test_is_unsafe_address_blocks_internal_ranges(host: str) -> None:
+    from bentoml._internal.utils.uri import is_unsafe_address
+
+    assert is_unsafe_address(ipaddress.ip_address(host)) is True
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "100.63.255.255",  # just below the CGNAT range
+        "100.128.0.1",  # just above the CGNAT range
+        "8.8.8.8",  # public
+        "1.1.1.1",  # public
+        "2001:4860:4860::8888",  # public IPv6
+    ],
+)
+def test_is_unsafe_address_allows_public_addresses(host: str) -> None:
+    from bentoml._internal.utils.uri import is_unsafe_address
+
+    assert is_unsafe_address(ipaddress.ip_address(host)) is False

--- a/tests/unit/_internal/utils/test_uri.py
+++ b/tests/unit/_internal/utils/test_uri.py
@@ -48,6 +48,10 @@ def test_uri_path_conversion(
         "240.0.0.1",  # reserved
         "::1",  # IPv6 loopback
         "fc00::1",  # IPv6 unique local (private)
+        "::ffff:100.64.1.1",  # IPv4-mapped IPv6 CGNAT
+        "::ffff:100.100.0.1",  # IPv4-mapped IPv6 CGNAT
+        "::ffff:127.0.0.1",  # IPv4-mapped IPv6 loopback
+        "::ffff:192.168.1.1",  # IPv4-mapped IPv6 private
     ],
 )
 def test_is_unsafe_address_blocks_internal_ranges(host: str) -> None:
@@ -64,6 +68,7 @@ def test_is_unsafe_address_blocks_internal_ranges(host: str) -> None:
         "8.8.8.8",  # public
         "1.1.1.1",  # public
         "2001:4860:4860::8888",  # public IPv6
+        "::ffff:8.8.8.8",  # IPv4-mapped IPv6 public
     ],
 )
 def test_is_unsafe_address_allows_public_addresses(host: str) -> None:


### PR DESCRIPTION
Closes #5644.

## Problem

`make_safe_connect()` in `src/bentoml/_internal/utils/uri.py` blocks outbound connections to private, loopback, and link-local IPs (added for CVE-2025-54381 / GHSA-mrmq-3q62-6cc8). Python's `ipaddress` module does not classify the RFC 6598 Shared Address Space (CGNAT, `100.64.0.0/10`) as private, loopback, or link-local, so those addresses pass the check unblocked:

```pycon
>>> import ipaddress
>>> ip = ipaddress.ip_address("100.64.1.1")
>>> ip.is_private, ip.is_loopback, ip.is_link_local, ip.is_reserved
(False, False, False, False)
```

CGNAT addresses are used for carrier-grade NAT and, in several cloud environments, for internal load balancers and service endpoints reachable from the server — so this is a real SSRF gap for requests to user-supplied URLs (e.g. file/image inputs).

## Fix

- Extend the guard with `is_reserved` and an explicit check against the `100.64.0.0/10` network (guarded to IPv4 to avoid a version-mismatch error when comparing against an IPv6 address).
- Extract the predicate into a small `is_unsafe_address()` function so the security-critical logic is unit-testable directly, without needing to patch uvloop's event loop.

## Test

Added `test_is_unsafe_address_blocks_internal_ranges` / `test_is_unsafe_address_allows_public_addresses` in `tests/unit/_internal/utils/test_uri.py`, covering the CGNAT boundary (`100.63.255.255` allowed, `100.64.0.1`/`100.127.255.255` blocked, `100.128.0.1` allowed) plus existing private/loopback/link-local/reserved ranges and IPv6.

Verified as a true regression guard: reverting the fix fails the new CGNAT test cases; restoring it passes all 16 tests in the file.

```
tests/unit/_internal/utils/test_uri.py ................  16 passed
```