### PR TITLE
fix: prevent config pollution in Service.inject_config() (#5409)

### DIFF
--- a/src/_bentoml_sdk/service/factory.py
+++ b/src/_bentoml_sdk/service/factory.py
@@ -454,7 +454,9 @@ class Service(t.Generic[T_co]):
         rest_config = {
             k: main_config[k] for k in main_config if k not in api_server_keys
         }
-        existing = copy.deepcopy(t.cast(dict[str, t.Any], BentoMLContainer.config.get()))
+        existing = copy.deepcopy(
+            t.cast(dict[str, t.Any], BentoMLContainer.config.get())
+        )
         deep_merge(existing, {"api_server": api_server_config, **rest_config})
         BentoMLContainer.config.set(existing)  # type: ignore
 

--- a/src/_bentoml_sdk/service/factory.py
+++ b/src/_bentoml_sdk/service/factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import inspect
 import logging
 import math
@@ -453,7 +454,7 @@ class Service(t.Generic[T_co]):
         rest_config = {
             k: main_config[k] for k in main_config if k not in api_server_keys
         }
-        existing = t.cast(t.Dict[str, t.Any], BentoMLContainer.config.get())
+        existing = copy.deepcopy(t.cast(dict[str, t.Any], BentoMLContainer.config.get()))
         deep_merge(existing, {"api_server": api_server_config, **rest_config})
         BentoMLContainer.config.set(existing)  # type: ignore
 

--- a/tests/unit/_bentoml_sdk/test_service.py
+++ b/tests/unit/_bentoml_sdk/test_service.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from _bentoml_sdk import service
+from bentoml._internal.configuration.containers import BentoMLContainer
+
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    original_config = copy.deepcopy(BentoMLContainer.config.get())
+    yield
+    BentoMLContainer.config.set(original_config)
+
+
+def test_inject_config_pollution_regression():
+    @service(name="service_a", workers=2)
+    class ServiceA:
+        pass
+
+    @service(name="service_b", workers=3)
+    class ServiceB:
+        pass
+
+    ServiceA.inject_config()
+    config_a_ref = BentoMLContainer.config.get()  # live reference
+    workers_a_snapshot = config_a_ref["workers"]
+
+    ServiceB.inject_config()
+
+    assert config_a_ref["workers"] == workers_a_snapshot == 2


### PR DESCRIPTION
## Summary

`Service.inject_config()` retrieves the shared config dict via
`BentoMLContainer.config.get()` and merges into it in place via
`deep_merge()`. Since `config.get()` returns a live reference (not a
copy), and `deep_merge()` mutates its first argument, calling
`inject_config()` on one Service can leak mutated config into
subsequent `inject_config()` calls.

Note: this reproduces **sequentially, with no concurrency involved** —
building Service A then Service B in the same process is enough to
see A's previously retrieved config change underneath it. This is a
config isolation issue, not a race condition.

## Fix

Deepcopy the config dict before merging, so mutation happens on an
isolated copy instead of the shared container state:

```python
existing = copy.deepcopy(t.cast(dict[str, t.Any], BentoMLContainer.config.get()))
deep_merge(existing, {"api_server": api_server_config, **rest_config})
BentoMLContainer.config.set(existing)
```

No public API changes, no new dependencies, no locking — the existing
config loading flow is unchanged, only the mutation target is isolated.

## Testing

Added a regression test in `tests/unit/_bentoml_sdk/test_service.py`
that mirrors the reported repro: builds Service A and calls
`inject_config()`, holds a live reference to its resulting config,
then builds and injects Service B, and asserts A's config reference is
unchanged. This test fails on current `main` and passes with this fix.

Ran the existing test suite for this module to confirm no other
behavior changed.

Fixes #5409