### PR TITLE
fix(cli): validate argument file mappings

### DIFF
--- a/src/bentoml_cli/utils.py
+++ b/src/bentoml_cli/utils.py
@@ -514,6 +514,8 @@ def set_build_args_from_file(ctx: Context, param: Parameter, value: str) -> None
             data = yaml.safe_load(f)
         except yaml.YAMLError as e:
             raise click.BadParameter(f"Invalid YAML file: {value}") from e
+    if not isinstance(data, dict):
+        raise click.BadParameter("Argument file must contain a YAML mapping")
     set_arguments(data, override=False)
 
 

--- a/tests/unit/bentoml_cli/test_utils.py
+++ b/tests/unit/bentoml_cli/test_utils.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from bentoml_cli.utils import build_args_option
+
+
+@click.command()
+@build_args_option
+def command_with_build_args() -> None:
+    pass
+
+
+@pytest.mark.parametrize("content", ["", "- first\n- second\n"])
+def test_build_args_file_requires_mapping(tmp_path: Path, content: str) -> None:
+    args_file = tmp_path / "args.yaml"
+    args_file.write_text(content)
+
+    result = CliRunner().invoke(command_with_build_args, ["--arg-file", str(args_file)])
+
+    assert result.exit_code == 2
+    assert "Argument file must contain a YAML mapping" in result.output


### PR DESCRIPTION
## What does this PR address?

`--arg-file` currently passes every successful `yaml.safe_load()` result to
`set_arguments()`. Empty documents and non-mapping YAML values therefore leak
an internal `TypeError` instead of producing a useful CLI error.

This change validates that the YAML document root is a mapping and raises
`click.BadParameter` otherwise.

## Regression test

Added coverage for:

- an empty YAML document
- a top-level YAML sequence

Both now exit through Click's normal usage-error path with:

`Argument file must contain a YAML mapping`

## Validation

- `pytest tests/unit/bentoml_cli/test_utils.py -q` — 2 passed
- `pytest tests/unit/bentoml_cli -q` — 5 passed
- `pytest tests/unit -q` — 300 passed, 5 skipped
- changed-file pre-commit hooks — passed
- `git diff --check` — passed

`make type` could not run because the checked-in Makefile references a
`typecheck` hook that is absent from `.pre-commit-config.yaml`.

## Compatibility

Valid mapping-based argument files are unchanged. No public API, dependency,
lockfile, or documentation changes are introduced.
