### PR TITLE
fix: sanitize docker.env values to prevent Dockerfile injection

### DIFF
--- a/src/bentoml/_internal/container/frontend/dockerfile/templates/base.j2
+++ b/src/bentoml/_internal/container/frontend/dockerfile/templates/base.j2
@@ -44,8 +44,8 @@ RUN groupadd -g $BENTO_USER_GID -o $BENTO_USER && useradd -m -u $BENTO_USER_UID 
 {% block SETUP_BENTO_ENVARS %}
 {% if __options__env is not none %}
 {% for key, value in __options__env.items() -%}
-ARG {{ key }}={{ value }}
-ENV {{ key }}=${{ key }}
+ARG {{ key|normalize_line }}={{ value|default("", true)|normalize_line|bash_quote }}
+ENV {{ key|normalize_line }}=${{ key|normalize_line }}
 {% endfor -%}
 {% endif -%}
 

--- a/src/bentoml/_internal/container/frontend/dockerfile/templates/base_v2.j2
+++ b/src/bentoml/_internal/container/frontend/dockerfile/templates/base_v2.j2
@@ -67,7 +67,7 @@ ENV BENTOML_CONTAINERIZED=true
 {% for env in __bento_envs__ %}
 {% set stage = env.stage | default("all") -%}
 {% if stage != "runtime" -%}
-ARG {{ env.name|normalize_line }}{% if env.value %}={{ env.value | bash_quote }}{% endif %}
+ARG {{ env.name|normalize_line }}={{ env.value|default("", true)|normalize_line|bash_quote }}
 
 ENV {{ env.name|normalize_line }}=${{ env.name|normalize_line }}
 {% endif -%}

--- a/tests/unit/_internal/container/test_generate.py
+++ b/tests/unit/_internal/container/test_generate.py
@@ -64,3 +64,41 @@ def test_generate_containerfile_normalizes_custom_base_image(tmp_path) -> None:
 
     assert "FROM python:3.11-slim RUN touch /tmp/pwned as base-container" in dockerfile
     assert "\nRUN touch /tmp/pwned" not in dockerfile
+
+
+def test_generate_containerfile_sanitizes_env_dict_values(tmp_path) -> None:
+    dockerfile = generate_containerfile(
+        DockerOptions(
+            distro="debian",
+            python_version="3.11",
+            env={"X": "a\nRUN echo PWNED_VIA_ENV_INJECTION", "GREETING": "hello world"},
+        ),
+        str(tmp_path),
+        conda=CondaOptions(),
+        bento_fs=tmp_path,
+    )
+
+    # A newline in an env value must not break out into a new Dockerfile instruction.
+    assert "\nRUN echo PWNED_VIA_ENV_INJECTION" not in dockerfile
+    # The payload is neutralized inside a single-quoted ARG value.
+    assert "ARG X='a RUN echo PWNED_VIA_ENV_INJECTION'" in dockerfile
+    # Legitimate multi-word values are preserved and quoted.
+    assert "ARG GREETING='hello world'" in dockerfile
+
+
+def test_generate_dockerfile_sanitizes_envs_values(tmp_path) -> None:
+    from _bentoml_impl.docker import generate_dockerfile
+    from bentoml._internal.bento.bento import ImageInfo
+    from bentoml._internal.bento.build_config import BentoEnvSchema
+
+    image = ImageInfo(python_version="3.11", base_image="python:3.11-slim")
+    dockerfile = generate_dockerfile(
+        image,
+        tmp_path,
+        envs=[BentoEnvSchema(name="X", value="a\nRUN echo PWNED_V2", stage="all")],
+    )
+
+    # The newline must not break out into a new Dockerfile instruction.
+    assert "\nRUN echo PWNED_V2" not in dockerfile
+    # The payload is neutralized inside a single-quoted ARG value.
+    assert "ARG X='a RUN echo PWNED_V2'" in dockerfile


### PR DESCRIPTION
## Summary

The generated container Dockerfile interpolated `docker.env` values with no
sanitization, so a newline in a value broke out into a new `RUN` instruction
that executed during `docker build`. This affected every `bentoml build` /
`containerize` user relying on the `docker.env` dict (the default path for
`bentofile.yaml`), as well as the newer `envs` path rendered via `base_v2.j2`.
This PR sanitizes env values consistently in both templates, neutralizing the
injection.

## Root Cause

`base.j2` is the default template chain for `bentoml build`
(`python_debian.j2` → `base_debian.j2` → `base.j2`); neither override of
`SETUP_BENTO_ENVARS` exists, so `base.j2`'s env loop is used. It rendered:

```jinja
ARG {{ key }}={{ value }}
ENV {{ key }}=${{ key }}
```

`DockerOptions._convert_env` converts the dict form with no validation
(`{str(k): str(v) for k, v in env.items()}`), so a value such as
`"a\nRUN echo PWNED\n"` became a physical newline in the Dockerfile. The Docker
lexer treats that newline as a new instruction, producing a real `RUN` step.

`base_v2.j2` already applied `bash_quote`, but that filter wraps the value in
single quotes **without removing the newline**, so the lexer still broke the
line. The newline must be collapsed (via `normalize_line`) *before* quoting.

## Solution

Sanitize every env value with the same filters already used elsewhere in the
codebase — `normalize_line` (collapse newlines / control chars) then `bash_quote`
(shell-safety) — applied identically in both `base.j2` and `base_v2.j2`:

```jinja
ARG {{ key|normalize_line }}={{ value|default("", true)|normalize_line|bash_quote }}
ENV {{ key|normalize_line }}=${{ key|normalize_line }}
```

`default("", true)` safely handles `None` / empty values. This mirrors the
hardening already applied to `system_packages` (`bash_quote`) and `base_image`
(`normalize_line`), and removes the previous inconsistency where the two
templates used different guards (`is not none` vs truthy). No Python-level
refactoring was needed; the fix is contained to the Jinja templates, matching
the established pattern for adjacent injection fixes.

## Testing

- Added `test_generate_containerfile_sanitizes_env_dict_values` (legacy
  `docker.env` dict path) and `test_generate_dockerfile_sanitizes_envs_values`
  (new `envs` path via `base_v2.j2`).
- Both fail before the fix and pass after.
- Existing container tests pass (24/24). `ruff check` and `ruff format` are
  clean.

Commands:

```bash
pytest tests/unit/_internal/container/test_generate.py -v
ruff check src/bentoml/_internal/container/frontend/dockerfile/templates/ tests/unit/_internal/container/test_generate.py
```

Manual verification covered edge cases: newline injection, backslash
continuation (`hello \`), normal values, multi-word values (`hello world` →
`ARG GREETING='hello world'`), empty string, `"0"`, `"false"`, list-form env,
and `.env`-file env.

## Performance Impact

None. `normalize_line` and `bash_quote` are O(length) string operations applied
only to env values during Dockerfile generation, which already renders the full
template.

## Backward Compatibility

- Public API: unchanged. `DockerOptions.env` / `BentoEnvSchema` signatures
  unaffected.
- Rendered Dockerfile: non-special env values render identically
  (`KEY=value`). Values containing special characters are now single-quoted;
  empty-string values render as `ARG X=''` instead of `ARG X=` (consistent with
  the existing `base_v2.j2` convention). List-form env cannot produce empty
  values (regex-validated), so no impact there.
- Serialization / checkpoint / inference / training: not applicable — this is
  build-time Dockerfile generation only.

## Risk Assessment

- Risk: empty-string env values now render as `''` rather than empty. Impact is
  negligible and documented above.
- Risk: a value containing a shell metacharacter used later in a `RUN` via
  `$VAR` is now quoted, which is strictly safer.
- Mitigation: behavior matches the already-shipped `base_v2.j2` convention.
- Remaining limitation: values are sanitized only at render time; users who
  hand-edit the generated Dockerfile are unaffected by this change.
- Future work: optionally validate the dict form in `_convert_env` (mirroring
  the list-form regex) as defense in depth. Not required for this fix.

## Files Changed

| File | Purpose |
| ---- | ------- |
| `src/bentoml/_internal/container/frontend/dockerfile/templates/base.j2` | Sanitize legacy `docker.env` values |
| `src/bentoml/_internal/container/frontend/dockerfile/templates/base_v2.j2` | Sanitize new `envs` values |
| `tests/unit/_internal/container/test_generate.py` | Regression tests for both paths |

## Reviewer Notes

- Focus on the two template lines; the change is intentionally minimal and
  symmetric across both templates.
- The `default("", true)` idiom is what makes both templates byte-for-byte
  consistent and handles `None`/empty safely; an alternative `{% if value is not
  none %}` guard is equivalent but less consistent.
- `cuda_debian.j2` extends `base_debian.j2` and only calls `{{ super() }}` in
  `SETUP_BENTO_ENVARS`, so the `base.j2` fix covers the CUDA path as well.

## Checklist

- [x] Root cause identified
- [x] Minimal fix
- [x] Regression test added
- [x] Existing tests pass
- [x] No breaking API changes
- [x] Documentation updated (if required) — N/A, internal build-time change
- [x] Style checks pass
- [x] Backward compatible

## Related Issues

Fixes #5656

Related #5603 (base_image normalize_line), #79fbea5a (system_packages
bash_quote), #5614 (new `envs` name POSIX validation — different field).

## Additional Notes

- The `.env`-file path rejects keyless entries (`parse_dotenv` raises), so
  `None` values do not occur via that route; `default("", true)` handles the
  case defensively anyway.
- This is the same injection class the maintainers have been actively fixing;
  the `docker.env` dict was the one unguarded path.
