### PR TITLE
docs: fix parameter name mismatches in docstrings

### DIFF
--- a/src/bentoml/_internal/models/model.py
+++ b/src/bentoml/_internal/models/model.py
@@ -318,7 +318,7 @@ class Model(StoreItem):
             name:
             max_batch_size:
             max_latency_ms:
-            runnable_method_configs:
+            method_configs:
 
         Returns:
 

--- a/src/bentoml/_internal/utils/analytics/usage_stats.py
+++ b/src/bentoml/_internal/utils/analytics/usage_stats.py
@@ -292,7 +292,7 @@ def get_metrics_report(
 
     Args:
         metrics_client: Instance of bentoml._internal.server.metrics.prometheus.PrometheusClient
-        grpc: Whether the metrics are for gRPC server.
+        serve_kind: The kind of serving server the metrics are for (e.g. http or grpc).
 
     Returns:
         A tuple of a list of metrics and an optional boolean to determine whether the return metrics are legacy metrics.


### PR DESCRIPTION
## What does this PR address?

Fixes two docstrings where the documented parameter name does not match the actual function signature:

| File | Function | Docstring said | Signature has |
|------|----------|---------------|---------------|
| `src/bentoml/_internal/models/model.py` | `Model.to_runner` | `runnable_method_configs` | `method_configs` |
| `src/bentoml/_internal/utils/analytics/usage_stats.py` | `get_metrics_report` | `grpc` | `serve_kind` |

Doc-only change; no behavior modified.

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming?
- [x] Does the change require documentation update? (this is the documentation update)