### PR TITLE
feat: set BentoML user agent on the S3 client used by import/export

### DIFF
--- a/docs/source/build-with-bentoml/model-loading-and-management.rst
+++ b/docs/source/build-with-bentoml/model-loading-and-management.rst
@@ -196,6 +196,13 @@ You can perform the following operations on models by using the BentoML CLI.
             pip install fs-s3fs  *# Additional dependency required for working with s3*
             bentoml models export summarization-model:latest s3://my_bucket/my_prefix/
 
+        The ``s3://`` scheme works with Amazon S3 and with any S3-compatible object store, such as Backblaze B2, Cloudflare R2 and MinIO. Set the standard ``AWS_ENDPOINT_URL`` environment variable to point the Model Store at a non-AWS endpoint.
+
+        .. code-block:: bash
+
+            export AWS_ENDPOINT_URL=https://your-s3-endpoint.example.com
+            bentoml models export summarization-model:latest s3://my_bucket/my_prefix/
+
     .. tab-item:: Pull/Push
 
         `BentoCloud <https://cloud.bentoml.com/>`_ provides a centralized model repository with flexible APIs and a web console for managing all models created by your team. After you :doc:`log in to BentoCloud </scale-with-bentocloud/manage-api-tokens>`, use ``bentoml models push`` and ``bentoml models pull`` to upload your models to and download them from BentoCloud:

--- a/src/bentoml/_internal/exportable.py
+++ b/src/bentoml/_internal/exportable.py
@@ -21,6 +21,16 @@ from .utils.filesystem import safe_remove_dir
 T = t.TypeVar("T", bound="Exportable")
 
 
+def _s3_storage_options(protocol: str) -> dict[str, t.Any]:
+    """Append a BentoML user-agent to the S3 client for any S3-compatible
+    endpoint. Additive only: credentials and endpoint_url are left untouched."""
+    if protocol != "s3":
+        return {}
+    from .configuration import BENTOML_VERSION
+
+    return {"s3": {"config_kwargs": {"user_agent_extra": f"BentoML/{BENTOML_VERSION}"}}}
+
+
 class Exportable(ABC):
     _path: Path
 
@@ -129,14 +139,16 @@ class Exportable(ABC):
         if input_format == "folder":
             from fsspec.implementations.dirfs import DirFileSystem
 
-            fs, fspath = fsspec.url_to_fs(resource_url)
+            fs, fspath = fsspec.url_to_fs(resource_url, **_s3_storage_options(protocol))
             if protocol == "file":  # Use the local file system
                 return cls.from_path(fspath)
             fs = DirFileSystem(fspath, fs=fs)
         elif input_format == "zip":
             from fsspec.implementations.zip import ZipFileSystem
 
-            fs = ZipFileSystem(resource_url)
+            fs = ZipFileSystem(
+                resource_url, target_options=_s3_storage_options(protocol) or None
+            )
         else:
             from fsspec.implementations.tar import TarFileSystem
 
@@ -146,7 +158,9 @@ class Exportable(ABC):
                 "tar": None,
             }
             fs = TarFileSystem(
-                resource_url, compression=compressions.get(input_format, input_format)
+                resource_url,
+                compression=compressions.get(input_format, input_format),
+                target_options=_s3_storage_options(protocol) or None,
             )
 
         return cls._from_fs(fs)
@@ -229,7 +243,7 @@ class Exportable(ABC):
             subpath += f".{self._export_ext()}"
         resource_url = urllib.parse.urlunsplit((protocol, netloc, subpath, query, ""))
 
-        fs, fspath = fsspec.url_to_fs(resource_url)
+        fs, fspath = fsspec.url_to_fs(resource_url, **_s3_storage_options(protocol))
         if output_format == "folder":
             fs.put(str(self._path), fspath, recursive=True)
         else:


### PR DESCRIPTION
## What does this PR address?

`bentoml models export/import` (and the Bento equivalents) build their fsspec filesystem without passing any client configuration, so requests to `s3://` targets go out with the default botocore user agent. Nothing in an access log or a support ticket identifies the traffic as coming from BentoML.

This PR appends `BentoML/<version>` to the user agent of the S3 client used by import/export, and documents how to point the Model Store at a non-AWS, S3-compatible endpoint.

## Changes

**`src/bentoml/_internal/exportable.py`**

- Add `_s3_storage_options(protocol)`, which returns `{"s3": {"config_kwargs": {"user_agent_extra": f"BentoML/{BENTOML_VERSION}"}}}` when the protocol is `s3`, and `{}` otherwise. `BENTOML_VERSION` is imported inside the helper so the module import stays unchanged.
- Thread those options through the three places import/export constructs a filesystem: `fsspec.url_to_fs()` on the import path, `fsspec.url_to_fs()` on the export path, and `target_options=` for `ZipFileSystem` / `TarFileSystem`, so archives read straight out of S3 are configured too.

**`docs/source/build-with-bentoml/model-loading-and-management.rst`**

- Note that the `s3://` scheme works with Amazon S3 and with any S3-compatible object store (Backblaze B2, Cloudflare R2, MinIO), and that the standard `AWS_ENDPOINT_URL` environment variable selects a non-AWS endpoint. Includes a two-line example.

## Notes

- Additive only. `user_agent_extra` is botocore's documented hook for appending to the user agent string, so credentials, `endpoint_url`, region and any other storage option a user already passes are left untouched. Non-`s3` protocols (`file`, `gs`, `abfs`, ...) receive an empty dict and behave exactly as before.
- `{"s3": {...}}` is fsspec's protocol-keyed storage-option form, which both `url_to_fs()` and the chained `target_options` understand, so the same helper works for the plain and archive code paths.
- No new dependency, and no change to request semantics or payloads.
- No tests added: the change is a keyword-argument pass-through, and asserting on it end to end would mean asserting the shape of s3fs/botocore internals. Happy to add a unit test over `_s3_storage_options()` if you would prefer one.

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming?
- [x] Does the code follow BentoML's code style? `ruff-check` and `ruff-format` are clean on the changed file.
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [x] Did your changes require updates to the documentation? Have you updated those accordingly?
- [ ] Did you write tests to cover your changes? (see Notes)
