### PR TITLE
fix: handle bare iterator output annotations

### DIFF
--- a/src/_bentoml_sdk/io_models.py
+++ b/src/_bentoml_sdk/io_models.py
@@ -432,7 +432,8 @@ class IODescriptor(IOMixin, BaseModel):
             )
         media_type: str | None = None
         if is_iterator_type(return_annotation):
-            return_annotation = get_args(return_annotation)[0]
+            iterator_args = get_args(return_annotation)
+            return_annotation = iterator_args[0] if iterator_args else t.Any
         elif is_annotated(return_annotation):
             content_type = next(
                 (a for a in get_args(return_annotation) if isinstance(a, ContentType)),

--- a/tests/unit/_bentoml_sdk/test_io_models.py
+++ b/tests/unit/_bentoml_sdk/test_io_models.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import collections.abc as cabc
+import typing as t
+
+import pytest
+
+from _bentoml_sdk.io_models import IODescriptor
+
+
+@pytest.mark.parametrize(
+    "return_annotation",
+    [
+        t.Iterator,
+        t.Generator,
+        t.AsyncIterator,
+        t.AsyncGenerator,
+        cabc.Iterator,
+        cabc.Generator,
+        cabc.AsyncIterator,
+        cabc.AsyncGenerator,
+    ],
+)
+def test_from_output_accepts_bare_iterators(return_annotation: t.Any) -> None:
+    def stream() -> t.Iterator[t.Any]:
+        yield None
+
+    stream.__annotations__["return"] = return_annotation
+
+    descriptor = IODescriptor.from_output(stream)
+
+    assert descriptor.model_fields["root"].annotation is t.Any


### PR DESCRIPTION
## What does this PR address?

<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the Conventional Commits specification.
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR. If no one has reviewed your PR after a week has passed, don't hesitate to post a new comment and ping the same person.
-->

Bare iterator and generator return annotations have no type arguments, so indexing `get_args()` raised `IndexError` during output-spec inference. This change falls back to `Any`, matching the existing behavior for an omitted return annotation, and adds regression coverage for all sync and async iterator/generator variants from both `typing` and `collections.abc`.

Tests:

- `.venv/bin/pytest tests/unit/_bentoml_sdk/test_io_models.py -q` (8 passed)
- `.venv/bin/pytest tests/unit/bentoml_io/test_decorators.py -q` (8 passed)
- `.venv/bin/pre-commit run --all-files` (passed; Buf hooks skipped because no matching files changed)

<!-- Remove if not applicable -->

Fixes #5625

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Does the Pull Request follow Conventional Commits specification naming?
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed?
- [x] Did you read through contribution guidelines and follow development guidelines?
- [x] Did your changes require updates to the documentation? N/A; this only prevents an inference crash and does not change the public API.
- [x] Did you write tests to cover your changes?
