### PR TITLE
fix: make TransformersRunnable work on CPU-only machines (#4376)

### DIFF
--- a/src/bentoml/_internal/frameworks/transformers.py
+++ b/src/bentoml/_internal/frameworks/transformers.py
@@ -609,7 +609,9 @@ def make_default_signatures(pretrained_cls: t.Any) -> ModelSignaturesType:
         )
         return {}
 
-    return {k: default_config for k in infer_fn}
+    # NOTE: filter out methods that are not available on the given class, since
+    # the set of generation methods varies between transformers versions.
+    return {k: default_config for k in infer_fn if hasattr(pretrained_cls, k)}
 
 
 def import_model(
@@ -1208,7 +1210,8 @@ def get_runnable(bento_model: bentoml.Model) -> type[bentoml.legacy.Runnable]:
                                 "cuda" if available_gpus not in ("", "-1") else "cpu"
                             )
                         )
-                        torch.set_default_tensor_type("torch.cuda.FloatTensor")
+                        if available_gpus not in ("", "-1"):
+                            torch.set_default_tensor_type("torch.cuda.FloatTensor")
                     elif "tf" == bento_model.info.metadata["_framework"]:
                         with tf.device(
                             "/device:CPU:0"
@@ -1239,6 +1242,15 @@ def get_runnable(bento_model: bentoml.Model) -> type[bentoml.legacy.Runnable]:
 
             self.predict_fns: dict[str, t.Callable[..., t.Any]] = {}
             for method_name in bento_model.info.signatures:
+                if not hasattr(self.model, method_name):
+                    # model was saved with a transformers version that had
+                    # methods the installed version no longer provides.
+                    logger.warning(
+                        "Saved signature method '%s' is not available on %s and will be skipped.",
+                        method_name,
+                        type(self.model).__name__,
+                    )
+                    continue
                 self.predict_fns[method_name] = getattr(self.model, method_name)
 
     def add_runnable_method(method_name: str, options: ModelSignature):

--- a/tests/integration/frameworks/test_transformers_unit.py
+++ b/tests/integration/frameworks/test_transformers_unit.py
@@ -293,6 +293,69 @@ def test_custom_pipeline(pair_classification_pipeline: PairClassificationPipelin
     runner.destroy()
 
 
+def test_pretrained_runnable_init_without_gpu(monkeypatch: pytest.MonkeyPatch):
+    """
+    Instantiating a runnable for a torch pretrained model on a machine without an
+    assigned GPU must not set the default tensor type to CUDA.
+    See https://github.com/bentoml/BentoML/issues/4376
+    """
+    import torch
+
+    if torch.cuda.is_available():
+        pytest.skip("requires a machine without CUDA")
+
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+    config = transformers.BertConfig(
+        vocab_size=99,
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        intermediate_size=37,
+    )
+    model = transformers.BertForSequenceClassification(config).eval()
+    bento_model = bentoml.transformers.save_model("tiny_pretrained_pt", model)
+
+    runnable = bento_model.to_runnable()()
+
+    assert next(runnable.model.parameters()).device.type == "cpu"
+    # default tensor type must remain a CPU type
+    assert torch.tensor([1.0]).device.type == "cpu"
+
+
+def test_pretrained_runnable_skips_unavailable_signature_methods(
+    caplog: pytest.LogCaptureFixture,
+):
+    """
+    Models saved with an older transformers version may have recorded signature
+    methods (e.g. 'greedy_search') that no longer exist on the loaded model.
+    The runnable should skip them with a warning instead of crashing.
+    """
+    config = transformers.BertConfig(
+        vocab_size=99,
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        intermediate_size=37,
+    )
+    model = transformers.BertForSequenceClassification(config).eval()
+    bento_model = bentoml.transformers.save_model(
+        "tiny_pretrained_pt_stale",
+        model,
+        signatures={
+            "__call__": {"batchable": False},
+            "greedy_search": {"batchable": False},
+        },
+    )
+
+    with caplog.at_level(logging.WARNING):
+        runnable = bento_model.to_runnable()()
+
+    assert "greedy_search" in caplog.text
+    assert "__call__" in runnable.predict_fns
+    assert "greedy_search" not in runnable.predict_fns
+
+
 def test_import_model_with_synced_version():
     revision = "3956d303d3cddf0708ff20660c1ea5f6ec30e434"
     bento_model = bentoml.transformers.import_model(


### PR DESCRIPTION
## What does this PR address?

Fixes #4376.

Instantiating a runnable for a torch pretrained transformers model (`bentoml.transformers.save_model(name, pretrained_model)` → `bento_model.to_runnable()()`) crashed in two independent ways:

1. **CUDA default tensor type set on CPU-only machines** (the bug reported in #4376): `TransformersRunnable.__init__` called `torch.set_default_tensor_type("torch.cuda.FloatTensor")` unconditionally for torch-framework pretrained models — even when `CUDA_VISIBLE_DEVICES` was unset/`-1` and the model had just been placed on CPU. On machines without CUDA this raises `TypeError: type torch.cuda.FloatTensor not available`. The call is now gated on the same GPU-assignment condition used for device placement, matching how `common/pytorch.py` and `detectron.py` gate the identical call on `torch.cuda.is_available()`.

2. **Stale generation methods in default signatures**: `make_default_signatures` records `generate`, `greedy_search`, `beam_search`, etc. for every `PreTrainedModel` subclass, but on transformers >= 4.50 these methods moved to `GenerationMixin` (and the individual search methods were removed entirely), so runnable init crashed at `getattr(self.model, method_name)` for **every** torch pretrained model, GPU or not. Default signatures are now filtered to methods the class actually provides, and signature methods missing at load time (e.g. models saved with an older transformers version) are skipped with a warning instead of crashing.

## Testing

Added two regression tests in `tests/integration/frameworks/test_transformers_unit.py` using a tiny offline `BertForSequenceClassification` built from config (same pattern as the existing custom-pipeline test — no network needed):

- `test_pretrained_runnable_init_without_gpu`: before this fix it fails with the exact `TypeError` from the issue; now it verifies the model lands on CPU and the default tensor type stays a CPU type.
- `test_pretrained_runnable_skips_unavailable_signature_methods`: saves a model with a stale `greedy_search` signature and verifies runnable init warns and skips it instead of crashing.

Verified locally on macOS (CPU-only, torch 2.13, transformers 4.57): both new tests pass, `tests/unit` passes (298 passed, 5 skipped), and the remaining failures in `test_transformers_unit.py` are pre-existing on `main` (transformers 4.57 API incompatibilities, unrelated to this change).

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming?
- [x] Does the code follow BentoML's code style, both `make format` and `make lint` script have passed ([documentation](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did your changes require updates to the documentation? Not needed — behavior fix only.
- [x] Did you write tests to cover your changes?

🤖 Generated with [Claude Code](https://claude.com/claude-code)