### PR TITLE
test: add unit tests for the dotenv parser

### DIFF
--- a/tests/unit/_internal/utils/test_dotenv.py
+++ b/tests/unit/_internal/utils/test_dotenv.py
@@ -1,0 +1,46 @@
+from bentoml._internal.utils.dotenv import parse_dotenv
+
+
+def test_simple_assignment():
+    assert parse_dotenv("KEY=value") == {"KEY": "value"}
+
+
+def test_export_prefix_is_stripped():
+    assert parse_dotenv("export KEY=value") == {"KEY": "value"}
+
+
+def test_colon_separator():
+    assert parse_dotenv("KEY: value") == {"KEY": "value"}
+
+
+def test_double_quoted_value():
+    assert parse_dotenv('KEY="value"') == {"KEY": "value"}
+
+
+def test_single_quoted_value():
+    assert parse_dotenv("KEY='value'") == {"KEY": "value"}
+
+
+def test_empty_value():
+    assert parse_dotenv("KEY=") == {"KEY": ""}
+
+
+def test_trailing_comment_is_stripped():
+    assert parse_dotenv("KEY=value # trailing comment") == {"KEY": "value"}
+
+
+def test_comment_and_blank_lines_are_ignored():
+    assert parse_dotenv("# a comment\n\nKEY=v") == {"KEY": "v"}
+
+
+def test_variable_substitution():
+    assert parse_dotenv("A=1\nB=${A}x") == {"A": "1", "B": "1x"}
+
+
+def test_escaped_variable_is_not_substituted():
+    # A leading backslash escapes the reference, leaving it literal.
+    assert parse_dotenv("A=1\nB=\\$A") == {"A": "1", "B": "$A"}
+
+
+def test_single_quotes_disable_substitution():
+    assert parse_dotenv("A=1\nB='$A'") == {"A": "1", "B": "$A"}


### PR DESCRIPTION
## Description

`bentoml._internal.utils.dotenv.parse_dotenv` parses `.env`-style content into
a dict. It handles `export` prefixes, `=`/`:` separators, single/double
quoting, inline comments, and `$VAR`/`${VAR}` substitution - but had no test
coverage.

This adds `tests/unit/_internal/utils/test_dotenv.py` covering:

- simple assignment, `export` prefix, and the `:` separator
- single- and double-quoted values, and empty values
- trailing inline comments and full comment / blank lines being ignored
- `${VAR}` substitution from earlier keys
- a backslash-escaped `\$VAR` staying literal
- single quotes disabling substitution

No source changes.

## Verification

`pytest tests/unit/_internal/utils/test_dotenv.py` - 11 passed. `ruff check` /
`ruff format --check` clean.
