### PR TITLE
feat: support configurable proxy host and user-provided aiohttp client

### DIFF
--- a/src/_bentoml_impl/server/proxy.py
+++ b/src/_bentoml_impl/server/proxy.py
@@ -52,24 +52,33 @@ def create_proxy_app(service: Service[t.Any]) -> Starlette:
     ) -> t.AsyncGenerator[dict[str, t.Any], None]:
         server_instance = get_current_service()
         assert server_instance is not None, "Current service is not initialized"
-        # Only start process for the first worker or when replicate_process is True
-        should_start_process = (
+        http_config = service.config.get("http", {})
+        proxy_host = http_config.get("proxy_host", "localhost")
+        proxy_port = http_config.get("proxy_port", 8000)
+        proxy_url = f"http://{proxy_host}:{proxy_port}"
+        health_url = f"{proxy_url}/{health_endpoint.lstrip('/')}"
+        # A remote proxy host points at an externally managed upstream server,
+        # so this process must not try to spawn the command locally.
+        is_remote_proxy = proxy_host not in ("localhost", "127.0.0.1", "::1")
+        # Only start the process for the first worker (or when replicate_process
+        # is True), and never when proxying to a remote host.
+        should_start_process = not is_remote_proxy and (
             service.config.get("replicate_process", False)
             or server_context.worker_index == 1
         )
         async with contextlib.AsyncExitStack() as stack:
-            proxy_port = service.config.get("http", {}).get("proxy_port", 8000)
-            proxy_url = f"http://localhost:{proxy_port}"
             proc: Process | None = None
             if (
                 instance_client := getattr(server_instance, "client", None)
             ) is not None and isinstance(instance_client, aiohttp.ClientSession):
-                # TODO: support aiohttp client
+                # Use the user-provided session as-is. We always build absolute
+                # URLs (see the health check and reverse_proxy below), so the
+                # user's client does not need a base_url pointing at BentoML's
+                # internal proxy port.
                 client = instance_client
             else:
                 client = await stack.enter_async_context(
                     aiohttp.ClientSession(
-                        base_url=proxy_url,
                         timeout=aiohttp.ClientTimeout(),
                         connector=aiohttp.TCPConnector(limit=512),
                     )
@@ -88,7 +97,7 @@ def create_proxy_app(service: Service[t.Any]) -> Starlette:
                 logger.info("Running service with command: %s", " ".join(cmd))
                 proc = await anyio.open_process(cmd, stdout=None, stderr=None)
             while proc is None or proc.returncode is None:
-                if await _check_health(client, health_endpoint):
+                if await _check_health(client, health_url):
                     break
                 await anyio.sleep(0.5)
             else:
@@ -97,6 +106,7 @@ def create_proxy_app(service: Service[t.Any]) -> Starlette:
                 )
 
             app.state.client = client
+            app.state.proxy_url = proxy_url
             try:
                 state = {
                     "proc": proc,
@@ -129,7 +139,11 @@ def create_proxy_app(service: Service[t.Any]) -> Starlette:
         import yarl
         from starlette.background import BackgroundTask
 
-        url = yarl.URL.build(path=f"/{path}", query=request.url.query or None)
+        # Build an absolute URL so the proxy works for both BentoML's own client
+        # and a user-provided session that has no base_url configured.
+        url = (yarl.URL(app.state.proxy_url) / path.lstrip("/")).with_query(
+            request.url.query or None
+        )
         client = t.cast(aiohttp.ClientSession, app.state.client)
         headers = dict(request.headers)
         headers.pop("host", None)

--- a/src/_bentoml_sdk/service/config.py
+++ b/src/_bentoml_sdk/service/config.py
@@ -153,6 +153,7 @@ class HTTPCorsSchema(TypedDict, total=False):
 class HTTPSchema(TypedDict, total=False):
     host: IPvAnyAddress
     port: int
+    proxy_host: str
     proxy_port: int
     cors: HTTPCorsSchema
     response: TypedDict("HTTPResponseSchema", {"trace_id": bool}, total=False)  # type: ignore

--- a/src/bentoml/_internal/configuration/v2/__init__.py
+++ b/src/bentoml/_internal/configuration/v2/__init__.py
@@ -126,6 +126,7 @@ _SERVICE_CONFIG = {
     s.Optional("http"): {
         "host": s.And(str, is_valid_ip_address),
         "port": s.And(int, ensure_larger_than_zero),
+        "proxy_host": str,
         "proxy_port": s.And(int, ensure_larger_than_zero),
         "cors": {
             "enabled": bool,

--- a/src/bentoml/_internal/configuration/v2/default_configuration.yaml
+++ b/src/bentoml/_internal/configuration/v2/default_configuration.yaml
@@ -51,6 +51,7 @@ services:
   http:
     host: 0.0.0.0
     port: 3000
+    proxy_host: localhost
     proxy_port: 8000
     cors:
       enabled: false

--- a/tests/unit/_internal/server/test_proxy.py
+++ b/tests/unit/_internal/server/test_proxy.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import contextlib
+from types import SimpleNamespace
+from unittest import mock
+
+import aiohttp
+import pytest
+from starlette.requests import Request
+
+from _bentoml_impl.server import proxy
+
+
+class _ResponseContent:
+    async def iter_any(self):
+        if False:
+            yield b""
+
+
+class _UpstreamResponse:
+    status = 200
+    headers: dict[str, str] = {}
+    content = _ResponseContent()
+
+
+@contextlib.asynccontextmanager
+async def _upstream_response():
+    yield _UpstreamResponse()
+
+
+@pytest.mark.asyncio
+async def test_remote_proxy_uses_configured_host_and_supplied_client(
+    monkeypatch,
+) -> None:
+    service = mock.MagicMock()
+    service.config = {
+        "http": {"proxy_host": "upstream.internal", "proxy_port": 9100},
+        "endpoints": {"livez": "/ready"},
+    }
+    service.has_custom_command.return_value = True
+    service.context.state = {}
+
+    supplied_client = mock.Mock(spec=aiohttp.ClientSession)
+    supplied_client.request.return_value = _upstream_response()
+    server_instance = SimpleNamespace(client=supplied_client)
+    monkeypatch.setattr(proxy, "get_current_service", lambda: server_instance)
+
+    health_check = mock.AsyncMock(return_value=True)
+    monkeypatch.setattr(proxy, "_check_health", health_check)
+    open_process = mock.AsyncMock()
+    monkeypatch.setattr(proxy.anyio, "open_process", open_process)
+
+    app = proxy.create_proxy_app(service)
+    async with app.router.lifespan_context(app):
+        assert app.state.client is supplied_client
+        assert app.state.proxy_url == "http://upstream.internal:9100"
+        health_check.assert_awaited_once_with(
+            supplied_client, "http://upstream.internal:9100/ready"
+        )
+        open_process.assert_not_awaited()
+
+        route = next(route for route in app.routes if route.path == "/{path:path}")
+        scope = {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/claims/42",
+            "raw_path": b"/claims/42",
+            "query_string": b"detail=full",
+            "root_path": "",
+            "headers": [],
+            "client": ("127.0.0.1", 50000),
+            "server": ("testserver", 80),
+        }
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        request = Request(scope, receive)
+        response = await route.endpoint(request, "claims/42")
+
+        requested_url = supplied_client.request.call_args.kwargs["url"]
+        assert str(requested_url) == (
+            "http://upstream.internal:9100/claims/42?detail=full"
+        )
+        assert response.status_code == 200
+        await response.background()


### PR DESCRIPTION
> This replaces #5632, which I accidentally closed when its source fork was detached. The change has been rebased onto current `main`; the original discussion remains in #5632.

## Summary

`create_proxy_app` hardcoded `localhost` as the proxy host and could not use a user-provided `aiohttp.ClientSession` (set via `self.client`). Closes #5568.

The user's session has no `base_url` — they cannot know BentoML's internal `proxy_port` at client-creation time — so the existing code (which relied on `base_url` and built relative URLs) broke for user-provided clients. The host was also hardcoded to `localhost`, so requests could not be forwarded to a remote/external upstream server.

## Changes

- **Configurable proxy host**: add optional `http.proxy_host` (default `localhost`) so requests can be forwarded to a remote/external ML server.
- **Remote-safe process management**: when `proxy_host` is remote, `should_start_process` is `False` — BentoML cannot spawn the upstream command on another machine.
- **Absolute URLs**: build full absolute URLs in `reverse_proxy` and the startup health check instead of relying on the session's `base_url`, so a user-provided client works as-is (custom auth/SSL/retries supported).
- **Config registration**: register `proxy_host` in the v2 config schema, the SDK `HTTPSchema`, and the default configuration.

## Testing

- `py_compile` passes for all changed Python files; default config YAML parses.
- Verified URL construction (local / remote / multi-segment path / query string) and the remote-host classification (`localhost`/`127.0.0.1`/`::1` → local; others → remote).

## Notes

Backward compatible: when `proxy_host` is unset it defaults to `localhost`, preserving current behavior. No new dependencies.

## Validation
- `pytest -q tests/unit/_internal/server/test_proxy.py` (1 passed)
