### PR TITLE
fix: correct inverted isinstance check in transformers custom pipeline save (#5132)

### DIFF
--- a/src/bentoml/_internal/frameworks/transformers.py
+++ b/src/bentoml/_internal/frameworks/transformers.py
@@ -1076,7 +1076,7 @@ def save_model(
             assert "impl" in task_definition, "'task_definition' requires 'impl' key."
 
             impl = task_definition["impl"]
-            if isinstance(pipeline_, impl):
+            if not isinstance(pipeline_, impl):
                 raise BentoMLException(
                     f"Argument 'pipeline' is not an instance of {impl}. It is an instance of {type(pipeline_)}."
                 )


### PR DESCRIPTION
Fixes #5132

## Root cause
`save_model()`'s validation for custom transformers pipelines had an
inverted `isinstance()` check: it raised
`Argument 'pipeline' is not an instance of {impl}. It is an instance of {type(pipeline_)}.`
whenever `pipeline_` *was* a valid instance of `impl` (the correct case),
and silently accepted the pipeline when it was *not* an instance (the
invalid case). This matches the reporter's symptom of the same class name
appearing on both sides of the error message.

## What changed
One-line fix in `src/bentoml/_internal/frameworks/transformers.py`:
negate the condition so the exception is raised only when the pipeline
does not match the declared `impl`.

## Test evidence
No new test was required — two existing tests in
`tests/integration/frameworks/test_transformers_unit.py` already covered
both branches of this logic and were silently broken (this framework's
tests are excluded from CI due to runner space constraints, per
`.github/workflows/ci.yml`, which is how this regression went unnoticed):

- `test_raise_does_not_match_impl_field` (mismatched impl should raise):
  FAILED before this change (`DID NOT RAISE BentoMLException`), PASSED after.
- `test_logs_custom_task_definition` (matching impl should not raise):
  FAILED before this change, PASSED after.

Both verified via git stash/pop round-trips against the unmodified code.

Prepared with AI assistance (Claude, agent: claude-sonnet-5), reviewed for correctness before submission.