### PR TITLE
fix: avoid mutating shared config in Service.inject_config

### DIFF
--- a/src/_bentoml_sdk/service/factory.py
+++ b/src/_bentoml_sdk/service/factory.py
@@ -422,6 +422,8 @@ class Service(t.Generic[T_co]):
         return generate_spec(self)
 
     def inject_config(self) -> None:
+        from copy import deepcopy
+
         from bentoml._internal.configuration import load_config
         from bentoml._internal.configuration.containers import BentoMLContainer
         from bentoml._internal.utils import deep_merge
@@ -453,7 +455,7 @@ class Service(t.Generic[T_co]):
         rest_config = {
             k: main_config[k] for k in main_config if k not in api_server_keys
         }
-        existing = t.cast(t.Dict[str, t.Any], BentoMLContainer.config.get())
+        existing = deepcopy(t.cast(t.Dict[str, t.Any], BentoMLContainer.config.get()))
         deep_merge(existing, {"api_server": api_server_config, **rest_config})
         BentoMLContainer.config.set(existing)  # type: ignore
 

--- a/tests/unit/_bentoml_sdk/test_service.py
+++ b/tests/unit/_bentoml_sdk/test_service.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any
+
+import bentoml
+from bentoml._internal import configuration
+from bentoml._internal.configuration.containers import BentoMLContainer
+
+
+def test_inject_config_does_not_mutate_existing_config_dict(monkeypatch: Any) -> None:
+    @bentoml.service(name="service_inject_config_test", traffic={"timeout": 15})
+    class DummyService:
+        pass
+
+    container_dict_after_load: dict[str, Any] = {}
+    original_load_config = configuration.load_config
+
+    def mock_load_config(*args: Any, **kwargs: Any) -> None:
+        original_load_config(*args, **kwargs)
+        nonlocal container_dict_after_load
+        container_dict_after_load = BentoMLContainer.config.get()
+
+    monkeypatch.setattr(configuration, "load_config", mock_load_config)
+
+    DummyService.inject_config()
+
+    assert "api_server" not in container_dict_after_load


### PR DESCRIPTION
## What does this PR address?

This PR fixes an issue where `Service.inject_config()` mutates the shared `BentoMLContainer.config` object instead of working with an isolated configuration state.

Previously, `inject_config()` retrieved the process-wide configuration, merged service-specific settings into it, and wrote the modified object back into `BentoMLContainer.config`. As a result, configuration changes from one service initialization could persist globally and affect subsequent service configurations within the same process.

This behavior caused service initialization to depend on previous mutations of shared state, making configuration ownership unclear and potentially leading to unexpected configuration leakage between services.

### Changes made

- Avoid mutating the shared `BentoMLContainer.config` object directly inside `Service.inject_config()`.
- Create an isolated configuration copy before applying service-specific overrides.
- Ensure each service injection operates on its own configuration state instead of inheriting mutations from previous calls.
- Preserve existing configuration behavior while preventing unintended global state modification.

### Why this matters

`BentoMLContainer.config` represents shared process-level state, so modifying it during service initialization can introduce hidden dependencies between services. By isolating configuration updates, service initialization becomes deterministic and avoids side effects caused by previous `inject_config()` calls.

Fixes #5678