### PR TITLE
test: add unit tests for pkg_version_info

### DIFF
--- a/tests/unit/_internal/utils/test_pkg.py
+++ b/tests/unit/_internal/utils/test_pkg.py
@@ -1,0 +1,21 @@
+import importlib.metadata
+
+import packaging
+import pytest
+
+from bentoml._internal.utils.pkg import pkg_version_info
+
+
+def test_returns_major_minor_micro_int_tuple():
+    version = pkg_version_info("packaging")
+    assert len(version) == 3
+    assert all(isinstance(part, int) for part in version)
+
+
+def test_accepts_module_or_name():
+    assert pkg_version_info(packaging) == pkg_version_info("packaging")
+
+
+def test_missing_package_raises():
+    with pytest.raises(importlib.metadata.PackageNotFoundError):
+        pkg_version_info("bentoml_no_such_package_9999")


### PR DESCRIPTION
## Description

`bentoml._internal.utils.pkg.pkg_version_info` returns a package's
`(major, minor, micro)` version tuple, accepting either a module name or a
module object. It had no direct test coverage (the neighbouring
`source_locations` is already tested).

This adds `tests/unit/_internal/utils/test_pkg.py` covering:

- the result being a 3-tuple of ints
- passing a module object and its name yielding the same result
- a missing package raising `PackageNotFoundError`

It asserts structure rather than a specific version number, and uses the
always-present `packaging` dependency as the target. No source changes.

## Verification

`pytest tests/unit/_internal/utils/test_pkg.py` - 3 passed. `ruff check` /
`ruff format --check` clean.
