### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/source/examples/vllm.rst
+++ b/docs/source/examples/vllm.rst
@@ -200,6 +200,8 @@ BentoCloud provides fast and scalable infrastructure for building and scaling AI
 
             For more information, see the `OpenAI API reference documentation <https://platform.openai.com/docs/api-reference/introduction>`_.
 
+        The same ``OpenAI(base_url=...)`` client pattern also works with OpenAI-compatible multi-model gateways when you are not self-hosting or using BentoCloud — for example `DaoXE <https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=bentoml&utm_content=openai_base_url>`_ at ``https://api.daoxe.com/v1``.
+
         If your Service is deployed with :ref:`protected endpoints on BentoCloud <scale-with-bentocloud/manage-api-tokens:access protected deployments>`, you need to set the environment variable ``OPENAI_API_KEY`` to your BentoCloud API key first.
 
         .. code-block:: bash

--- a/docs/source/examples/vllm.rst
+++ b/docs/source/examples/vllm.rst
@@ -200,7 +200,7 @@ BentoCloud provides fast and scalable infrastructure for building and scaling AI
 
             For more information, see the `OpenAI API reference documentation <https://platform.openai.com/docs/api-reference/introduction>`_.
 
-        The same ``OpenAI(base_url=...)`` client pattern also works with OpenAI-compatible multi-model gateways when you are not self-hosting or using BentoCloud — for example `DaoXE <https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=bentoml&utm_content=openai_base_url>`_ at ``https://api.daoxe.com/v1``.
+        The same ``OpenAI(base_url=...)`` client pattern also works with OpenAI-compatible multi-model gateways when you are not self-hosting or using BentoCloud — for example `DaoXE <https://daoxe.com/>`_ at ``https://api.daoxe.com/v1``.
 
         If your Service is deployed with :ref:`protected endpoints on BentoCloud <scale-with-bentocloud/manage-api-tokens:access protected deployments>`, you need to set the environment variable ``OPENAI_API_KEY`` to your BentoCloud API key first.
 


### PR DESCRIPTION
## Summary

The BentoML vLLM example already shows the OpenAI-compatible client pattern.

This PR adds a short note that the same `OpenAI(base_url=...)` client pattern also works with OpenAI-compatible multi-model gateways when you are not self-hosting or using BentoCloud, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.


Docs only — no runtime behavior changes.

## Test plan

- [ ] Docs still build
- [ ] Existing OpenAI client example unchanged
- [ ] Note is clearly optional / vendor-neutral

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
