### PR TITLE
fix: handle bare iterator return annotations in IODescriptor.from_output

### DIFF
--- a/src/_bentoml_sdk/io_models.py
+++ b/src/_bentoml_sdk/io_models.py
@@ -432,7 +432,9 @@ class IODescriptor(IOMixin, BaseModel):
             )
         media_type: str | None = None
         if is_iterator_type(return_annotation):
-            return_annotation = get_args(return_annotation)[0]
+            # bare Iterator/Generator annotations carry no item type
+            iterator_args = get_args(return_annotation)
+            return_annotation = iterator_args[0] if iterator_args else t.Any
         elif is_annotated(return_annotation):
             content_type = next(
                 (a for a in get_args(return_annotation) if isinstance(a, ContentType)),

--- a/tests/unit/_bentoml_sdk/test_io_models.py
+++ b/tests/unit/_bentoml_sdk/test_io_models.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import typing as t
+
+from _bentoml_sdk.io_models import IODescriptor
+
+
+def test_from_output_parameterized_iterator():
+    def fn() -> t.Iterator[str]:
+        yield "a"
+
+    output = IODescriptor.from_output(fn)
+    assert output.mime_type() == "text/plain"
+
+
+def test_from_output_bare_iterator():
+    def fn() -> t.Iterator:
+        yield 1
+
+    # should not raise IndexError for an unparameterized iterator
+    output = IODescriptor.from_output(fn)
+    assert output is not None


### PR DESCRIPTION
## What does this PR address?

Fixes #5625

`IODescriptor.from_output()` crashed with an `IndexError` when a service method was annotated with a bare iterator type (`t.Iterator`, `t.Generator`, etc.), because `get_args()` returns an empty tuple for unparameterized generics and line 435 indexed it unconditionally. Now falls back to `t.Any`, matching the behavior for missing return annotations.

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [x] Did you write tests to cover your changes?
