### PR TITLE
fix(server): retain CapacityLimiter slot until worker thread completes (#5642)

### DIFF
--- a/src/_bentoml_impl/server/app.py
+++ b/src/_bentoml_impl/server/app.py
@@ -661,9 +661,34 @@ class ServiceAppFactory(BaseAppFactory):
         if self._limiter is None:
             threads = self.service.config.get("threads", 1)
             self._limiter = anyio.CapacityLimiter(threads)
-        func = functools.partial(func, *args, **kwargs)
-        output = await anyio.to_thread.run_sync(func, limiter=self._limiter)
-        return output
+        limiter = self._limiter
+        borrower = object()
+        await limiter.acquire_on_behalf_of(borrower)
+
+        loop = asyncio.get_running_loop()
+        started = False
+        released = False
+
+        def _worker_wrapper() -> R:
+            nonlocal started, released
+            started = True
+            try:
+                return func(*args, **kwargs)
+            finally:
+                if not released:
+                    released = True
+                    loop.call_soon_threadsafe(limiter.release_on_behalf_of, borrower)
+
+        try:
+            output = await anyio.to_thread.run_sync(
+                _worker_wrapper, abandon_on_cancel=True
+            )
+            return output
+        except BaseException:
+            if not started and not released:
+                released = True
+                limiter.release_on_behalf_of(borrower)
+            raise
 
     async def batch_infer(
         self, name: str, input_args: tuple[t.Any, ...], input_kwargs: dict[str, t.Any]

--- a/src/_bentoml_impl/server/app.py
+++ b/src/_bentoml_impl/server/app.py
@@ -666,29 +666,24 @@ class ServiceAppFactory(BaseAppFactory):
         await limiter.acquire_on_behalf_of(borrower)
 
         loop = asyncio.get_running_loop()
-        started = False
-        released = False
 
         def _worker_wrapper() -> R:
-            nonlocal started, released
-            started = True
             try:
                 return func(*args, **kwargs)
             finally:
-                if not released:
-                    released = True
-                    loop.call_soon_threadsafe(limiter.release_on_behalf_of, borrower)
+                loop.call_soon_threadsafe(limiter.release_on_behalf_of, borrower)
 
         try:
-            output = await anyio.to_thread.run_sync(
-                _worker_wrapper, abandon_on_cancel=True
+            # Keep submission in a child task so cancellation cannot release the
+            # borrower before AnyIO has queued the worker.
+            worker_task = asyncio.create_task(
+                anyio.to_thread.run_sync(_worker_wrapper, abandon_on_cancel=True)
             )
-            return output
         except BaseException:
-            if not started and not released:
-                released = True
-                limiter.release_on_behalf_of(borrower)
+            limiter.release_on_behalf_of(borrower)
             raise
+
+        return await asyncio.shield(worker_task)
 
     async def batch_infer(
         self, name: str, input_args: tuple[t.Any, ...], input_kwargs: dict[str, t.Any]

--- a/tests/unit/_bentoml_impl/__init__.py
+++ b/tests/unit/_bentoml_impl/__init__.py
@@ -1,0 +1,1 @@
+# Unit tests for _bentoml_impl

--- a/tests/unit/_bentoml_impl/test_server_app.py
+++ b/tests/unit/_bentoml_impl/test_server_app.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from _bentoml_impl.server.app import ServiceAppFactory
+
+
+class DummyService:
+    name = "dummy"
+    apis = {}
+    config = {"threads": 1}
+
+
+def make_dummy_factory(threads: int = 1) -> ServiceAppFactory:
+    service = DummyService()
+    service.config = {"threads": threads}
+    services = {
+        "dummy": {
+            "traffic": {"timeout": 30, "max_concurrency": 10},
+            "threads": threads,
+        }
+    }
+    return ServiceAppFactory(
+        service=service,
+        is_main=True,
+        enable_metrics=False,
+        services=services,
+        enable_access_control=False,
+        access_control_options={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_to_thread_limiter_holds_token_during_cancellation():
+    """Verify that _to_thread retains the CapacityLimiter token when a coroutine is cancelled
+    until the underlying background worker thread completes its execution.
+    """
+    factory = make_dummy_factory(threads=1)
+    thread_started = threading.Event()
+    finish_thread = threading.Event()
+
+    def slow_func():
+        thread_started.set()
+        finish_thread.wait(timeout=5)
+        return "done"
+
+    # Start _to_thread in a task
+    task = asyncio.create_task(factory._to_thread(slow_func))
+
+    # Wait until the worker thread has acquired the limiter token and started executing
+    while not thread_started.is_set():
+        await asyncio.sleep(0.01)
+
+    assert factory._limiter is not None
+    assert factory._limiter.borrowed_tokens == 1
+
+    # Cancel the task (simulating traffic.timeout or client cancellation)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Even though the task was cancelled, the worker thread is still running in the background,
+    # so borrowed_tokens MUST remain 1 to prevent request barging.
+    assert factory._limiter.borrowed_tokens == 1
+
+    # Unblock the worker thread
+    finish_thread.set()
+
+    # Wait briefly for the worker thread's finally block to release the token
+    for _ in range(50):
+        if factory._limiter.borrowed_tokens == 0:
+            break
+        await asyncio.sleep(0.05)
+
+    assert factory._limiter.borrowed_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_to_thread_normal_execution():
+    """Verify _to_thread executes synchronous functions normally and releases limiter token."""
+    factory = make_dummy_factory(threads=2)
+
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    result = await factory._to_thread(add, 5, 7)
+    assert result == 12
+    assert factory._limiter is not None
+    assert factory._limiter.borrowed_tokens == 0

--- a/tests/unit/_bentoml_impl/test_server_app.py
+++ b/tests/unit/_bentoml_impl/test_server_app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import threading
 
+import anyio
 import pytest
 
 from _bentoml_impl.server.app import ServiceAppFactory
@@ -76,6 +77,50 @@ async def test_to_thread_limiter_holds_token_during_cancellation():
         await asyncio.sleep(0.05)
 
     assert factory._limiter.borrowed_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_to_thread_limiter_holds_token_before_worker_starts():
+    """Keep the service slot held while AnyIO waits to start the worker."""
+    factory = make_dummy_factory(threads=1)
+    default_limiter = anyio.to_thread.current_default_thread_limiter()
+    original_tokens = default_limiter.total_tokens
+    default_limiter.total_tokens = 1
+    blocker_started = threading.Event()
+    release_blocker = threading.Event()
+
+    def block_thread():
+        blocker_started.set()
+        release_blocker.wait(timeout=5)
+
+    blocker_task = asyncio.create_task(anyio.to_thread.run_sync(block_thread))
+    try:
+        while not blocker_started.is_set():
+            await asyncio.sleep(0.01)
+
+        task = asyncio.create_task(factory._to_thread(lambda: "done"))
+        for _ in range(100):
+            if factory._limiter is not None and factory._limiter.borrowed_tokens == 1:
+                break
+            await asyncio.sleep(0.01)
+        assert factory._limiter is not None
+        assert factory._limiter.borrowed_tokens == 1
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert factory._limiter.borrowed_tokens == 1
+
+        release_blocker.set()
+        for _ in range(100):
+            if factory._limiter.borrowed_tokens == 0:
+                break
+            await asyncio.sleep(0.01)
+        assert factory._limiter.borrowed_tokens == 0
+    finally:
+        release_blocker.set()
+        await blocker_task
+        default_limiter.total_tokens = original_tokens
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR address?

Fixes #5642

### Problem & Root Cause
When synchronous (`def`) `@bentoml.api` endpoints are executed via `ServiceAppFactory._to_thread`, cancellation can release the `CapacityLimiter` slot before the background worker has finished (or, in a narrow pre-start window, before AnyIO has queued the worker). A freed slot admits another request while the timed-out work is still running, violating the configured concurrency limit.

### Solution
- Acquire the `CapacityLimiter` slot on behalf of a unique borrower token.
- Submit the worker from a child task shielded from request cancellation, so the borrower cannot be released before AnyIO queues the worker.
- Release the borrower from the worker wrapper's `finally:` block, after the sync function completes; release immediately if task creation itself fails.
- Continue using `abandon_on_cancel=True` so request cancellation does not wait for the sync worker.

### Verification
Added focused unit coverage in `tests/unit/_bentoml_impl/test_server_app.py` for normal execution, cancellation after worker start, and cancellation while the AnyIO default thread limiter is saturated before the worker starts.

Local verification: Ruff and formatting pass; 3 focused tests pass.

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming?
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed?
- [ ] Did your changes require updates to the documentation? Have you updated those accordingly?
- [x] Did you write tests to cover your changes?
