### PR TITLE
fix(exportable): create traversable symlinks on Windows when importing a bento

### DIFF
--- a/src/bentoml/_internal/exportable.py
+++ b/src/bentoml/_internal/exportable.py
@@ -195,7 +195,14 @@ def _copy_tar_fs(fs: fsspec.AbstractFileSystem, temp_dir: str) -> None:
         _validate_symlink_target(entry.linkname, destination, root)
         if os.path.lexists(destination):
             _raise_unsafe_member(entry.path, "duplicate destination path")
-        os.symlink(entry.linkname, destination)
+        # entry.linkname is a POSIX target from the archive; on Windows a
+        # forward-slash symlink is not traversable (OSError [Errno 22]), so
+        # localize the separators for the on-disk link (validation above ran
+        # on the original POSIX target).
+        link_target = entry.linkname
+        if os.sep != "/":
+            link_target = link_target.replace("/", os.sep)
+        os.symlink(link_target, destination)
         _ensure_within_directory(root, destination)
 
 

--- a/tests/unit/_internal/test_exportable.py
+++ b/tests/unit/_internal/test_exportable.py
@@ -142,7 +142,9 @@ def test_from_fs_preserves_safe_tar_symlink(tmp_path: Path) -> None:
     assert os.readlink(link) == "marker.txt"
     assert link.read_text() == "ok"
     assert nested_link.is_symlink()
-    assert os.readlink(nested_link) == "../marker.txt"
+    # ``os.symlink`` stores the target using the platform separator, so compare
+    # through ``Path`` to stay correct on Windows (``..\\marker.txt``) as well.
+    assert Path(os.readlink(nested_link)) == Path("../marker.txt")
     assert nested_link.read_text() == "ok"
 
 


### PR DESCRIPTION
## What does this PR address?

Importing a bento that contains a relative symlink whose target spans a directory (e.g. `nested/link -> ../marker.txt`) fails on Windows with `OSError: [Errno 22] Invalid argument` when the link is accessed.

This is currently red on `main`: the `unit-tests (*.windows-latest)` matrix jobs fail on `tests/unit/_internal/test_exportable.py::test_from_fs_preserves_safe_tar_symlink` (for example, the scheduled `CI` run on 2026-07-17, id 29544812233).

### Root cause

Archive members carry POSIX-style symlink targets. In `_copy_tar_fs`, `os.symlink(entry.linkname, destination)` writes that target verbatim. On Windows a forward-slash target (`../marker.txt`) produces a reparse point the OS cannot traverse, so any later access (`is_symlink()` / `read_text()`) raises `OSError [Errno 22]`. A same-directory target (`marker.txt`, no separator) works, which is why only the nested case fails.

### Fix

Localize the target separators to `os.sep` right before creating the on-disk link. On POSIX platforms `os.sep == "/"`, so this is a no-op there.

The existing regression test `test_from_fs_preserves_safe_tar_symlink` now passes on Windows. Its `os.readlink` check is compared through `Path`, because the stored target is now platform-native (`..\marker.txt` on Windows, `../marker.txt` elsewhere).

### Security

The separator localization runs *after* `_validate_symlink_target`, which still validates the original POSIX target (rejecting NUL / absolute / backslash / drive-qualified targets and ensuring the resolved target stays within the import root via `_ensure_within_directory`). Swapping `/` for `os.sep` does not change the resolved target, so the traversal guarantees are unaffected.

### Verification (Windows 11, Python 3.12)

- Before (on `main`): `test_from_fs_preserves_safe_tar_symlink` fails with `OSError: [Errno 22] Invalid argument`.
- After: the test passes; the full `tests/unit/_internal/test_exportable.py` suite is green (38 passed); `ruff check` and `ruff format --check` report no changes.

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming?
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed? (ruff-check, ruff-format, trailing-whitespace, end-of-file-fixer all clean on the changed files)
- [x] Did you read through the contribution guidelines and follow the development guidelines?
- [ ] Did your changes require updates to the documentation? (not applicable)
- [x] Did you write tests to cover your changes? (the existing Windows regression test now passes; readlink assertion made separator-agnostic)
