### PR TITLE
Keep every URL value of a multipart list field

### DIFF
--- a/src/_bentoml_impl/client/http.py
+++ b/src/_bentoml_impl/client/http.py
@@ -336,7 +336,10 @@ class HTTPClient(AbstractClient, t.Generic[C]):
             for v in value:
                 file = self._file_manager.get_file(v)
                 if isinstance(file, str):
-                    data[name] = file
+                    # A list field can resolve to several plain values, e.g. URLs that
+                    # are forwarded as-is. Collect them so each one is sent as its own
+                    # part, instead of overwriting the previous value.
+                    data.setdefault(name, []).append(file)
                 else:
                     files.append((name, file))
         headers.pop("content-type", None)

--- a/src/_bentoml_impl/client/proxy2.py
+++ b/src/_bentoml_impl/client/proxy2.py
@@ -493,13 +493,20 @@ class AsyncClient(AbstractClient):
             for v in value:
                 file = self._file_manager.get_file(v)
                 if isinstance(file, str):
-                    data[name] = file
+                    # A list field can resolve to several plain values, e.g. URLs that
+                    # are forwarded as-is. Collect them so each one is sent as its own
+                    # part, instead of overwriting the previous value.
+                    data.setdefault(name, []).append(file)
                 else:
                     files.append((name, file))
         headers.pop("content-type", None)
         payload = aiohttp.FormData()
         for key, val in data.items():
-            payload.add_field(key, val)
+            if isinstance(val, list):
+                for item in val:
+                    payload.add_field(key, item)
+            else:
+                payload.add_field(key, val)
         for key, (filename, fileobj, content_type) in files:
             payload.add_field(
                 key,

--- a/tests/unit/_internal/client/test_multipart_list_fields.py
+++ b/tests/unit/_internal/client/test_multipart_list_fields.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import io
+import types
+import typing as t
+
+import httpx
+import pytest
+
+from _bentoml_impl.client.http import HTTPClient
+from _bentoml_impl.client.proxy2 import AsyncClient
+
+
+class _PassthroughFileManager:
+    """Stands in for the real file manager.
+
+    `ClientFileManager.get_file` returns an HTTP URL unchanged, as a plain string,
+    and returns a `(filename, fileobj, content_type)` tuple for an actual upload.
+    """
+
+    def get_file(self, value: t.Any) -> t.Any:
+        return value
+
+
+def _endpoint(is_array: bool = True) -> types.SimpleNamespace:
+    field = (
+        {"type": "array", "items": {"type": "file"}} if is_array else {"type": "file"}
+    )
+    return types.SimpleNamespace(route="/echo", input={"properties": {"files": field}})
+
+
+def _httpx_body(model: dict[str, t.Any], is_array: bool = True) -> str:
+    client = types.SimpleNamespace(
+        _file_manager=_PassthroughFileManager(), client=httpx.Client()
+    )
+    request = HTTPClient._build_multipart(
+        client, _endpoint(is_array), model, httpx.Headers()
+    )
+    return request.read().decode("utf-8", "replace")
+
+
+def _aiohttp_values(model: dict[str, t.Any]) -> list[t.Any]:
+    client = types.SimpleNamespace(_file_manager=_PassthroughFileManager())
+    payload = AsyncClient._build_multipart(client, _endpoint(), model, {})
+    return [field[2] for field in payload._fields]
+
+
+URL_A = "https://files.example.invalid/a.txt"
+URL_B = "https://files.example.invalid/b.txt"
+
+
+def test_httpx_client_keeps_every_url_in_a_list_field() -> None:
+    # Each value of a list field resolves to a plain string, and every one of them
+    # has to be sent. Assigning instead of accumulating dropped all but the last.
+    body = _httpx_body({"files": [URL_A, URL_B]})
+
+    assert "a.txt" in body
+    assert "b.txt" in body
+
+
+def test_aiohttp_client_keeps_every_url_in_a_list_field() -> None:
+    assert _aiohttp_values({"files": [URL_A, URL_B]}) == [URL_A, URL_B]
+
+
+@pytest.mark.parametrize("is_array", [True, False])
+def test_single_url_is_unchanged(is_array: bool) -> None:
+    # A field carrying one value must still be sent exactly once.
+    model = {"files": [URL_A] if is_array else URL_A}
+    assert _httpx_body(model, is_array).count("a.txt") == 1
+
+
+def test_urls_and_uploads_can_be_mixed() -> None:
+    # A URL travels as a form value while a real upload travels as a file part;
+    # collecting the URLs must not disturb the upload.
+    body = _httpx_body({"files": [URL_A, ("real.txt", io.BytesIO(b"X"), "text/plain")]})
+
+    assert "a.txt" in body
+    assert 'filename="real.txt"' in body
+
+
+def test_aiohttp_single_url_is_unchanged() -> None:
+    assert _aiohttp_values({"files": [URL_A]}) == [URL_A]


### PR DESCRIPTION
Closes #5675

### The problem

`_build_multipart` walks the values of a file field and splits them two ways: real uploads are appended to the `files` list, while values the file manager hands back as plain strings — HTTP URLs are passed through untouched — go into `data`.

The string branch assigned instead of accumulating:

```python
for v in value:
    file = self._file_manager.get_file(v)
    if isinstance(file, str):
        data[name] = file        # each value overwrites the previous one
    else:
        files.append((name, file))
```

So a `list[Path]` field carrying several URLs reached the service with only the **last** one. Real uploads were never affected, because that branch already appended — which is why the issue's local-file control passed while the URL case lost values.

Confirmed against the encoded request body on `main`, with two URLs going in:

```
before:  ['https://ex.invalid/b.txt']
after:   ['https://ex.invalid/a.txt', 'https://ex.invalid/b.txt']
```

### The change

Collect the string values in a list so each is sent as its own part.

The aiohttp client (`proxy2`) needed a second change: it feeds `data` entries to `FormData.add_field` one at a time, which takes a single value, so the loop now adds one field per value. Without that it would have passed a list straight to `add_field`.

Both clients carried the same bug, so both are fixed here rather than in separate PRs.

Nothing changes for a field carrying a single value: one entry in, one part out, as before.

### Tests

Added `tests/unit/_internal/client/test_multipart_list_fields.py`, driving `_build_multipart` directly with a passthrough file manager so no network or running service is involved:

- both clients keep every URL of a multi-value list field — these two fail on `main`
- a single URL is sent exactly once, parametrized over the array and scalar field shapes, so the fix cannot start duplicating parts
- URLs and a real upload mixed in one field still produce one form value and one file part, since that is the path the accumulation could most easily disturb

`pytest tests/unit/_internal/client/` → 6 passed for the new file. `test_session_manager.py::test_session_refresh_creates_new_connector` fails in my environment, but it fails identically on an unmodified checkout (missing async plugin), so it is unrelated.

`ruff check` and `ruff format` are clean on all three files. `ruff check` reports 9 pre-existing errors in the two client modules on an unmodified checkout as well; I left those alone to keep the diff to the bug.
