### PR TITLE
feat: add span_id and service_name to monitoring logs

### DIFF
--- a/src/bentoml/_internal/monitoring/default.py
+++ b/src/bentoml/_internal/monitoring/default.py
@@ -56,10 +56,18 @@ class DefaultMonitor(MonitorBase["JSONSerializable"]):
     data is logged as a JSON array.
     """
 
-    PRESERVED_COLUMNS = (COLUMN_TIME, COLUMN_RID, COLUMN_TID) = (
+    PRESERVED_COLUMNS = (
+        COLUMN_TIME,
+        COLUMN_RID,
+        COLUMN_TID,
+        COLUMN_SID,
+        COLUMN_SVC,
+    ) = (
         "timestamp",
         "request_id",
         "trace_id",
+        "span_id",
+        "service_name",
     )
 
     def __init__(
@@ -144,6 +152,8 @@ class DefaultMonitor(MonitorBase["JSONSerializable"]):
             self.COLUMN_TIME: datetime.datetime.now().isoformat(),
             self.COLUMN_RID: str(trace_context.request_id),
             self.COLUMN_TID: str(trace_context.trace_id),
+            self.COLUMN_SID: str(trace_context.span_id),
+            self.COLUMN_SVC: str(trace_context.service_name),
         }
         while True:
             try:

--- a/src/bentoml/_internal/monitoring/otlp.py
+++ b/src/bentoml/_internal/monitoring/otlp.py
@@ -94,10 +94,19 @@ class OTLPMonitor(MonitorBase["JSONSerializable"]):
 
     """
 
-    PRESERVED_COLUMNS = (COLUMN_TIME, COLUMN_RID, COLUMN_TID, COLUMN_META) = (
+    PRESERVED_COLUMNS = (
+        COLUMN_TIME,
+        COLUMN_RID,
+        COLUMN_TID,
+        COLUMN_SID,
+        COLUMN_SVC,
+        COLUMN_META,
+    ) = (
         "timestamp",
         "request_id",
         "trace_id",
+        "span_id",
+        "service_name",
         "bento_meta",
     )
 
@@ -245,6 +254,8 @@ class OTLPMonitor(MonitorBase["JSONSerializable"]):
             self.COLUMN_TIME: datetime.datetime.now().timestamp(),
             self.COLUMN_RID: str(trace_context.request_id),
             self.COLUMN_TID: str(trace_context.trace_id),
+            self.COLUMN_SID: str(trace_context.span_id),
+            self.COLUMN_SVC: str(trace_context.service_name),
         }
 
         if self._will_export_schema or random.random() < self.meta_sample_rate:

--- a/tests/unit/_internal/monitoring/test_context_columns.py
+++ b/tests/unit/_internal/monitoring/test_context_columns.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import collections
+from unittest import mock
+
+import pytest
+
+from bentoml._internal.monitoring.default import DefaultMonitor
+
+
+def _assert_trace_context_columns(monitor, context_path: str) -> None:
+    monitor.data_logger = mock.Mock()
+    with mock.patch(context_path) as context:
+        context.request_id = 101
+        context.trace_id = 202
+        context.span_id = 303
+        context.service_name = "fraud-service"
+        monitor.export_data({"prediction": collections.deque(["fraud"])})
+
+    record = monitor.data_logger.info.call_args.args[0]
+    assert record["request_id"] == "101"
+    assert record["trace_id"] == "202"
+    assert record["span_id"] == "303"
+    assert record["service_name"] == "fraud-service"
+
+
+def test_default_monitor_includes_span_and_service_context(tmp_path) -> None:
+    monitor = DefaultMonitor("predictions", str(tmp_path))
+    _assert_trace_context_columns(
+        monitor, "bentoml._internal.monitoring.default.trace_context"
+    )
+
+
+def test_otlp_monitor_includes_span_and_service_context() -> None:
+    pytest.importorskip("opentelemetry.exporter.otlp.proto.http._log_exporter")
+    from bentoml._internal.monitoring.otlp import OTLPMonitor
+
+    monitor = OTLPMonitor("predictions", meta_sample_rate=0)
+    _assert_trace_context_columns(
+        monitor, "bentoml._internal.monitoring.otlp.trace_context"
+    )


### PR DESCRIPTION
> This replaces #5633, which I accidentally closed when its source fork was detached. The change has been rebased onto current `main`; the original discussion remains in #5633.

## Summary

Monitoring records already include `trace_id`, but not `span_id` or the service name. This makes it impossible to correlate a monitoring log line to a specific span (or service) within a distributed trace without manually calling `mon.log(...)` in user code. Closes #4367.

## Changes

Add `span_id` and `service_name` as preserved columns in both monitor backends, populated from the existing `trace_context` — exactly how `trace_id` is already handled:

- `DefaultMonitor` (`monitoring/default.py`) — file/JSON logs
- `OTLPMonitor` (`monitoring/otlp.py`) — OTLP export

Before:
```json
{"trace_id": "...", "request_id": "...", "timestamp": "...", "...": "..."}
```
After:
```json
{"trace_id": "...", "span_id": "...", "service_name": "...", "request_id": "...", "timestamp": "...", "...": "..."}
```

## Notes

- Crash-safe: `span_id` falls back to `0` when no span is active, identical to the existing `trace_id` behavior; `service_name` is `None` when unset (same pattern as `request_id`).
- No new dependencies; mirrors the existing preserved-column pattern, so users no longer need to log trace context manually.

## Validation
- `pytest -q tests/unit/_internal/monitoring/test_context_columns.py` (2 passed)
