### PR TITLE
test: add unit tests for FixedBucket and TokenBucket

### DIFF
--- a/tests/unit/_internal/utils/test_alg.py
+++ b/tests/unit/_internal/utils/test_alg.py
@@ -1,0 +1,54 @@
+from bentoml._internal.utils.alg import FixedBucket
+from bentoml._internal.utils.alg import TokenBucket
+
+
+class TestFixedBucket:
+    def test_empty(self):
+        b = FixedBucket(3)
+        assert len(b) == 0
+        assert b.data == []
+        assert b[:] == []
+
+    def test_under_capacity(self):
+        b = FixedBucket(3)
+        b.put(1)
+        b.put(2)
+        assert len(b) == 2
+        assert b.data == [1, 2]
+        assert b[:] == [1, 2]
+
+    def test_exactly_full(self):
+        b = FixedBucket(3)
+        for v in (1, 2, 3):
+            b.put(v)
+        assert len(b) == 3
+        assert b[:] == [1, 2, 3]
+
+    def test_wraps_and_iterates_fifo_oldest_first(self):
+        b = FixedBucket(3)
+        for v in (1, 2, 3, 4, 5):
+            b.put(v)
+        assert len(b) == 3
+        # Indexing yields items oldest-to-newest after wrap-around.
+        assert b[:] == [3, 4, 5]
+        assert b[:2] == [3, 4]
+        # data returns the raw ring-buffer contents (not reordered).
+        assert b.data == [4, 5, 3]
+
+
+class TestTokenBucket:
+    def test_consume_within_amount_succeeds(self):
+        bucket = TokenBucket(10)
+        assert bucket.consume(5, avg_rate=0, burst_size=10) is True
+
+    def test_consume_more_than_available_fails(self):
+        bucket = TokenBucket(10)
+        bucket.consume(5, avg_rate=0, burst_size=10)
+        assert bucket.consume(10, avg_rate=0, burst_size=10) is False
+
+    def test_burst_size_caps_available_tokens(self):
+        bucket = TokenBucket(100)
+        # burst_size caps usable tokens to 10, so a small take still succeeds.
+        assert bucket.consume(1, avg_rate=0, burst_size=10) is True
+        # ...but a take above the cap fails.
+        assert bucket.consume(11, avg_rate=0, burst_size=10) is False


### PR DESCRIPTION
## Description

`bentoml._internal.utils.alg` provides two small pure data structures used
internally - `FixedBucket` (a fixed-size FIFO ring buffer) and `TokenBucket`
(a token-bucket rate limiter) - neither of which had test coverage.

This adds `tests/unit/_internal/utils/test_alg.py` covering:

- `FixedBucket`: empty state, filling under capacity, exactly full, and
  wrap-around behavior - indexing yields items oldest-to-newest while `.data`
  returns the raw ring-buffer contents
- `TokenBucket`: consuming within the available amount, failing when the take
  exceeds what's available, and `burst_size` capping the usable tokens

`TokenBucket` tests use `avg_rate=0` so they don't depend on wall-clock time.
No source changes.

## Verification

`pytest tests/unit/_internal/utils/test_alg.py` - 7 passed. `ruff check` /
`ruff format --check` clean.
