### PR TITLE
fix(build): resolve dockerfile_template against build ctx, not cwd

### DIFF
--- a/src/bentoml/_internal/utils/filesystem.py
+++ b/src/bentoml/_internal/utils/filesystem.py
@@ -143,22 +143,31 @@ def resolve_user_filepath(
 
     _path = Path(os.path.expanduser(os.path.expandvars(filepath)))
 
+    # The base directory that relative paths are resolved against and that the
+    # ``secure`` containment check is enforced against. This defaults to the
+    # current working directory, but when a ctx (e.g. the Bento build context)
+    # is provided it must be used for both, otherwise a file that is legitimately
+    # relative to ctx is wrongly rejected whenever ctx differs from the cwd.
+    base_dir = Path(os.path.expanduser(ctx) if ctx else os.getcwd()).resolve()
+
     # Try finding file in ctx if provided
     if not _path.is_absolute():
-        ctx = os.path.expanduser(ctx) if ctx else os.getcwd()
-        _path = Path(ctx).joinpath(_path)
+        _path = base_dir.joinpath(_path)
     elif secure:
         raise ValueError(f"Absolute path {filepath} is not allowed")
     _path = _path.resolve()
     if not _path.exists():
         raise FileNotFoundError(f"file {filepath} not found")
     if secure:
-        cwd = Path().resolve()
-        if not _path.is_relative_to(cwd):
+        if not _path.is_relative_to(base_dir):
             raise ValueError(
-                f"Accessing file outside of current working directory is not allowed: {_path}"
+                f"Accessing file outside of the base directory is not allowed: {_path}"
             )
-        if any(part.startswith(".") for part in _path.parts):
+        # Only inspect the path *relative to* base_dir for hidden segments, so a
+        # base_dir that itself lives under a dotted path (e.g. a temp dir or
+        # ~/.cache) does not trigger a false positive.
+        relative_parts = _path.relative_to(base_dir).parts
+        if any(part.startswith(".") for part in relative_parts):
             raise ValueError(f"Accessing hidden files is not allowed: {_path}")
         if any(_path.is_relative_to(item) for item in ("/etc", "/proc")):
             raise ValueError(f"Accessing system files is not allowed: {_path}")

--- a/tests/unit/_internal/utils/test_filesystem.py
+++ b/tests/unit/_internal/utils/test_filesystem.py
@@ -1,0 +1,98 @@
+import os
+
+import pytest
+
+from bentoml._internal.utils.filesystem import resolve_user_filepath
+
+
+def test_resolve_relative_to_ctx_outside_cwd(tmp_path, monkeypatch):
+    """A file that is legitimately relative to ctx must resolve even when the
+    current working directory is somewhere else.
+
+    Regression test for the ``bentoml containerize`` failure where a
+    ``dockerfile_template`` relative to the Bento build context was rejected
+    with "Accessing file outside of current working directory is not allowed"
+    simply because the process cwd differed from the build context.
+    """
+    build_ctx = tmp_path / "myproject"
+    build_ctx.mkdir()
+    template = build_ctx / "Dockerfile.template"
+    template.write_text("FROM debian\n")
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    resolved = resolve_user_filepath("Dockerfile.template", ctx=str(build_ctx))
+    assert resolved == str(template.resolve())
+
+
+def test_resolve_escaping_ctx_is_blocked(tmp_path, monkeypatch):
+    """Paths that escape the base directory are still rejected under secure."""
+    build_ctx = tmp_path / "myproject"
+    build_ctx.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("secret\n")
+
+    monkeypatch.chdir(build_ctx)
+
+    with pytest.raises(ValueError, match="outside of the base directory"):
+        resolve_user_filepath("../secret.txt", ctx=str(build_ctx))
+
+
+def test_resolve_hidden_file_is_blocked(tmp_path, monkeypatch):
+    """Hidden segments relative to the base directory are still rejected."""
+    build_ctx = tmp_path / "myproject"
+    build_ctx.mkdir()
+    hidden = build_ctx / ".env"
+    hidden.write_text("SECRET=1\n")
+
+    monkeypatch.chdir(build_ctx)
+
+    with pytest.raises(ValueError, match="hidden files"):
+        resolve_user_filepath(".env", ctx=str(build_ctx))
+
+
+def test_resolve_dotted_base_dir_not_false_positive(tmp_path, monkeypatch):
+    """A base directory that itself lives under a dotted segment (e.g. a temp
+    dir or ~/.cache) must not trigger the hidden-file check for files that are
+    not themselves hidden relative to that base."""
+    build_ctx = tmp_path / ".cache" / "myproject"
+    build_ctx.mkdir(parents=True)
+    template = build_ctx / "Dockerfile.template"
+    template.write_text("FROM debian\n")
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    resolved = resolve_user_filepath("Dockerfile.template", ctx=str(build_ctx))
+    assert resolved == str(template.resolve())
+
+
+def test_resolve_absolute_path_blocked_under_secure(tmp_path, monkeypatch):
+    """Absolute paths are still rejected under secure mode."""
+    build_ctx = tmp_path / "myproject"
+    build_ctx.mkdir()
+    template = build_ctx / "Dockerfile.template"
+    template.write_text("FROM debian\n")
+
+    monkeypatch.chdir(build_ctx)
+
+    with pytest.raises(ValueError, match="is not allowed"):
+        resolve_user_filepath(str(template.resolve()), ctx=str(build_ctx))
+
+
+def test_resolve_insecure_allows_outside(tmp_path, monkeypatch):
+    """With secure=False, paths outside the base directory are permitted."""
+    build_ctx = tmp_path / "myproject"
+    build_ctx.mkdir()
+    other = tmp_path / "other.txt"
+    other.write_text("data\n")
+
+    monkeypatch.chdir(build_ctx)
+
+    resolved = resolve_user_filepath(
+        str(other.resolve()), ctx=str(build_ctx), secure=False
+    )
+    assert resolved == str(other.resolve())

--- a/tests/unit/_internal/utils/test_filesystem.py
+++ b/tests/unit/_internal/utils/test_filesystem.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from bentoml._internal.utils.filesystem import resolve_user_filepath


### PR DESCRIPTION
## Describe the bug

`bentoml containerize` (and `build`) fails when `bentofile.yaml` specifies a `dockerfile_template` and the command is run from a directory other than the project root:

```
ValueError: Accessing file outside of current working directory is not allowed
```

Fixes #5566.

## Root cause

`resolve_user_filepath` joins relative paths against `ctx` (the Bento build context) but enforces the `secure=True` containment check against a **hard-coded cwd** (`Path().resolve()`). The two bases disagree: a `dockerfile_template` that is legitimately relative to `build_ctx` is rejected whenever `build_ctx` differs from the current working directory. This is a regression from #5548, which added `secure=True` as the default.

## Fix

- Use a single `base_dir` (`ctx` when provided, else `cwd`) for **both** the relative-path join and the containment check, so they can no longer disagree.
- Inspect only the path *relative to* `base_dir` for hidden (`.`-prefixed) segments, so a `base_dir` that itself lives under a dotted path (a temp dir, `~/.cache`, etc.) no longer trips a false positive.
- All other secure guarantees are preserved: absolute paths, escaping the base dir, hidden files, and `/etc`|`/proc` are still rejected.

## Testing

Added `tests/unit/_internal/utils/test_filesystem.py` covering:
- template legitimately relative to ctx outside cwd now resolves (the bug)
- escaping ctx is still blocked
- hidden files still blocked
- dotted base_dir no longer false-positives
- absolute path still blocked under secure
- `secure=False` still permits outside access

```
6 passed in 0.04s
```