### PR TITLE
feat: add agent skills for deploying BentoML services to vanilla Kubernetes

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,56 @@
+# BentoML → Kubernetes Agent Skills
+
+A set of [Claude Code agent skills](https://code.claude.com/docs/en/skills) for deploying
+BentoML services to **your own Kubernetes cluster** using a fully open-source stack:
+the `bentoml` CLI, Docker, and `kubectl` with plain Kubernetes manifests. No Helm charts,
+no operators or CRDs, no closed-source dependencies, and no BentoCloud.
+
+These skills cover **basic deployment**. Features that were part of the commercial
+BentoCloud platform — scale-to-zero, inference-metric autoscaling, canary rollouts,
+model registry sync, observability dashboards — are out of scope. For horizontal
+scaling, standard Kubernetes HPA works with the manifests these skills produce.
+
+## The skills
+
+| Skill | What it does |
+|---|---|
+| [`bentoml-containerize`](bentoml-containerize/SKILL.md) | Turns a local BentoML project into a Docker image: verifies the runtime spec, `bentoml build`, `bentoml containerize`, local smoke test, push to your registry (Docker Hub, GHCR, ECR, private, `kind`/`minikube` load, or ttl.sh for throwaway tests). |
+| [`bentoml-k8s-deploy`](bentoml-k8s-deploy/SKILL.md) | Deploys a pushed image to your cluster: gathers parameters, renders plain manifests (Deployment + Service, optional Ingress) into your project's `k8s/`, applies them, and verifies with a real inference request. |
+| [`bentoml-k8s-troubleshoot`](bentoml-k8s-troubleshoot/SKILL.md) | Diagnostic runbook for failed deployments: ImagePullBackOff, CrashLoopBackOff, OOM, Pending/GPU, probe failures, unreachable services, inference errors. |
+
+A typical session chains them: containerize → deploy → (troubleshoot if needed).
+
+## Installation
+
+Copy the skill directories to where Claude Code discovers skills:
+
+```bash
+# For all your projects (personal):
+cp -r bentoml-containerize bentoml-k8s-deploy bentoml-k8s-troubleshoot ~/.claude/skills/
+
+# Or for a single project (shared with your team via git):
+cp -r bentoml-containerize bentoml-k8s-deploy bentoml-k8s-troubleshoot <your-project>/.claude/skills/
+```
+
+Then ask Claude Code things like "containerize my BentoML service and deploy it to my
+Kubernetes cluster" — the skills activate on matching requests, or invoke them directly
+with `/bentoml-containerize` etc.
+
+## Prerequisites
+
+- Python with `bentoml` ≥ 1.4 (`pip install bentoml`)
+- Docker (daemon running) — used to build and smoke-test images
+- `kubectl` configured with a context for your target cluster
+- A container registry your cluster can pull from (or a local kind/minikube cluster)
+
+## Conventions the skills follow
+
+- BentoML serves on port **3000**; probes use **`/livez`** (liveness) and **`/readyz`**
+  (readiness), with a generous startupProbe for model loading.
+- Manifests are written to your project's `k8s/` directory and labeled
+  `app.kubernetes.io/name: <service>` + `app.kubernetes.io/managed-by: bentoml-k8s-deploy`.
+- Secrets are created imperatively (`kubectl create secret`); no secret material is ever
+  written into manifest files.
+- The deploy skill pins `--context` on every `kubectl` command; the troubleshoot skill
+  confirms the current context before running anything. The skills always confirm the
+  target cluster and namespace with you before applying anything.

--- a/.claude/skills/bentoml-containerize/SKILL.md
+++ b/.claude/skills/bentoml-containerize/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: bentoml-containerize
+description: >
+  Build a local BentoML project into a Bento, containerize it into an OCI/Docker
+  image, smoke-test it locally, and push it to a container registry (Docker Hub,
+  GHCR, ECR, private registry, kind/minikube local load, or ttl.sh). Use when the
+  user asks to "containerize a Bento", "build a Docker image for my BentoML
+  service", "package my BentoML service for deployment", "push my Bento image to
+  a registry", or as the first step of deploying BentoML to Kubernetes. Does NOT
+  create Kubernetes manifests — hand off to the bentoml-k8s-deploy skill for that.
+---
+
+# Containerize a BentoML project and push it to a registry
+
+You will take the user's local BentoML project (a `service.py` plus either a
+`bentofile.yaml` or an inline `bentoml.images.Image` spec), build a Bento,
+containerize it, verify the container actually serves, and push the image to the
+registry the user chooses. The output of this skill is a **pushed image
+reference** that the `bentoml-k8s-deploy` skill consumes.
+
+Work through the steps in order. Do not skip the smoke test.
+
+## Step 0 — Preflight checks
+
+Run each check; fix or instruct before continuing.
+
+```bash
+# 1. BentoML CLI present?
+command -v bentoml && bentoml --version
+```
+If missing, install it into the user's active environment:
+```bash
+pip install bentoml
+```
+
+```bash
+# 2. Docker daemon reachable? (bentoml containerize uses the docker backend by default)
+docker info --format '{{.ServerVersion}} {{.Architecture}}'
+```
+If this fails, tell the user to start Docker (or Docker Desktop / colima) and stop
+until it is reachable. Note the reported `Architecture` — you need it in Step 3.
+`docker info` prints kernel names: `x86_64` = `amd64`, `aarch64` = `arm64`
+(container platforms use the latter, e.g. `linux/amd64`).
+
+```bash
+# 3. Locate the project
+ls service.py bentofile.yaml 2>/dev/null
+# If not in the current directory (e.g. invoked from a repo root):
+find . -maxdepth 3 -name service.py -not -path '*/.venv/*'
+```
+Identify the build context: the directory containing `service.py`. A
+`bentofile.yaml` is optional — modern projects define the runtime environment in
+code with `bentoml.images.Image` attached via `@bentoml.service(image=...)`.
+If neither a `bentofile.yaml` nor an `image=` spec exists, you must create one
+(Step 1). All later commands run **from the build context directory**.
+
+Ask the user up front (one round of questions):
+1. Which registry should the image go to? Options: Docker Hub, GHCR, ECR, a
+   private registry, `kind`/`minikube` local load (no registry), or `ttl.sh`
+   (anonymous, ephemeral — good for throwaway tests).
+2. What CPU architecture do the target cluster nodes run (`amd64` or `arm64`)?
+   Most clouds are `linux/amd64`; a laptop building on Apple Silicon defaults to
+   `arm64` — mismatch causes `exec format error` in the cluster.
+
+## Step 1 — Verify / complete the runtime environment spec
+
+Read `service.py`. Confirm there is a class decorated with `@bentoml.service`.
+The class name converted to snake_case becomes the default Bento name (e.g.
+`class Summarization` → bento `summarization`, `class MyService` → bento
+`my_service`).
+
+The runtime environment must declare **every** Python dependency the service
+imports. Check one of:
+
+- **In code (preferred for new projects):**
+  ```python
+  import bentoml
+
+  my_image = bentoml.images.Image(python_version="3.11") \
+      .python_packages("torch", "transformers")
+
+  @bentoml.service(image=my_image)
+  class MyService: ...
+  ```
+- **Or `bentofile.yaml`:**
+  ```yaml
+  service: "service:MyService"
+  include:
+    - "*.py"
+  python:
+    packages:
+      - torch
+      - transformers
+  ```
+
+Cross-check the imports in `service.py` against the declared packages and add
+anything missing (`bentoml` itself is always included automatically). For the
+full `Image` API (`requirements_file()`, `system_packages()`, `run()`,
+`base_image`, `distro`, lockfiles), the `bentofile.yaml` field reference, env
+vars, and how models are packaged, read
+[references/runtime-environment.md](references/runtime-environment.md).
+
+**.bentoignore:** `bentoml build` packages files under the build context
+(everything matching `include`, default `*`). `.git/`, `.venv/`, `venv/`,
+`__pycache__/`, and `.DS_Store` are always excluded automatically — the file
+matters for large data/checkpoint dirs and other irrelevant artifacts. Create a
+`.bentoignore` file in the build context with gitignore-style patterns:
+```
+data/
+checkpoints/
+*.ipynb
+```
+
+**Secrets:** never put secret values (HF_TOKEN, API keys) in `envs` in
+`bentofile.yaml` or the service decorator — they get baked into image layers.
+Declare the env var name only; the value is injected at runtime (Step 4 locally,
+Kubernetes Secret later).
+
+## Step 2 — Build the Bento
+
+From the build context directory, run the build **once**, capturing the tag —
+`-o tag` prints a single `__tag__:name:version` line. (Do not run a plain
+`bentoml build` first: every build creates a new bento with a fresh
+auto-generated version.)
+
+```bash
+BENTO_TAG=$(bentoml build -o tag | grep '^__tag__:' | sed 's/^__tag__://')
+echo "$BENTO_TAG"    # e.g. summarization:6oxk5qvott3lsnry
+```
+
+If `BENTO_TAG` is empty, rerun as plain `bentoml build` (no `-o tag`) purely as
+a diagnostic to see the full error output. Common
+failures: `service:` entry not matching the actual module/class name, a missing
+package at import time, or model download failures (gated Hugging Face models
+need `export HF_TOKEN=...` in this shell — see
+[references/runtime-environment.md](references/runtime-environment.md)).
+
+You can always list built Bentos with `bentoml list` (newest first;
+`bentoml list -o json` for scripting) and inspect one with
+`bentoml get "$BENTO_TAG" -o json`.
+
+## Step 3 — Containerize
+
+`bentoml containerize` builds a Docker image tagged **the same as the bento tag**
+by default. Use `-t` to name it for the target registry in one shot (preferred —
+skips a separate `docker tag`). **Important:** when `-t` is given, the image is
+tagged ONLY with `$IMAGE` — no image named `$BENTO_TAG` is created.
+
+Read the chosen registry's section in `references/registries.md` NOW to compose
+`$IMAGE` with the right naming pattern before running this command.
+
+```bash
+# IMAGE is the full registry reference you'll push in Step 5,
+# e.g. docker.io/<user>/summarization:6oxk5qvott3lsnry
+bentoml containerize "$BENTO_TAG" -t "$IMAGE"
+```
+
+**Exception — kind/minikube (no registry):** there is nothing to push, so omit
+`-t`; the image is then named exactly `$BENTO_TAG`, and that is the name you
+load into the cluster in Step 5:
+
+```bash
+bentoml containerize "$BENTO_TAG"
+IMAGE="$BENTO_TAG"
+```
+
+Docker image names must be lowercase. Reuse the bento version as the image tag
+so images stay traceable to bentos.
+
+**Cross-architecture:** if the build machine's arch differs from the cluster
+(e.g. Apple Silicon → amd64 cluster), pass the target platform:
+
+```bash
+bentoml containerize "$BENTO_TAG" -t "$IMAGE" --opt platform=linux/amd64
+```
+
+(`--platform=linux/amd64` is an accepted legacy spelling of the same option.)
+For multi-arch images and buildx details, read
+[references/cross-platform.md](references/cross-platform.md).
+
+Note: containerize downloads all referenced models (BentoModel and
+HuggingFaceModel) and **bakes them into the image**. Expect a large image and a
+long first build for LLM-sized models; gated HF models again need `HF_TOKEN`
+exported in this shell.
+
+## Step 4 — Smoke test locally with docker run
+
+The image's entrypoint serves automatically — no command needed. Skip this step
+only if the image platform doesn't match the local machine (cross-arch build);
+say so explicitly in that case.
+
+Use an uncommon **host** port (3007 below) — host port 3000 is commonly
+occupied by dev servers, and probing an occupied port would test the wrong
+process. The container port is always 3000.
+
+```bash
+docker rm -f bento-smoke 2>/dev/null || true
+docker run -d --name bento-smoke -p 3007:3000 "$IMAGE" || { echo "docker run failed"; exit 1; }
+
+# Confirm the container is actually up BEFORE curling — otherwise a
+# stale/unrelated process on the host port yields a false READY.
+docker ps --filter name=bento-smoke --format '{{.Status}}'   # must show "Up ..."
+
+# Wait for readiness (model loading can take minutes for big models)
+for i in $(seq 1 60); do
+  if curl -sf http://localhost:3007/readyz > /dev/null; then echo READY; break; fi
+  sleep 5
+done
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:3007/readyz   # expect 200
+```
+
+If the service needs runtime env vars (e.g. models downloaded at startup), add
+`-e NAME=value` flags to `docker run`.
+
+If `docker run` fails or `/readyz` never returns 200: `docker logs bento-smoke`
+and diagnose (missing dependency → back to Step 1; missing env var → add `-e`;
+host port conflict → pick another host port, container port stays 3000). Always
+run the cleanup command below afterwards — on the failure path too, once you've
+captured the logs.
+
+Then exercise one real endpoint — this is **mandatory**, not optional: a 200 on
+`/readyz` alone cannot distinguish your container from some other process that
+happens to own the port, and it doesn't prove the model actually loaded. Derive
+the route and payload from the `@bentoml.api` methods in `service.py`
+(endpoints are `POST /<method_name>` with a JSON body of the method's
+parameters) and check the **response content** is a plausible result:
+
+```bash
+curl -s -X POST http://localhost:3007/<method_name> \
+  -H 'Content-Type: application/json' \
+  -d '{"<param>": <value>}'
+```
+
+Clean up:
+
+```bash
+docker rm -f bento-smoke
+```
+
+## Step 5 — Push to the user's registry
+
+Log in and push using the registry the user chose in Step 0. Exact login, image
+naming rules, visibility gotchas (GHCR packages default to private!), and the
+no-registry paths (`kind load` / `minikube image load`, ttl.sh) are in
+[references/registries.md](references/registries.md) — read the section for the
+chosen registry.
+
+The generic flow (when `-t` in Step 3 already named the image for the registry):
+
+```bash
+docker login <registry-host>       # per-registry specifics in the reference
+docker push "$IMAGE"
+```
+
+Verify the push succeeded (the push output ends with a digest, or pull it back
+with `docker manifest inspect "$IMAGE"`).
+
+## Step 6 — Hand off to bentoml-k8s-deploy
+
+Report to the user, and pass to the `bentoml-k8s-deploy` skill:
+
+1. **Image reference**: the exact pushed `$IMAGE` (or the image name loaded into
+   kind/minikube).
+2. **Registry access**: whether the registry is private (deploy skill must set
+   up `imagePullSecrets`), and — for kind/minikube loaded images — that
+   `imagePullPolicy` must NOT be `Always` (use `IfNotPresent`).
+3. **Runtime env vars** the service needs (names only; secret values go into a
+   Kubernetes Secret, never into manifests).
+4. **Architecture** the image was built for.
+5. **Suggested Kubernetes service name**: the snake_cased bento name with
+   underscores converted to hyphens (e.g. `my_service` → `my-service`). Never
+   derive it from the image repository — for ttl.sh images the repo is a random
+   UUID that may start with a digit, which is an invalid DNS-1035 Service name.
+6. Useful facts for the manifests: the container serves HTTP on **port 3000**;
+   health endpoints are **`/livez`** (liveness) and **`/readyz`** (readiness);
+   the image entrypoint already runs `serve`, so no `command:` override is
+   needed in the pod spec.

--- a/.claude/skills/bentoml-containerize/references/cross-platform.md
+++ b/.claude/skills/bentoml-containerize/references/cross-platform.md
@@ -1,0 +1,72 @@
+# Cross-platform (cross-architecture) image builds
+
+## When this matters
+
+The image must match the CPU architecture of the **cluster nodes**, not the
+build machine. Typical mismatch: building on Apple Silicon (arm64) for a cloud
+cluster (amd64). Symptom of getting it wrong: the pod crashes instantly with
+`exec /home/bentoml/bento/env/docker/entrypoint.sh: exec format error` (or
+similar `exec format error`) in `kubectl logs`.
+
+## Detecting architectures
+
+```bash
+# Build machine / docker daemon
+docker info --format '{{.Architecture}}'      # x86_64 => amd64, aarch64 => arm64
+
+# Cluster nodes (needs kubectl access; otherwise ask the user)
+kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.nodeInfo.architecture}{"\n"}{end}'
+```
+
+## Single target platform
+
+`bentoml containerize` accepts the platform via the backend option:
+
+```bash
+bentoml containerize "$BENTO_TAG" -t "$IMAGE" --opt platform=linux/amd64
+```
+
+`--platform=linux/amd64` is the older spelling of the same thing (it maps to
+`--opt platform=...` and prints a deprecation-style warning; both work).
+
+Notes:
+
+- Emulated builds (arm64 host building amd64) go through QEMU/Rosetta and are
+  **much slower** — expect several minutes even for small services. On Docker
+  Desktop this works out of the box; on plain Linux you may need binfmt
+  handlers: `docker run --privileged --rm tonistiigi/binfmt --install all`.
+- You generally **cannot smoke-test** a cross-arch image on the build machine
+  (Docker Desktop can run amd64 images under emulation, slowly; plain Linux
+  cannot unless the binfmt/QEMU handlers shown above are installed). Skip the
+  local `docker run` smoke test and note that verification happens after
+  deployment instead.
+- Do not confuse this with `bentoml build --platform` — that flag controls the
+  platform used for **Python dependency locking** (values like `linux`,
+  `x86_64-unknown-linux-gnu`), not the container image arch. When
+  cross-building from macOS it can help to also pass `bentoml build
+  --platform linux` so locked wheels resolve for Linux.
+
+## Multi-arch images (amd64 + arm64 in one tag)
+
+Only needed when the same tag must run on mixed-arch clusters. Requires the
+buildx backend and pushes directly to the registry (multi-arch manifests cannot
+be loaded into the local docker image store):
+
+```bash
+docker buildx create --use --name bento-builder 2>/dev/null || docker buildx use bento-builder
+
+bentoml containerize "$BENTO_TAG" -t "$IMAGE" \
+  --backend buildx \
+  --opt platform=linux/amd64 --opt platform=linux/arm64 \
+  --opt push
+```
+
+You must be logged in to the registry before running this (`--opt push` uploads
+as part of the build). Verify with:
+
+```bash
+docker manifest inspect "$IMAGE" | grep -E 'architecture|os'
+```
+
+For a basic single-cluster deployment, prefer a single-platform build — it is
+simpler and faster.

--- a/.claude/skills/bentoml-containerize/references/registries.md
+++ b/.claude/skills/bentoml-containerize/references/registries.md
@@ -1,0 +1,147 @@
+# Registry-specific push instructions
+
+Conventions used below:
+
+- `$BENTO_TAG` — bento tag from the build step, e.g. `summarization:6oxk5qvott3lsnry`.
+- Split it when you need the parts:
+  ```bash
+  BENTO_NAME=${BENTO_TAG%%:*}      # summarization
+  BENTO_VERSION=${BENTO_TAG##*:}   # 6oxk5qvott3lsnry
+  ```
+- Image repository names must be **lowercase**. Reuse `$BENTO_VERSION` as the
+  image tag for traceability.
+- The sections below assume the SKILL.md Step 3 flow:
+  `bentoml containerize "$BENTO_TAG" -t "$IMAGE"`. With `-t`, the image is
+  tagged ONLY `$IMAGE` — **no image named `$BENTO_TAG` exists**. Compose
+  `$IMAGE` from the section's naming pattern BEFORE containerizing.
+- Only if you containerized **without** `-t` (image named `$BENTO_TAG`, e.g.
+  the kind/minikube path), retag before pushing:
+  `docker tag "$BENTO_TAG" "$IMAGE"`.
+- After pushing, record `$IMAGE` for the handoff to `bentoml-k8s-deploy`.
+
+## Docker Hub
+
+```bash
+docker login                       # prompts for Docker Hub username + password/PAT
+IMAGE="docker.io/<dockerhub-username>/${BENTO_NAME}:${BENTO_VERSION}"
+# (containerize with -t "$IMAGE"; if you containerized WITHOUT -t, first:
+#  docker tag "$BENTO_TAG" "$IMAGE")
+docker push "$IMAGE"
+```
+
+- Free accounts: pushes to a repo that doesn't exist create it as **public** by
+  default (private repos are limited). If the repo must be private, the cluster
+  needs an imagePullSecret (deploy skill handles it; it will need the username
+  and a PAT).
+
+## GHCR (GitHub Container Registry)
+
+```bash
+# PAT needs the write:packages scope (classic PAT), or use gh's token:
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u <github-username> --password-stdin
+# With gh CLI installed: gh auth token | docker login ghcr.io -u <github-username> --password-stdin
+
+IMAGE="ghcr.io/<github-username-or-org>/${BENTO_NAME}:${BENTO_VERSION}"
+# (containerize with -t "$IMAGE"; if you containerized WITHOUT -t, first:
+#  docker tag "$BENTO_TAG" "$IMAGE")
+docker push "$IMAGE"
+```
+
+- **Gotcha:** new GHCR packages are **private by default**. Either make the
+  package public (GitHub → Packages → package settings → Change visibility) or
+  tell the deploy skill an imagePullSecret is required (username + PAT with
+  `read:packages`).
+
+## AWS ECR
+
+```bash
+AWS_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+AWS_REGION=<region>
+aws ecr get-login-password --region "$AWS_REGION" \
+  | docker login --username AWS --password-stdin "${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+
+# ECR requires the repository to exist before pushing:
+aws ecr create-repository --repository-name "$BENTO_NAME" --region "$AWS_REGION" 2>/dev/null || true
+
+IMAGE="${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${BENTO_NAME}:${BENTO_VERSION}"
+# (containerize with -t "$IMAGE"; if you containerized WITHOUT -t, first:
+#  docker tag "$BENTO_TAG" "$IMAGE")
+docker push "$IMAGE"
+```
+
+- EKS nodes in the same account usually pull from ECR without imagePullSecrets
+  (node IAM role). Non-EKS clusters need a docker-registry secret with
+  temporary ECR credentials (they expire every 12h — mention this caveat).
+
+## Generic private registry
+
+```bash
+docker login registry.example.com      # ask user for credentials
+IMAGE="registry.example.com/<project>/${BENTO_NAME}:${BENTO_VERSION}"
+# (containerize with -t "$IMAGE"; if you containerized WITHOUT -t, first:
+#  docker tag "$BENTO_TAG" "$IMAGE")
+docker push "$IMAGE"
+```
+
+- HTTP-only or self-signed registries need `insecure-registries` in the Docker
+  daemon config on every machine that pulls — including the cluster nodes.
+  Prefer a TLS-enabled registry.
+- The cluster will need an imagePullSecret unless the nodes are pre-configured
+  for this registry — pass this fact to the deploy skill.
+
+## kind / minikube — no registry at all (local clusters)
+
+Load the image straight into the cluster nodes; nothing is pushed. This path
+assumes you containerized **without** `-t` (per SKILL.md Step 3), so the image
+is named exactly `$BENTO_TAG`.
+
+```bash
+# kind (find the cluster name with: kind get clusters)
+kind load docker-image "$BENTO_TAG" --name <cluster-name>
+
+# minikube
+minikube image load "$BENTO_TAG"
+```
+
+- The image reference for the deployment is the local name (e.g. `$BENTO_TAG`
+  itself) — no registry prefix.
+- **Critical for the deploy skill:** `imagePullPolicy` must be `IfNotPresent`
+  (or `Never`). With `Always` — Kubernetes' default for `:latest`-style
+  unqualified tags — the kubelet tries to pull from Docker Hub and fails.
+- Loading multi-GB images into kind can be slow; that's expected.
+
+## ttl.sh — anonymous ephemeral registry (throwaway tests)
+
+No account, no login; images are world-readable and auto-expire. Never use for
+anything sensitive. The **tag is the time-to-live** (`1h`, up to `24h`).
+Note: the "reuse the bento version as the image tag" traceability rule does NOT
+apply here — the tag must be the TTL and the repository name is random.
+
+```bash
+# Random repository name; falls back if uuidgen is not installed
+RAND=$( (uuidgen 2>/dev/null || head -c16 /dev/urandom | od -An -tx1) | tr -d ' \n' | tr 'A-Z' 'a-z' )
+IMAGE="ttl.sh/${RAND}:2h"
+# (containerize with -t "$IMAGE"; if you containerized WITHOUT -t, first:
+#  docker tag "$BENTO_TAG" "$IMAGE")
+docker push "$IMAGE"
+echo "Ephemeral image (expires in 2h): $IMAGE"
+```
+
+- Public and unauthenticated: anyone with the URL can pull. Fine for demo
+  services; NOT for images containing private models or proprietary code.
+- Deploy within the TTL window; the cluster cannot pull after expiry.
+- **Handoff caveat:** when passing a ttl.sh image to `bentoml-k8s-deploy`, tell
+  the deploy skill NOT to derive the Kubernetes Service/Deployment name from
+  the image repository — it's a random UUID that may start with a digit
+  (invalid DNS-1035 Service name). Pass the snake_cased bento name with
+  underscores converted to hyphens (e.g. `my_service` → `my-service`) as the
+  suggested service name instead.
+
+## Verifying a push
+
+```bash
+docker manifest inspect "$IMAGE" > /dev/null && echo "image is pullable"
+```
+
+(For kind/minikube loads instead: `docker exec <kind-node> crictl images | grep "$BENTO_NAME"`
+or `minikube image ls | grep "$BENTO_NAME"`.)

--- a/.claude/skills/bentoml-containerize/references/runtime-environment.md
+++ b/.claude/skills/bentoml-containerize/references/runtime-environment.md
@@ -1,0 +1,172 @@
+# Runtime environment spec — deep reference
+
+Two equivalent ways to define a Bento's runtime environment. Prefer the
+in-code `bentoml.images.Image` API for new projects; `bentofile.yaml` remains
+fully supported.
+
+## Option A: `bentoml.images.Image` (in `service.py`)
+
+```python
+import bentoml
+
+my_image = (
+    bentoml.images.Image(python_version="3.11")
+    .python_packages("torch", "transformers")
+)
+
+@bentoml.service(image=my_image)
+class MyService:
+    ...
+```
+
+### Constructor arguments
+
+| Argument | Default | Meaning |
+|---|---|---|
+| `python_version` | current build env's Python | e.g. `"3.11"` |
+| `distro` | `"debian"` | base image family |
+| `base_image` | `""` | custom Docker base image; overrides `python_version`/`distro` |
+| `lock_python_packages` | `True` | lock all versions (incl. transitive deps) at build time; set `False` when you pin versions yourself |
+
+### Chainable methods (order-sensitive — commands run in the order declared)
+
+- `.python_packages("numpy>=1.20", "git+https://github.com/user/repo.git@branch", "./wheels/pkg-0.1.0-py3-none-any.whl")`
+  — PyPI specs, Git URLs, or local wheels. The `wheels/` directory is included
+  in the Bento automatically.
+- `.requirements_file("./requirements.txt")` — use an existing requirements file.
+- `.pyproject_toml("pyproject.toml")` — take dependencies from a pyproject.
+- `.system_packages("curl", "git")` — distro package manager installs.
+- `.run('command')` — arbitrary build-time shell command. Placement matters:
+  `.run(...)` before `.python_packages(...)` executes before pip install, after
+  it executes after.
+- `.run_script("scripts/setup.sh")` — run a script file (needs a shebang).
+- `.build_include("data/", "config/settings.yaml")` — extra paths copied into
+  the build context before python packages are installed.
+
+Note: in a multi-service Bento all services share one runtime environment; a
+per-service image is not supported.
+
+## Option B: `bentofile.yaml`
+
+Placed next to `service.py`. Only `service:` is required.
+
+```yaml
+service: "service:MyService"      # <module>:<class name>
+name: my-bento                    # optional; default = service class name in snake_case (MyService -> my_service)
+description: "..."
+labels:
+  owner: my-team
+include:                          # files to package, relative to build ctx (default: everything)
+  - "*.py"
+  - "config/"
+exclude:                          # applied after include
+  - "tests/"
+python:
+  packages:
+    - torch
+    - transformers
+  requirements_txt: "./requirements.txt"   # alternative to packages
+  lock_packages: true
+docker:
+  distro: debian                  # debian|alpine|ubi8|amazonlinux
+  python_version: "3.11"
+  system_packages:
+    - curl
+  base_image: ""                  # custom base image (advanced)
+  cuda_version: "12.1"            # GPU images; incompatible with conda
+# (a miniconda-based image variant is selected automatically when top-level
+#  `conda:` options are present; there is no separate distro value for it)
+envs:                             # env vars baked as ENV into the image
+  - name: HF_HUB_OFFLINE
+    value: "1"
+  - name: HF_TOKEN                # name only => value supplied at runtime
+models:                           # models from the local model store to package
+  - my_model:latest
+args: {}                          # template args for parametrized builds
+```
+
+Unknown top-level keys are rejected (`__forbid_extra_keys__`), so typos fail the
+build with a clear message.
+
+Build with a non-default file name/location: `bentoml build -f path/to/bentofile.yaml`.
+Other useful flags: `--name`, `--version` (default auto-generated), `--label KEY=VALUE`.
+
+## `.bentoignore`
+
+Gitignore-style, evaluated per directory recursively (the file can exist at any
+level of the build context; patterns are relative to the directory containing
+it). Note that `.git/`, `.venv/`, `venv/`, `__pycache__/`, and `.DS_Store` are
+**always excluded automatically** — you don't need to list them. Use
+`.bentoignore` for large data/checkpoint dirs and other artifacts:
+
+```
+data/
+checkpoints/
+*.ipynb
+```
+
+`include`/`exclude` in `bentofile.yaml` and `.bentoignore` compose: a file is
+packaged only if it matches `include`, does not match `exclude`, and is not
+ignored.
+
+## Environment variables
+
+- `envs` entries **with a value** become `ARG`/`ENV` lines in the generated
+  Dockerfile — they are baked into image layers and visible to anyone with the
+  image. Never bake secrets.
+- `envs` entries **without a value** (name only) document what must be supplied
+  at runtime (`docker run -e`, Kubernetes Secret/env).
+- The same list can be given in code: `@bentoml.service(envs=[{"name": "HF_TOKEN"}])`.
+
+## Models: baked into the image vs downloaded at runtime
+
+There are three patterns; know which one the user's service uses because it
+changes both containerize behavior and what the Kubernetes deployment needs.
+
+### 1. Declared model references (recommended) — baked into the image
+
+```python
+import bentoml
+from bentoml.models import BentoModel, HuggingFaceModel
+
+@bentoml.service()
+class MyService:
+    # MUST be class variables, not created inside __init__ —
+    # class-level declaration registers them as Bento dependencies.
+    model_path = HuggingFaceModel("google-bert/bert-base-uncased")  # returns a path
+    sk_ref = BentoModel("iris_sklearn:latest")                       # local model store
+
+    def __init__(self):
+        from transformers import AutoModelForSequenceClassification
+        self.model = AutoModelForSequenceClassification.from_pretrained(self.model_path)
+```
+
+During `bentoml containerize`, BentoML resolves **all** declared models —
+downloading Hugging Face snapshots and copying model-store models — into the
+image build context, so the final image contains the weights (HF models under
+`$BENTO_PATH/hf-models`, wired up via the baked `BENTOML_HF_CACHE_DIR` env var;
+model-store models under `$BENTO_PATH/models`). Consequences:
+
+- No network or token is needed **at runtime** to fetch weights.
+- The image can be multiple GB. Registry and cluster must tolerate the size.
+- **Gated/private HF models**: export the token in the shell that runs the
+  build/containerize commands: `export HF_TOKEN=hf_...` (huggingface_hub reads
+  it). The token is used at build time only and is NOT stored in the image.
+- `HuggingFaceModel(model_id, revision="main", include=[...], exclude=[...])`
+  can trim what gets downloaded (e.g. exclude `*.bin` when safetensors exist).
+
+### 2. Ad-hoc runtime downloads — NOT baked
+
+If the service calls e.g. `from_pretrained("some/model")` in `__init__` without
+a class-level `HuggingFaceModel` reference, nothing is packaged; the container
+downloads the model **every time it starts**. This works, but:
+
+- The pod needs outbound network access and any auth token at runtime
+  (`docker run -e HF_TOKEN=...` locally; a Kubernetes Secret in the cluster —
+  tell the deploy skill).
+- Startup is slow and unreliable; prefer converting to pattern 1.
+
+### 3. Models from the local model store (`bentofile.yaml` `models:` list)
+
+Same baking behavior as `BentoModel` above; entries reference tags in the local
+store (`bentoml models list`).

--- a/.claude/skills/bentoml-k8s-deploy/SKILL.md
+++ b/.claude/skills/bentoml-k8s-deploy/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: bentoml-k8s-deploy
+description: Deploy a containerized BentoML service to a vanilla Kubernetes cluster using plain kubectl manifests (no Helm, no operators, no BentoCloud/Yatai). Takes a pushed container image (built by the bentoml-containerize skill or `bentoml containerize`), generates Deployment/Service/Ingress manifests under k8s/, applies them, and verifies the rollout with a real inference request. Use when the user says things like "deploy my BentoML service to Kubernetes", "deploy this bento image to my cluster", "run my bento on k8s", "create k8s manifests for my bento", or "expose my BentoML service in Kubernetes".
+---
+
+# Deploy a BentoML service to vanilla Kubernetes
+
+You will take a **pushed container image reference** (e.g. `ghcr.io/acme/summarization:v1`,
+produced by the `bentoml-containerize` skill), generate plain Kubernetes manifests from the
+templates in this skill's `templates/` directory, apply them with `kubectl`, and verify the
+service end to end.
+
+Facts that are always true for images built by `bentoml containerize`:
+- The HTTP server listens on **port 3000**.
+- Health endpoints: **`/livez`** (liveness), **`/readyz`** (readiness). `/metrics` serves Prometheus metrics.
+- The image entrypoint already starts the server — **never set `command:`/`args:`** in the pod spec.
+- Models are usually baked into the image; models downloaded at runtime (e.g. gated HF models) need env vars such as `HF_TOKEN` via a Kubernetes Secret.
+
+Safety rules (apply throughout):
+- **Never apply anything before the user has confirmed the kubectl context AND namespace.**
+- Never `kubectl delete` anything this skill did not create in this session.
+- Never write secret values into files on disk — secrets are created only with `kubectl create secret ... --from-literal`.
+
+## Step 0 — Preflight checks
+
+Run, and stop with a clear message if any check fails:
+
+```bash
+kubectl version --client        # kubectl installed?
+kubectl config get-contexts     # list contexts; note the current one (*)
+```
+
+Then **ask the user which context to use — never assume the current context is the
+intended cluster**, even if there is only one. Show them the list and get an explicit
+answer. Use `--context <ctx>` on every subsequent kubectl command (do not silently
+switch their current context with `kubectl config use-context`).
+
+With the confirmed context, verify connectivity and permissions:
+
+```bash
+kubectl --context <ctx> get nodes -L kubernetes.io/arch   # cluster reachable? note node arch
+kubectl --context <ctx> auth can-i create deployment -n <ns>   # run once the namespace is known (Step 1)
+```
+
+If the image was built on Apple Silicon and the `ARCH` column above shows `amd64`
+nodes, warn the user now: the image must have been containerized with
+`--platform=linux/amd64`, otherwise pods will crash with "exec format error".
+
+## Step 1 — Gather deployment parameters
+
+Ask the user for anything you cannot detect. Present defaults and let them accept in one go:
+
+| Parameter | Default | Notes |
+|---|---|---|
+| Image reference | (required) | Full pushed ref incl. registry + tag. If the user only ran `bentoml containerize`, the image may exist only locally — it must be pushed (or `kind load` / `minikube image load` for local clusters; see `references/private-registries.md`). |
+| Service name | image repo basename, sanitized | Must be **DNS-1035** (see naming rule below), e.g. `summarization:v1` → `summarization`. |
+| Namespace | `default` | Offer to create a dedicated one. |
+| Replicas | `1` | |
+| CPU request/limit | `500m` / `2` | |
+| Memory request/limit | `1Gi` / `4Gi` | Size to the model: OOMKilled pods usually mean the limit is below model memory. |
+| GPU | none | If needed: how many `nvidia.com/gpu` per pod. First read `references/gpu-scheduling.md` and check the cluster actually advertises the resource. |
+| Env vars (plain) | none | Non-sensitive config only. |
+| Secrets | none | Tokens/keys (e.g. `HF_TOKEN`). Handled in Step 2, never written to manifests. |
+| Private registry? | detect/ask | If pulling needs auth → imagePullSecret, Step 2. See `references/private-registries.md`. |
+| Exposure | `port-forward` | One of: port-forward (testing), NodePort, LoadBalancer, Ingress. Read `references/exposure-options.md` before recommending; check what the cluster supports (`kubectl --context <ctx> get ingressclass`, cloud LB availability). |
+
+**Service naming rule (DNS-1035 — stricter than most K8s names).** Kubernetes
+`Service` objects require an RFC 1035 label: lowercase alphanumerics and `-`, **must
+start with a letter**, must end with an alphanumeric, max 63 chars. Since
+`{{SERVICE_NAME}}` names the Service too, always enforce DNS-1035:
+
+- Validate the derived name against `^[a-z]([-a-z0-9]*[a-z0-9])?$` before rendering.
+- If the image repo basename starts with a digit or is a meaningless random name (e.g. a
+  ttl.sh UUID like `1f0d3c2a-...`), do NOT use it — derive the name from the bento name
+  instead (the service class name lowercased/snake_cased, e.g. bento `text_summarizer:v1`),
+  converting underscores to `-` (→ `text-summarizer`). If nothing usable can be derived,
+  ask the user.
+- **`kubectl apply --dry-run=client` does NOT reliably catch DNS-1035 violations for
+  Services** — a bad name passes dry-run, then the real apply rejects the Service while
+  the Deployment succeeds, leaving a half-applied state (see Step 4). Validate the name
+  yourself; never rely on dry-run for this.
+
+## Step 2 — Namespace and Secrets (imperative, before manifests)
+
+Create the namespace if it does not exist (or render `templates/namespace.yaml` into
+`k8s/namespace.yaml` if the user wants it tracked in git):
+
+```bash
+kubectl --context <ctx> get namespace <ns> || kubectl --context <ctx> create namespace <ns>
+```
+
+**Application secrets** — one Secret holding all sensitive env vars. Ask the user to
+provide values (or confirm reading them from their shell env); never echo values back,
+never put them in a file:
+
+```bash
+kubectl --context <ctx> create secret generic <service-name>-env -n <ns> \
+  --from-literal=HF_TOKEN="$HF_TOKEN" \
+  --from-literal=OTHER_KEY="..."
+```
+
+**Registry pull secret** (only for private registries):
+
+```bash
+kubectl --context <ctx> create secret docker-registry <service-name>-regcred -n <ns> \
+  --docker-server=<registry> --docker-username=<user> \
+  --docker-password="$REGISTRY_TOKEN"
+```
+
+Registry-specific details (GHCR, ECR, Docker Hub, local kind/minikube):
+`references/private-registries.md`.
+
+## Step 3 — Render manifests into the project's `k8s/` directory
+
+For each needed manifest, in this exact order:
+
+1. **Render**: run sed on the file in this skill's `templates/` directory, substituting
+   every placeholder you have a value for (including placeholders inside OPTIONAL blocks
+   that apply), and write the output to `<project>/k8s/<file>.yaml`. Never modify the
+   templates themselves.
+2. **Prune**: edit the `k8s/` copy in place and **delete every `OPTIONAL` block that does
+   not apply**, including its comment lines (imagePullSecrets, env, envFrom, GPU line,
+   Ingress TLS). Each block's comment states exactly how many lines to delete.
+3. **Check**: a finished manifest must contain **no `{{...}}` left** (verified below).
+
+Which files to write:
+- `k8s/deployment.yaml` — always.
+- `k8s/service.yaml` — always (`SERVICE_TYPE`: `ClusterIP` for port-forward and Ingress; `NodePort` or `LoadBalancer` if that exposure was chosen).
+- `k8s/namespace.yaml` — only if the user wants the namespace in git (otherwise Step 2 already created it).
+- `k8s/ingress.yaml` — only for Ingress exposure.
+
+### Placeholder reference (all templates)
+
+| Placeholder | Used in | Meaning / example |
+|---|---|---|
+| `{{SERVICE_NAME}}` | all | DNS-1035 name (see naming rule, Step 1), e.g. `summarization`. Also used as label value. |
+| `{{NAMESPACE}}` | all | Target namespace, e.g. `ml-services`. |
+| `{{IMAGE}}` | deployment | Full pushed image ref, e.g. `ghcr.io/acme/summarization:v1`. |
+| `{{REPLICAS}}` | deployment | Integer, e.g. `1`. |
+| `{{CPU_REQUEST}}` / `{{CPU_LIMIT}}` | deployment | e.g. `500m` / `2`. |
+| `{{MEMORY_REQUEST}}` / `{{MEMORY_LIMIT}}` | deployment | e.g. `1Gi` / `4Gi`. |
+| `{{IMAGE_PULL_SECRET}}` | deployment (optional) | docker-registry Secret name from Step 2, e.g. `summarization-regcred`. |
+| `{{ENV_NAME}}` / `{{ENV_VALUE}}` | deployment (optional) | One plain env var; duplicate the pair per extra var. |
+| `{{ENV_SECRET_NAME}}` | deployment (optional) | generic Secret name from Step 2, e.g. `summarization-env`. |
+| `{{GPU_COUNT}}` | deployment (optional) | Integer GPUs per pod, e.g. `1`. |
+| `{{SERVICE_TYPE}}` | service | `ClusterIP`, `NodePort`, or `LoadBalancer`. |
+| `{{INGRESS_CLASS_NAME}}` | ingress | From `kubectl --context <ctx> get ingressclass`, e.g. `nginx`. |
+| `{{INGRESS_HOST}}` | ingress | e.g. `summarization.example.com`. |
+| `{{TLS_SECRET_NAME}}` | ingress (optional) | Existing TLS Secret, e.g. `summarization-tls`. |
+
+Example — step 1 (render). Add extra `-e` expressions for any optional placeholders that
+apply (`{{IMAGE_PULL_SECRET}}`, `{{ENV_SECRET_NAME}}`, `{{GPU_COUNT}}`, ...):
+
+```bash
+mkdir -p k8s
+sed -e 's|{{SERVICE_NAME}}|summarization|g' \
+    -e 's|{{NAMESPACE}}|ml-services|g' \
+    -e 's|{{IMAGE}}|ghcr.io/acme/summarization:v1|g' \
+    -e 's|{{REPLICAS}}|1|g' \
+    -e 's|{{CPU_REQUEST}}|500m|g'  -e 's|{{CPU_LIMIT}}|2|g' \
+    -e 's|{{MEMORY_REQUEST}}|1Gi|g' -e 's|{{MEMORY_LIMIT}}|4Gi|g' \
+    <path-to-skill>/templates/deployment.yaml > k8s/deployment.yaml
+```
+
+Then step 2 (prune): edit `k8s/deployment.yaml` in place (your file-editing tool, or
+`sed -i`) to delete the non-applicable OPTIONAL blocks — e.g. with no private registry,
+no env vars, no secrets and no GPU, delete all four blocks listed in the template
+comments. Only after pruning does the placeholder check below pass.
+
+Sanity-check every rendered file before showing it to the user:
+
+```bash
+grep -n '{{' k8s/*.yaml && echo "ERROR: unreplaced placeholders" || echo OK
+kubectl --context <ctx> apply --dry-run=client -f k8s/
+```
+
+Suggest adding `k8s/` to `.gitignore` only if it contains environment-specific values the
+user does not want committed; otherwise committing it is fine (it contains no secrets).
+
+## Step 4 — Confirm, then apply
+
+Show the user the rendered manifests plus a one-line summary —
+**`context=<ctx>  namespace=<ns>  image=<image>`** — and wait for explicit confirmation.
+Then:
+
+```bash
+kubectl --context <ctx> apply -n <ns> -f k8s/
+```
+
+**If apply partially fails** (some manifests created, one rejected — e.g. an invalid
+Service name that dry-run did not catch): fix the offending manifest, then re-apply the
+whole `k8s/` directory. Two rules for the cleanup:
+
+- Resources **this skill just created in this run** are yours to fix: deleting and
+  re-applying them is allowed and is NOT covered by the "never delete" safety rule —
+  that rule protects pre-existing resources you did not create.
+- If the fix involves **renaming** (e.g. correcting `{{SERVICE_NAME}}`), `kubectl apply`
+  would create a second object under the new name instead of updating the old one —
+  first delete the just-created misnamed objects
+  (`kubectl --context <ctx> delete -n <ns> deployment/<old-name> service/<old-name> ...`,
+  only the ones created moments ago in this run), update the name in **all** manifests
+  in `k8s/`, then re-apply the whole directory.
+
+## Step 5 — Verify
+
+1. Wait for the rollout (budget matches the startupProbe: up to ~10 min for model loading):
+
+```bash
+kubectl --context <ctx> rollout status deployment/<service-name> -n <ns> --timeout=600s
+```
+
+If it stalls, inspect
+(`kubectl --context <ctx> get pods -n <ns> -l app.kubernetes.io/name=<service-name>`,
+`kubectl --context <ctx> describe pod <pod> -n <ns>`,
+`kubectl --context <ctx> logs <pod> -n <ns>`) and hand off to the
+`bentoml-k8s-troubleshoot` skill for diagnosis.
+
+2. Readiness check plus **one real inference request** through a port-forward. Derive
+   the inference endpoint and payload from the user's `service.py` (each `@bentoml.api`
+   method `def foo(self, text: str)` is `POST /foo` with JSON body `{"text": "..."}`);
+   if the source is not available, fetch the live schema from
+   `http://127.0.0.1:3100/docs.json` (while the port-forward is up) or ask the user.
+   If you need the schema first, run the block below once with only the readyz check
+   plus a `curl -s http://127.0.0.1:3100/docs.json`, then re-run it with the inference
+   call filled in.
+
+   Forward to an **uncommon local port (3100)**, not local 3000: port 3000 is commonly
+   occupied by dev servers, and if the port-forward fails to bind, your curls silently
+   hit whatever local process squats there — producing convincing but fake results.
+   For the same reason the block checks that the port-forward process is still alive
+   before trusting any curl.
+
+   The whole sequence below — port-forward, checks, kill — **must run in ONE shell
+   invocation**: the background process and `$PF_PID` do not survive across separate
+   shell calls.
+
+```bash
+PF_ERR=$(mktemp)
+kubectl --context <ctx> port-forward svc/<service-name> -n <ns> 3100:3000 >"$PF_ERR" 2>&1 &
+PF_PID=$!
+OK=""
+for i in $(seq 1 15); do
+  kill -0 $PF_PID 2>/dev/null || { echo "port-forward exited:"; cat "$PF_ERR"; exit 1; }
+  curl -sfo /dev/null http://127.0.0.1:3100/readyz && { OK=1; break; }
+  sleep 2
+done
+[ -n "$OK" ] || { echo "not ready after 30s; port-forward log:"; cat "$PF_ERR"; kill $PF_PID; exit 1; }
+echo READY
+
+# Real inference request — substitute the endpoint/payload derived above:
+curl -s -X POST http://127.0.0.1:3100/summarize \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "Kubernetes is an open-source container orchestration system."}'
+
+kill $PF_PID
+rm -f "$PF_ERR"
+```
+
+**Judge the inference response by its content, not the status code.** Only a correct
+inference result proves the deployment works: HTTP 200 alone proves nothing, and a
+4xx/5xx or error body means the payload or service needs fixing. If the output looks
+unrelated to the service's API, suspect a local port squatter — confirm the port-forward
+owns the port (`kill -0 $PF_PID`, check `$PF_ERR`) before believing anything.
+
+## Step 6 — Tell the user how to reach the service
+
+Print the access instructions matching the chosen exposure (full details and commands in
+`references/exposure-options.md`):
+
+- **port-forward**: `kubectl --context <ctx> port-forward svc/<service-name> -n <ns> 3000:3000` → `http://127.0.0.1:3000`
+- **NodePort**: `http://<node-ip>:<node-port>` (get with `kubectl --context <ctx> get svc <service-name> -n <ns>` and `kubectl --context <ctx> get nodes -o wide`)
+- **LoadBalancer**: external IP/hostname from `kubectl --context <ctx> get svc <service-name> -n <ns> -w`
+- **Ingress**: `http(s)://<INGRESS_HOST>/` once DNS points at the ingress controller
+
+Also mention: interactive API docs at `/` (Swagger UI), Prometheus metrics at `/metrics`.
+
+## Out of scope
+
+Autoscaling, scale-to-zero, canary/blue-green rollouts, and metric-based scaling were
+BentoCloud features and are **not** part of this skill. If the user asks about scaling,
+point them at a standard CPU-based HorizontalPodAutoscaler
+(`kubectl --context <ctx> autoscale deployment <service-name> -n <ns> --min=1 --max=5 --cpu-percent=80`)
+and stop there.
+
+## References (read on demand)
+
+- `references/exposure-options.md` — choosing and configuring port-forward / NodePort / LoadBalancer / Ingress, TLS, inference-friendly timeouts.
+- `references/private-registries.md` — imagePullSecrets for GHCR/ECR/Docker Hub/self-hosted; kind/minikube local image loading; ttl.sh for throwaway tests.
+- `references/gpu-scheduling.md` — verifying the NVIDIA device plugin, requesting `nvidia.com/gpu`, node selectors and taints.

--- a/.claude/skills/bentoml-k8s-deploy/references/exposure-options.md
+++ b/.claude/skills/bentoml-k8s-deploy/references/exposure-options.md
@@ -1,0 +1,96 @@
+# Exposure options for a BentoML service on Kubernetes
+
+The BentoML container always listens on port **3000**; the Service template exposes
+port **3000** (named `http`) in every mode. Choose the exposure method with the user
+based on where clients live.
+
+| Method | Reachable from | Needs | Best for |
+|---|---|---|---|
+| port-forward | your machine only | nothing | development, testing, demos |
+| ClusterIP (default) | inside the cluster | nothing | other in-cluster workloads calling the model |
+| NodePort | anyone who can reach a node IP | routable node IPs | bare-metal / homelab without a LB |
+| LoadBalancer | internet / VPC | cloud LB integration (EKS/GKE/AKS) or MetalLB | production on managed clouds |
+| Ingress | internet, name-based | an installed ingress controller | production with hostnames/TLS, several services behind one IP |
+
+## port-forward (default for testing)
+
+No manifest changes; Service stays `ClusterIP`.
+
+```bash
+kubectl --context <ctx> port-forward svc/<service-name> -n <ns> 3000:3000
+# then: curl http://127.0.0.1:3000/readyz
+```
+
+The tunnel lives only while the command runs. Local port busy? Use `3001:3000` and call
+`http://127.0.0.1:3001`.
+
+## ClusterIP (in-cluster consumers)
+
+Other pods call the service at
+`http://<service-name>.<ns>.svc.cluster.local:3000`.
+
+## NodePort
+
+Set `{{SERVICE_TYPE}}` to `NodePort`. Kubernetes assigns a port in 30000–32767:
+
+```bash
+kubectl --context <ctx> get svc <service-name> -n <ns> \
+  -o jsonpath='{.spec.ports[0].nodePort}'
+kubectl --context <ctx> get nodes -o wide     # take any node's EXTERNAL-IP (or INTERNAL-IP on a LAN)
+curl http://<node-ip>:<node-port>/readyz
+```
+
+Caveats: node IPs may not be routable from the user's network (cloud security groups /
+firewalls must allow the port range); the port changes if the Service is recreated. For
+kind clusters NodePort is not reachable from the host unless the port was mapped in the
+kind config — prefer port-forward there.
+
+## LoadBalancer
+
+Set `{{SERVICE_TYPE}}` to `LoadBalancer`. Only works where something provisions LBs
+(managed clouds; MetalLB on bare metal). Wait for the address:
+
+```bash
+kubectl --context <ctx> get svc <service-name> -n <ns> -w
+# EXTERNAL-IP goes from <pending> to an IP/hostname; then:
+curl http://<external-ip>:3000/readyz
+```
+
+If EXTERNAL-IP stays `<pending>` for minutes, the cluster has no LB provider — fall back
+to NodePort or Ingress. Warn the user this usually creates a **billable, publicly
+reachable** cloud load balancer with no auth in front of the model.
+
+## Ingress
+
+Use `templates/ingress.yaml` (class-agnostic) with a `ClusterIP` Service. Precondition —
+a controller must already be installed:
+
+```bash
+kubectl --context <ctx> get ingressclass
+```
+
+No output → no controller; installing one (ingress-nginx, traefik, cloud-specific) is out
+of scope for this skill — offer NodePort/LoadBalancer instead. Otherwise use the listed
+name as `{{INGRESS_CLASS_NAME}}` (a class marked `(default)` still should be set
+explicitly).
+
+- `{{INGRESS_HOST}}`: a DNS name the user controls, pointed at the controller's external
+  address (`kubectl --context <ctx> get svc -n ingress-nginx` or the controller's namespace). For quick
+  tests without DNS: `curl -H 'Host: <host>' http://<controller-ip>/readyz` or an
+  `/etc/hosts` entry.
+- **TLS**: keep the optional `tls:` block only if a TLS Secret exists in the same
+  namespace — via cert-manager (out of scope to install) or manually:
+  `kubectl --context <ctx> create secret tls <name> -n <ns> --cert=cert.pem --key=key.pem`.
+  Otherwise delete the block and serve plain HTTP.
+- **Timeouts**: inference can exceed a controller's default upstream timeout (often 60s
+  for nginx). For long-running requests on ingress-nginx add annotations such as
+  `nginx.ingress.kubernetes.io/proxy-read-timeout: "300"` and
+  `nginx.ingress.kubernetes.io/proxy-body-size: "50m"` (large payloads). Other
+  controllers have equivalents — check theirs before debugging 504s.
+
+## A note on exposure and safety
+
+NodePort/LoadBalancer/Ingress make the model API reachable by anyone who can reach the
+address — BentoML applies no authentication by itself. Remind the user to put auth
+(ingress auth annotations, an API gateway, or network policy/firewall rules) in front of
+anything non-experimental.

--- a/.claude/skills/bentoml-k8s-deploy/references/gpu-scheduling.md
+++ b/.claude/skills/bentoml-k8s-deploy/references/gpu-scheduling.md
@@ -1,0 +1,82 @@
+# GPU scheduling for BentoML services
+
+GPUs are requested through the extended resource `nvidia.com/gpu` in the container's
+`resources.limits` (the optional GPU line in `templates/deployment.yaml`). Extended
+resources cannot be fractional and requests default to limits — setting the limit alone
+is correct.
+
+## Precondition: the cluster must advertise GPUs
+
+The **NVIDIA device plugin** (usually via the NVIDIA GPU Operator or the plugin
+DaemonSet) must already be running — installing it is the cluster admin's job and out of
+scope for this skill. Verify before writing a GPU manifest:
+
+```bash
+kubectl --context <ctx> get nodes \
+  -o custom-columns='NAME:.metadata.name,GPUS:.status.allocatable.nvidia\.com/gpu'
+```
+
+Every value is `<none>` or `0` → no schedulable GPUs (`0` means the device plugin runs
+but advertises no GPUs on that node); a GPU pod will sit **Pending** forever with
+`Insufficient nvidia.com/gpu`. Tell the user and either deploy CPU-only or stop.
+
+Also check free capacity — allocatable minus what other pods already claim:
+
+```bash
+kubectl --context <ctx> describe node <gpu-node> | grep -A8 'Allocated resources'
+```
+
+## What the pod gets
+
+- `nvidia.com/gpu: 1` grants exclusive use of one physical GPU (unless the admin
+  configured time-slicing/MIG — then one "gpu" is a slice; ask the admin, don't assume).
+- The device plugin injects the devices and driver libraries; the container needs no
+  privileged mode and no host mounts.
+- Multi-GPU (`nvidia.com/gpu: 2+`) only helps if the serving framework uses multiple
+  GPUs (e.g. vLLM tensor parallelism). Default to 1 per pod.
+
+## The image must be CUDA-capable
+
+Requesting a GPU does not make the code use it. The image needs CUDA-enabled ML
+libraries — in BentoML that comes from the project's image spec
+(`bentofile.yaml` `docker.cuda_version`, or a `bentoml.images.Image` runtime built on a
+CUDA base). If the containerize step produced a CPU-only image, the pod will schedule
+fine but run on CPU (or crash importing CUDA libs). When in doubt, check the logs after
+startup for the framework's device report (e.g. `torch.cuda.is_available()`).
+
+## Taints, tolerations, node selection
+
+GPU nodes are commonly tainted so CPU pods don't land on them. If GPU pods stay Pending
+with `node(s) had untolerated taint`, check the taint and add matching fields at the pod
+spec level of `deployment.yaml` (same indentation as `containers:`):
+
+```bash
+kubectl --context <ctx> describe node <gpu-node> | grep -i taint
+```
+
+```yaml
+      tolerations:
+        - key: nvidia.com/gpu        # match the actual taint key from the node
+          operator: Exists
+          effect: NoSchedule
+```
+
+To pin to a specific GPU type on heterogeneous clusters, add a nodeSelector using a label
+that exists on the nodes (check `kubectl --context <ctx> get nodes --show-labels`; common ones:
+`nvidia.com/gpu.product`, cloud instance-type labels):
+
+```yaml
+      nodeSelector:
+        nvidia.com/gpu.product: NVIDIA-A10G
+```
+
+## Sizing reminders
+
+- Keep CPU/memory realistic alongside the GPU: model loading and tokenization still use
+  host RAM; an OOMKilled GPU pod wastes the whole GPU. For LLM-sized models raise memory
+  (e.g. request 8Gi / limit 16Gi) rather than reusing the CPU defaults.
+- Startup is slower on GPU nodes (image is bigger, weights move to VRAM). The template's
+  10-minute startupProbe budget usually suffices; for very large models raise
+  `failureThreshold` (e.g. 240 → 20 min) instead of letting the rollout fail.
+- Replicas × GPUs-per-pod must fit the cluster's free GPU count, or the extra replicas
+  stay Pending.

--- a/.claude/skills/bentoml-k8s-deploy/references/private-registries.md
+++ b/.claude/skills/bentoml-k8s-deploy/references/private-registries.md
@@ -1,0 +1,95 @@
+# Pulling BentoML images from private registries (and local clusters)
+
+The kubelet pulls the image, not the user's docker login — a working `docker pull` on the
+laptop proves nothing about the cluster. Private registries need an `imagePullSecrets`
+entry in the pod spec pointing at a `kubernetes.io/dockerconfigjson` Secret.
+
+Never write registry credentials into YAML files. Always create the Secret imperatively:
+
+```bash
+kubectl --context <ctx> create secret docker-registry <service-name>-regcred -n <ns> \
+  --docker-server=<REGISTRY> \
+  --docker-username=<USERNAME> \
+  --docker-password="$REGISTRY_TOKEN"
+```
+
+Then keep the optional `imagePullSecrets` block in `deployment.yaml` with
+`{{IMAGE_PULL_SECRET}}` = `<service-name>-regcred`. The Secret is namespaced — recreate
+it in every namespace that pulls the image.
+
+Quick test that credentials + image ref are right (run once, then delete):
+
+```bash
+kubectl --context <ctx> run pull-test -n <ns> --image=<IMAGE> \
+  --overrides='{"spec":{"imagePullSecrets":[{"name":"<service-name>-regcred"}]}}' \
+  --restart=Never --command -- sleep 300
+kubectl --context <ctx> wait --for=condition=Ready pod/pull-test -n <ns> --timeout=60s \
+  && echo "pull OK"   # times out -> check: kubectl --context <ctx> describe pod pull-test -n <ns>
+kubectl --context <ctx> delete pod pull-test -n <ns>
+```
+
+## Registry specifics
+
+### Docker Hub
+- `--docker-server=https://index.docker.io/v1/`
+- Use an access token (hub.docker.com → Account Settings → Personal access tokens), not
+  the account password.
+- Public Docker Hub images need no pull secret, but anonymous pulls are rate-limited
+  (can cause intermittent `ImagePullBackOff` on busy clusters — a pull secret with a free
+  account raises the limit).
+
+### GitHub Container Registry (GHCR)
+- `--docker-server=ghcr.io`, `--docker-username=<github-username>`,
+  `--docker-password=$GITHUB_PAT` (classic PAT with `read:packages`).
+- Packages are private by default even in public repos — check the package's visibility
+  before assuming anonymous pulls work.
+
+### AWS ECR
+- Tokens are **temporary (12 h)** — fine for a one-off deploy, but the Secret must be
+  refreshed for future pulls (node restarts, scale-ups):
+
+```bash
+kubectl --context <ctx> create secret docker-registry <service-name>-regcred -n <ns> \
+  --docker-server=<ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com \
+  --docker-username=AWS \
+  --docker-password="$(aws ecr get-login-password --region <REGION>)"
+```
+
+- On EKS, prefer the node IAM role with the `AmazonEC2ContainerRegistryReadOnly` policy —
+  then **no pull secret is needed at all**; delete the `imagePullSecrets` block.
+
+### Self-hosted / other (Harbor, GitLab, Quay, ...)
+- Same `docker-registry` Secret pattern with the registry's hostname.
+- HTTP-only or self-signed registries fail with x509/`http: server gave HTTP response`
+  errors; fixing that requires containerd config on every node — out of scope; recommend
+  a registry with valid TLS.
+
+## Local clusters: skip the registry entirely
+
+If the image exists in the local docker daemon and the cluster is kind/minikube/k3d, load
+it directly instead of pushing:
+
+```bash
+kind load docker-image <IMAGE> --name <kind-cluster-name>   # kind
+minikube image load <IMAGE>                                  # minikube
+k3d image import <IMAGE> -c <cluster-name>                   # k3d
+```
+
+Then in `deployment.yaml` keep the image ref as-is, delete the `imagePullSecrets` block,
+and add `imagePullPolicy: Never` (or `IfNotPresent`) under the container — with the
+default policy the kubelet may still try to pull from a registry and fail, especially for
+`:latest`-style tags.
+
+## Throwaway public registry: ttl.sh
+
+For quick tests with zero setup, ttl.sh is an anonymous, ephemeral public registry
+(the tag is the time-to-live):
+
+```bash
+docker tag <IMAGE> ttl.sh/<any-unique-name>:1h
+docker push ttl.sh/<any-unique-name>:1h
+```
+
+Use `ttl.sh/<any-unique-name>:1h` as `{{IMAGE}}`; no pull secret needed. The image
+vanishes after the TTL and is publicly pullable meanwhile — never use it for anything
+sensitive or lasting.

--- a/.claude/skills/bentoml-k8s-deploy/templates/deployment.yaml
+++ b/.claude/skills/bentoml-k8s-deploy/templates/deployment.yaml
@@ -1,0 +1,83 @@
+# BentoML service Deployment.
+# Every double-curly-brace placeholder MUST be replaced before applying.
+# Blocks marked "OPTIONAL" MUST be deleted entirely when they do not apply —
+# never leave an unreplaced placeholder in the final manifest.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{SERVICE_NAME}}
+  namespace: {{NAMESPACE}}
+  labels:
+    app.kubernetes.io/name: {{SERVICE_NAME}}
+    app.kubernetes.io/managed-by: bentoml-k8s-deploy
+spec:
+  replicas: {{REPLICAS}}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{SERVICE_NAME}}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{SERVICE_NAME}}
+        app.kubernetes.io/managed-by: bentoml-k8s-deploy
+    spec:
+      # OPTIONAL block — private registry only. Delete this block (4 lines, these
+      # comments included) if the image is public. See references/private-registries.md.
+      imagePullSecrets:
+        - name: {{IMAGE_PULL_SECRET}}
+      containers:
+        - name: bentoml
+          image: {{IMAGE}}
+          # Do NOT add `command:` or `args:` — the image entrypoint produced by
+          # `bentoml containerize` already starts the HTTP server (`serve`).
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          # OPTIONAL block — plain (non-secret) environment variables. Delete this
+          # block (6 lines, these comments included) if there are none; otherwise
+          # add one name/value pair per variable (block grows accordingly).
+          env:
+            - name: {{ENV_NAME}}
+              value: "{{ENV_VALUE}}"
+          # OPTIONAL block — secret environment variables (tokens, API keys).
+          # The Secret must already exist, created via:
+          #   kubectl --context <ctx> create secret generic <name> -n <ns> --from-literal=KEY=VALUE
+          # Delete this block (7 lines, these comments included) if there are no secrets.
+          envFrom:
+            - secretRef:
+                name: {{ENV_SECRET_NAME}}
+          resources:
+            requests:
+              cpu: {{CPU_REQUEST}}
+              memory: {{MEMORY_REQUEST}}
+            limits:
+              cpu: {{CPU_LIMIT}}
+              memory: {{MEMORY_LIMIT}}
+              # OPTIONAL block — GPU. Delete this block (4 lines, these comments
+              # included) if not needed. Requires the NVIDIA device plugin on the
+              # cluster. See references/gpu-scheduling.md.
+              nvidia.com/gpu: {{GPU_COUNT}}
+          # Generous startup budget: model loading can take minutes.
+          # 120 failures x 5s = 10 minutes before the pod is considered failed.
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 120
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/.claude/skills/bentoml-k8s-deploy/templates/ingress.yaml
+++ b/.claude/skills/bentoml-k8s-deploy/templates/ingress.yaml
@@ -1,0 +1,34 @@
+# Class-agnostic Ingress. Only write/apply this file when the user chose
+# Ingress exposure. Requires an ingress controller already installed in the
+# cluster (check with: kubectl --context <ctx> get ingressclass).
+# See references/exposure-options.md.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{SERVICE_NAME}}
+  namespace: {{NAMESPACE}}
+  labels:
+    app.kubernetes.io/name: {{SERVICE_NAME}}
+    app.kubernetes.io/managed-by: bentoml-k8s-deploy
+  # OPTIONAL — some controllers need annotations (e.g. cert-manager issuer,
+  # nginx timeouts for slow inference). Add only what the user's controller needs.
+spec:
+  ingressClassName: {{INGRESS_CLASS_NAME}}
+  # OPTIONAL block — TLS. Delete this block (7 lines, these comments included) for
+  # plain HTTP. The TLS Secret must exist in this namespace beforehand (cert-manager,
+  # or: kubectl create secret tls <name> -n <ns> --cert=cert.pem --key=key.pem).
+  tls:
+    - hosts:
+        - {{INGRESS_HOST}}
+      secretName: {{TLS_SECRET_NAME}}
+  rules:
+    - host: {{INGRESS_HOST}}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{SERVICE_NAME}}
+                port:
+                  name: http

--- a/.claude/skills/bentoml-k8s-deploy/templates/namespace.yaml
+++ b/.claude/skills/bentoml-k8s-deploy/templates/namespace.yaml
@@ -1,0 +1,8 @@
+# Intentional deviation from the both-labels convention: no app.kubernetes.io/name
+# label here, because a namespace may host several services and is not tied to one.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{NAMESPACE}}
+  labels:
+    app.kubernetes.io/managed-by: bentoml-k8s-deploy

--- a/.claude/skills/bentoml-k8s-deploy/templates/service.yaml
+++ b/.claude/skills/bentoml-k8s-deploy/templates/service.yaml
@@ -1,0 +1,20 @@
+# Service in front of the BentoML Deployment.
+# {{SERVICE_TYPE}} is one of: ClusterIP (default), NodePort, LoadBalancer.
+# See references/exposure-options.md for how to choose.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{SERVICE_NAME}}
+  namespace: {{NAMESPACE}}
+  labels:
+    app.kubernetes.io/name: {{SERVICE_NAME}}
+    app.kubernetes.io/managed-by: bentoml-k8s-deploy
+spec:
+  type: {{SERVICE_TYPE}}
+  selector:
+    app.kubernetes.io/name: {{SERVICE_NAME}}
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+      protocol: TCP

--- a/.claude/skills/bentoml-k8s-troubleshoot/SKILL.md
+++ b/.claude/skills/bentoml-k8s-troubleshoot/SKILL.md
@@ -1,0 +1,355 @@
+---
+name: bentoml-k8s-troubleshoot
+description: Diagnose and fix BentoML services deployed to Kubernetes with the bentoml-k8s-deploy skill (plain Deployment + Service, port 3000, /livez + /readyz probes). Use when the user says things like "my BentoML deployment is failing", "pods are crashing / CrashLoopBackOff / ImagePullBackOff", "pod stuck Pending", "readiness probe failing", "rollout stuck", "can't reach my service on Kubernetes", or "inference requests return 4xx/5xx errors".
+---
+
+# Troubleshoot a BentoML service on Kubernetes
+
+You are diagnosing a BentoML service deployed as a plain `Deployment` + `Service`
+(created by the sibling skill `bentoml-k8s-deploy`): container port **3000**, liveness
+probe **`GET /livez`**, readiness probe **`GET /readyz`**, and a generous `startupProbe`
+on `/readyz` because model loading can take minutes.
+
+Work the decision tree below: run the triage block, match the symptom, run the
+diagnostics for that symptom, state the likely cause, then apply the fix.
+
+## Placeholders used throughout
+
+- `<ns>` — namespace of the deployment (ask the user; the deploy skill asked them too)
+- `<name>` — the app name, i.e. the value of the `app.kubernetes.io/name` label
+  (snake_cased BentoML service class name with underscores converted to hyphens,
+  e.g. `Summarization` → `summarization`, `MyService` → `my-service`)
+- `<pod>` — a concrete pod name from `kubectl get pods` output
+- `<deploy>` — the Deployment name (usually the same as `<name>`)
+- Other `<...>` tokens are literal values from the user's setup (registry, credentials,
+  image, endpoint name, etc.)
+
+## Safety rules (binding)
+
+- **Never delete** resources these skills did not create. Never `kubectl delete`
+  Deployments, Services, Secrets, or namespaces as a "fix". Prefer `kubectl apply` of a
+  corrected manifest (the deploy skill writes manifests to the project's `k8s/` dir) or
+  `kubectl rollout restart deployment/<deploy> -n <ns>`.
+- **Always show the user the target context and namespace before any mutating command**
+  and get their confirmation:
+  ```sh
+  kubectl config current-context
+  kubectl config view --minify -o jsonpath='{..namespace}{"\n"}'   # empty = default
+  ```
+- Read-only diagnostics (`get`, `describe`, `logs`, `events`, `port-forward`, `curl`)
+  may run freely once the context is confirmed.
+
+## Step 0 — Triage (always run first)
+
+```sh
+kubectl get pods -n <ns> -l app.kubernetes.io/name=<name> -o wide
+kubectl get deploy,svc -n <ns> -l app.kubernetes.io/name=<name>
+kubectl describe pod -n <ns> <pod>          # read Events at the bottom first
+kubectl get events -n <ns> --sort-by=.lastTimestamp | tail -30
+kubectl logs -n <ns> <pod> --tail=100
+kubectl logs -n <ns> <pod> --previous --tail=100   # if the container restarted
+```
+
+Route on the pod STATUS / describe output:
+
+| Observation | Go to |
+|---|---|
+| `ImagePullBackOff` / `ErrImagePull` | 1 |
+| `CrashLoopBackOff` / `Error` | 2 |
+| `OOMKilled` (in `Last State` of describe) | 3 |
+| `Pending` | 4 |
+| `Running` but `READY 0/1`; probe failures in events | 5 |
+| `kubectl rollout status` never completes | 6 |
+| Pods Ready but requests don't reach the service | 7 |
+| Service reachable but inference returns 4xx/5xx | 8 |
+| `kubectl apply` rejected a manifest (validation error, e.g. `Invalid value` for a name) | 9 |
+| port-forward "works" but responses look wrong / content is from another app | 10 |
+
+## 1. ImagePullBackOff / ErrImagePull
+
+Diagnose — the exact pull error is in events:
+
+```sh
+kubectl describe pod -n <ns> <pod> | grep -A5 -i "failed to pull\|pull image"
+kubectl get pod -n <ns> <pod> -o jsonpath='{.spec.containers[0].image}{"\n"}'
+kubectl get pod -n <ns> <pod> -o jsonpath='{.spec.imagePullSecrets}{"\n"}'
+```
+
+Likely causes and fixes:
+
+- **`not found` / `manifest unknown`** — wrong image ref or tag never pushed. Compare
+  the pod's image against what was actually pushed (`docker images | grep <name>`).
+  Remember BentoML tags images as `name:version` (e.g. `summarization:abc123`), which
+  must be retagged to `<registry>/<repo>:<tag>` and pushed. Fix the `image:` field in
+  `k8s/deployment.yaml` and `kubectl apply -n <ns> -f k8s/deployment.yaml`.
+- **`unauthorized` / `authentication required`** — private registry without
+  `imagePullSecrets`. Create the secret and reference it (never write credentials into
+  a manifest file):
+  ```sh
+  kubectl create secret docker-registry regcred -n <ns> \
+    --docker-server=<registry> --docker-username=<user> \
+    --docker-password=<password-or-token>
+  ```
+  Add to the Deployment pod spec: `spec.template.spec.imagePullSecrets: [{name: regcred}]`,
+  then `kubectl apply`.
+- **`no match for platform in manifest`** (containerd) or **`no matching manifest for
+  linux/amd64 in the manifest list entries`** (Docker) — arch mismatch: image built on
+  Apple Silicon (arm64) for an amd64 cluster. Rebuild with
+  `bentoml containerize --platform=linux/amd64 <name>:<version>`, retag, push, and
+  `kubectl rollout restart deployment/<deploy> -n <ns>`.
+- **kind/minikube cluster can't pull at all** — local clusters can't see the host's
+  Docker images. Use `kind load docker-image <image> --name <cluster>` or
+  `minikube image load <image>`, and set `imagePullPolicy: IfNotPresent`.
+
+## 2. CrashLoopBackOff
+
+The answer is almost always in the logs of the *previous* attempt:
+
+```sh
+kubectl logs -n <ns> <pod> --previous --tail=200
+kubectl describe pod -n <ns> <pod> | grep -A3 "Last State"
+```
+
+Read the log tail bottom-up (see "Reading BentoML logs" below). Likely causes:
+
+- **Python traceback ending in `KeyError`/`ValidationError` about an env var, or code
+  reading `os.environ[...]`** — missing env var or Secret. Check what the pod actually
+  has: `kubectl exec` won't work on a crashing pod, so inspect the spec:
+  ```sh
+  kubectl get pod -n <ns> <pod> -o jsonpath='{.spec.containers[0].env}{"\n"}'
+  kubectl get pod -n <ns> <pod> -o jsonpath='{.spec.containers[0].envFrom}{"\n"}'
+  kubectl get secret -n <ns>
+  ```
+  Fix: create the missing secret (`kubectl create secret generic <name>-env
+  --from-literal=HF_TOKEN=...` — ask the user for the value, never invent one), wire it
+  via `envFrom.secretRef` in the Deployment, `kubectl apply`.
+- **`NotFound: model ... does not exist` or an HF download error** — model missing.
+  Models are baked into the image at `bentoml build` time by default; if the traceback
+  shows a download attempt, the service downloads at runtime and likely needs
+  `HF_TOKEN` (see above) or network egress. If the model should be baked in, the Bento
+  was built without it — rebuild (`bentoml build`), re-containerize, push, restart.
+- **`ModuleNotFoundError` / `ImportError`** — a Python dependency missing from the
+  Bento's declared packages. Add it to `bentofile.yaml` (or the
+  `bentoml.images.Image(...)` spec), rebuild, re-containerize, push, rollout restart.
+- **`exec format error`** (often the only log line, or in describe events) — wrong CPU
+  architecture; same fix as the arch mismatch in section 1
+  (`bentoml containerize --platform=linux/amd64 ...`).
+- **Exit code 137 with no traceback** — see section 3 (OOMKilled).
+- Do **not** "fix" crashes by overriding `command:` in the pod spec — the image
+  entrypoint already runs `serve`; overriding it is a common way to break the container.
+
+## 3. OOMKilled
+
+Confirm, then check current limits:
+
+```sh
+kubectl describe pod -n <ns> <pod> | grep -B2 -A5 "OOMKilled"
+kubectl get pod -n <ns> <pod> -o jsonpath='{.spec.containers[0].resources}{"\n"}'
+```
+
+Likely cause: memory limit smaller than model weights + inference working set. Rule of
+thumb: limit >= ~1.5-2x the model files' size on disk (weights expand in RAM). Fix by
+raising `resources.limits.memory` (and `requests.memory`) in `k8s/deployment.yaml` and
+`kubectl apply -n <ns> -f k8s/deployment.yaml`. If the node itself is too small, that
+becomes a Pending problem (section 4). OOM during startup (kill within the first
+minutes, logs stop mid model-load) is the same fix — it is not a probe problem.
+
+## 4. Pending
+
+The scheduler's reason is in events:
+
+```sh
+kubectl describe pod -n <ns> <pod> | grep -A10 Events
+kubectl describe nodes | grep -A6 "Allocated resources"
+```
+
+- **`Insufficient cpu` / `Insufficient memory`** — requests exceed free node capacity.
+  Lower `resources.requests` in `k8s/deployment.yaml` (keep limits >= requests) and
+  apply, or the user must add/resize nodes.
+- **`Insufficient nvidia.com/gpu`** — either no GPU nodes, or the NVIDIA device plugin
+  is not installed so GPUs aren't advertised. Check:
+  ```sh
+  kubectl get nodes -o custom-columns='NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
+  ```
+  If GPU nodes exist but show `<none>`, the device plugin is missing — installing it is
+  the cluster admin's responsibility; tell the user rather than modifying their cluster.
+  If the service doesn't actually need a GPU, remove the `nvidia.com/gpu` limit and apply.
+- **`didn't match Pod's node affinity/selector`** — a `nodeSelector`/affinity in the
+  Deployment matches no node. Compare against `kubectl get nodes --show-labels`; fix or
+  remove the selector in the manifest and apply.
+- **`FailedScheduling ... untolerated taint`** — target nodes are tainted (common on GPU
+  pools). Add the matching `tolerations` to the pod spec and apply.
+
+## 5. Running but not Ready (readiness/startup probe failing)
+
+First decide: *still loading* vs *actually broken*.
+
+```sh
+kubectl describe pod -n <ns> <pod> | grep -iA4 "unhealthy\|probe failed"
+kubectl logs -n <ns> <pod> --tail=50
+```
+
+- If logs show active model loading (download progress bars, checkpoint shards) and the
+  pod is only a few minutes old: **wait**. The deploy skill's startupProbe budget is
+  about 10 minutes (`periodSeconds: 5`, `failureThreshold: 120`). If loading genuinely
+  needs longer, raise `failureThreshold` in `k8s/deployment.yaml` and apply — do not
+  shrink or remove the probe.
+- If the startup log line already appeared (see log hints below) but readiness still
+  fails, ask `/readyz` yourself and **read the response body** — BentoML puts the reason
+  there:
+  ```sh
+  kubectl port-forward -n <ns> <pod> 3100:3000 &   # local 3100: port 3000 is often squatted (section 10)
+  for i in $(seq 1 10); do curl -so /dev/null http://localhost:3100/livez && break; sleep 1; done
+  curl -si http://localhost:3100/readyz
+  curl -si http://localhost:3100/livez
+  kill %1
+  ```
+  Run every `port-forward ... & ... kill %1` sequence in this skill as ONE shell
+  invocation — job IDs (`%1`) don't survive across separate tool calls — and always
+  wait for the tunnel to bind (the retry loop above) before trusting a curl result.
+  - `200` with empty/whitespace body (it is a single newline) → ready; if K8s still
+    reports failure, the probe path/port in the manifest is wrong (must be `/readyz`
+    on port 3000) — fix and apply.
+  - `503` with `"Service is not ready because .__is_ready__() returns False."` → the
+    user's own `__is_ready__` hook is returning False; read their `service.py`.
+  - `503` with `"Runners are not ready."` → a dependent service in a multi-service Bento
+    isn't up; check its logs.
+  - Connection refused / connection reset / empty reply even after waiting for the
+    tunnel (retry loop above) → server never bound port 3000; treat as CrashLoop
+    (section 2). (Exact error text varies: kubectl may accept the local connection
+    and then fail the forward.)
+
+## 6. Rollout stuck
+
+```sh
+kubectl rollout status deployment/<deploy> -n <ns>
+kubectl get rs -n <ns> -l app.kubernetes.io/name=<name>
+kubectl get pods -n <ns> -l app.kubernetes.io/name=<name>
+```
+
+A stuck rollout means new-ReplicaSet pods never became Ready — diagnose those pods with
+sections 1-5. If the newly pushed image is broken and the user wants the previous
+version back while they fix it, prefer fixing the image ref in `k8s/deployment.yaml`
+and re-applying; `kubectl rollout undo deployment/<deploy> -n <ns>` is acceptable
+(it only rolls the Deployment back, deletes nothing) — confirm with the user first.
+If the same tag was re-pushed with new content, nodes may run a stale cached image:
+set a fresh unique tag instead of reusing tags.
+
+## 7. Pods Ready but service unreachable
+
+Check that the Service actually selects the pods:
+
+```sh
+kubectl get endpoints -n <ns> <name>   # deprecated on K8s >=1.33; modern equivalent:
+kubectl get endpointslices -n <ns> -l kubernetes.io/service-name=<name>
+kubectl get svc -n <ns> <name> -o yaml | grep -A5 "selector:\|ports:"
+kubectl get pods -n <ns> -l app.kubernetes.io/name=<name> --show-labels
+```
+
+- **`ENDPOINTS <none>`** — Service selector doesn't match pod labels (deploy skill uses
+  `app.kubernetes.io/name: <name>`), or matching pods aren't Ready (sections 2-5). Fix
+  the selector/labels in `k8s/` and apply.
+- **Endpoints exist but curl fails** — wrong port wiring. Service `targetPort` must be
+  `3000` (or the port name `http`). Bypass the Service to isolate:
+  ```sh
+  kubectl port-forward -n <ns> <pod> 3100:3000 &        # pod direct (local 3100, see section 10)
+  curl -sf --retry 5 --retry-connrefused http://localhost:3100/livez && echo POD-OK
+  kill %1
+  kubectl port-forward -n <ns> svc/<name> 3100:3000 &   # via the service (service port 3000, named http)
+  curl -sf --retry 5 --retry-connrefused http://localhost:3100/livez && echo SVC-OK
+  kill %1
+  ```
+  Pod OK + Service broken → fix Service `port`/`targetPort` and apply.
+- **Ingress path broken (pod and svc both OK)**:
+  ```sh
+  kubectl get ingress -n <ns> -o wide
+  kubectl describe ingress -n <ns> <name>
+  kubectl get ingressclass
+  ```
+  Common: `ingressClassName` names a class that doesn't exist / no controller installed
+  (ADDRESS stays empty), wrong `service.name`/`port` in the backend, or DNS for the host
+  rule not pointing at the controller. Fix the ingress manifest and apply; installing an
+  ingress controller is the user's call.
+
+## 8. Reachable but inference returns 4xx/5xx
+
+Reproduce with the real error body — BentoML returns JSON error details:
+
+```sh
+kubectl port-forward -n <ns> svc/<name> 3100:3000 &   # local 3100, see section 10
+for i in $(seq 1 10); do curl -so /dev/null http://localhost:3100/livez && break; sleep 1; done
+curl -si -X POST http://localhost:3100/<endpoint> \
+  -H 'Content-Type: application/json' -d '{"<arg>": "<value>"}'
+```
+
+Then check the actual API schema the server exposes — never guess the payload shape.
+(This block reuses the tunnel from the previous block — run both in the same shell
+invocation, with `kill %1` only at the end:)
+
+```sh
+curl -s http://localhost:3100/docs.json | python3 -m json.tool | head -100   # OpenAPI spec
+# Swagger UI is served at the service root path in a browser
+kill %1
+```
+
+- **404** — wrong path. BentoML API endpoints are `POST /<method_name>` (e.g.
+  `POST /summarize`); list them from the OpenAPI spec's `paths`.
+- **400 / 422** — payload doesn't match the method signature: wrong field names, wrong
+  types, or wrong content type. Match the request body schema in `docs.json` exactly;
+  keys are the Python parameter names.
+- **405** — used GET on an inference route; they are POST-only.
+- **500** — server-side exception. The full traceback is in the pod logs at the moment
+  of the request:
+  ```sh
+  kubectl logs -n <ns> <pod> --tail=50
+  ```
+- **503 / 429** — overloaded or concurrency limit hit; check for OOM/restarts
+  (`kubectl get pods -n <ns>` RESTARTS column) or retry after load drops.
+
+## 9. `kubectl apply` rejected a manifest (validation error)
+
+`kubectl apply -f k8s/` applies file-by-file, so a rejection leaves a half-applied
+state — run the Step 0 triage to see which objects exist. Common cause: invalid name —
+K8s **Service** names are DNS-1035 (must start with a *letter*) while most other names
+are DNS-1123, so e.g. `1st-model` fails as a Service name. Fix the name in the `k8s/`
+manifests and re-apply. Renames create *new* objects: it is OK to `kubectl delete` the
+misnamed objects **this deploy-skill run just created** and re-apply — that is the one
+sanctioned delete; the never-delete rule still protects everything pre-existing.
+
+## 10. port-forward "works" but responses look wrong
+
+If curl returns 200 but the body isn't BentoML (another app's page, wrong JSON), the
+local port is probably occupied by an unrelated process and the port-forward silently
+failed to bind (its error is easy to miss when output is redirected). Check the tunnel
+is alive (`kill -0 <port-forward-pid>`) and prefer an uncommon local port, e.g.
+`kubectl port-forward -n <ns> svc/<name> 3100:3000` then curl `localhost:3100`.
+Always verify response CONTENT (e.g. `/docs.json` mentions your endpoints), not just
+the status code — then follow the tunnel-wait guidance in section 5.
+
+## Reading BentoML logs (hints)
+
+- **Healthy startup** ends with a line like:
+  `Starting production HTTP BentoServer from "<bento_identifier>" listening on http://0.0.0.0:3000 (Press CTRL+C to quit)`
+  If this line is present, the server bound the port — later failures are probe config,
+  networking, or per-request errors, not startup.
+- Before that line you'll see worker/model-loading output (framework logs, HF download
+  progress). No startup line + logs stop mid-load → still loading, crashed during load
+  (traceback), or OOMKilled (logs cut off with no traceback, exit 137).
+- **Tracebacks go to the pod's stderr/stdout** — `kubectl logs` shows them; the last
+  frame of the last traceback is the actual error. For request-time errors the
+  traceback is logged when the request fails, so correlate by timestamp.
+- Access logs print one line per request with method, path, and status — useful to
+  confirm requests reach the pod at all (note: `/livez` and `/readyz` probe hits are
+  excluded from access logs by default, so their absence is normal).
+
+## Escalation
+
+If none of the branches match, collect a bundle and reason from it (do not delete or
+recreate resources speculatively):
+
+```sh
+kubectl get all -n <ns> -l app.kubernetes.io/name=<name> -o wide
+kubectl describe deploy -n <ns> <deploy>
+kubectl get events -n <ns> --sort-by=.lastTimestamp
+kubectl logs -n <ns> <pod> --all-containers --timestamps --tail=300
+```


### PR DESCRIPTION
## What this PR does

With BentoCloud winding down, this adds a set of **Claude Code agent skills** (under `.claude/skills/`) that give users a fully open-source path from a local BentoML project to a running service on their own vanilla Kubernetes cluster: `bentoml` CLI + Docker + `kubectl` with plain manifests. No Helm, no operators/CRDs, no Yatai, no closed-source dependencies.

| Skill | Purpose |
|---|---|
| `bentoml-containerize` | project → `bentoml build` → `bentoml containerize` → local smoke test (content-verified) → push to Docker Hub / GHCR / ECR / private registry / kind / minikube / ttl.sh |
| `bentoml-k8s-deploy` | pushed image → parameterized Deployment/Service(/Ingress) manifests rendered into the project's `k8s/` → `kubectl apply` → rollout verified with a real inference request |
| `bentoml-k8s-troubleshoot` | decision-tree runbook for the 10 common failure modes (image pull, crash loops, OOM, Pending/GPU, probes, stuck rollouts, networking, 4xx/5xx, rejected manifests, port-forward false positives) |

Scope is intentionally **basic deployment only** — BentoCloud-era features (autoscaling on inference metrics, canary, scale-to-zero) are explicitly out of scope; a one-line standard HPA pointer is the maximum.

Users install by copying the skill folders to `~/.claude/skills/` (or a project's `.claude/skills/`); see `.claude/skills/README.md`.

## How it was validated

- Every claimed CLI/server behavior (port 3000, `/livez` `/readyz`, `bentoml build -o tag` output format, `containerize -t` semantics, entrypoint behavior, model baking) was verified against this repo's source.
- Manifest templates validated with `kubectl apply --dry-run=client` for both maximal and minimal renders.
- Full end-to-end run on a real k3s cluster: sample service → build → containerize → push to ttl.sh → deploy → correct inference response through port-forward. Defects found by that run (DNS-1035 Service naming, port-squatter false positives in smoke tests and port-forward verification) are fixed in this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)