### PR TITLE
feat(images): add apt_sources_mirror() chainable method for Debian builds

### DIFF
--- a/src/_bentoml_sdk/images.py
+++ b/src/_bentoml_sdk/images.py
@@ -147,6 +147,36 @@ class Image:
         self._after_pip_install = True
         return self
 
+    def apt_sources_mirror(self, url: str) -> t.Self:
+        """Swap the Debian apt mirror URL before running apt-get. Supports chaining call.
+
+        This is useful for users in regions where the default Debian mirrors are slow.
+        The command tries both the Debian 12+ format (``debian.sources``) and the
+        legacy ``sources.list`` format so it works across Debian releases.
+
+        Example:
+
+        .. code-block:: python
+
+            image = (
+                Image("debian:latest")
+                .apt_sources_mirror("https://mirrors.tuna.tsinghua.edu.cn/debian")
+                .system_packages("curl")
+            )
+
+        Args:
+            url: The mirror URL to use, e.g. ``https://mirrors.tuna.tsinghua.edu.cn/debian``.
+
+        Returns:
+            The current :class:`Image` instance (chainable).
+        """
+        sed_cmd = (
+            f"sed -i 's|http://deb.debian.org/debian|{url}|g'"
+            " /etc/apt/sources.list.d/debian.sources 2>/dev/null ||"
+            f" sed -i 's|http://deb.debian.org/debian|{url}|g' /etc/apt/sources.list"
+        )
+        return self.run(sed_cmd)
+
     def run(self, command: str) -> t.Self:
         """Add a command to the image. Supports chaining call.
 

--- a/tests/unit/_bentoml_sdk/test_images.py
+++ b/tests/unit/_bentoml_sdk/test_images.py
@@ -3,6 +3,26 @@ from __future__ import annotations
 from _bentoml_sdk.images import Image
 
 
+def test_apt_sources_mirror_inserts_sed_command() -> None:
+    mirror = "https://mirrors.tuna.tsinghua.edu.cn/debian"
+    image = Image(distro="debian")
+    image.apt_sources_mirror(mirror)
+
+    # The sed command should be the last entry added to pre-pip commands
+    assert image.commands[-1] == (
+        f"sed -i 's|http://deb.debian.org/debian|{mirror}|g'"
+        " /etc/apt/sources.list.d/debian.sources 2>/dev/null ||"
+        f" sed -i 's|http://deb.debian.org/debian|{mirror}|g' /etc/apt/sources.list"
+    )
+
+
+def test_apt_sources_mirror_is_chainable() -> None:
+    mirror = "https://mirrors.tuna.tsinghua.edu.cn/debian"
+    image = Image(distro="debian")
+    result = image.apt_sources_mirror(mirror)
+    assert result is image
+
+
 def test_image_system_packages_are_shell_quoted() -> None:
     image = Image(distro="debian")
 


### PR DESCRIPTION
## Summary

Adds a new chainable `apt_sources_mirror(url: str)` method to the `Image` builder class (closes #5374).

- Users in regions with slow Debian mirrors can now call `.apt_sources_mirror("https://...")` on their image to swap the default `http://deb.debian.org/debian` URL before any `apt-get` invocation.
- The implementation inserts a `sed` command that tries the Debian 12+ `debian.sources` file first, then falls back to the legacy `sources.list`, so it works across Debian releases without any extra configuration.
- Two unit tests are added in `tests/unit/_bentoml_sdk/test_images.py` to verify the generated command and that the method returns `self` for chaining.

**Usage example:**

```python
from _bentoml_sdk.images import Image

image = (
    Image("debian:latest")
    .apt_sources_mirror("https://mirrors.tuna.tsinghua.edu.cn/debian")
    .system_packages("curl", "git")
)
```

## Test plan

- [ ] `pytest tests/unit/_bentoml_sdk/test_images.py` — all three tests pass (existing + two new ones).
- [ ] Manually verify the generated Dockerfile contains the `sed` line before `apt-get install`.

> Note: This PR was developed with AI assistance (Claude Code).