### PR TITLE
docs: fix docstring Args entries that name a parameter the function does not take

### DIFF
--- a/src/bentoml/_internal/cloud/model.py
+++ b/src/bentoml/_internal/cloud/model.py
@@ -526,7 +526,7 @@ class ModelAPI:
         """Get a model from the remote model store
 
         Args:
-            tag: The tag of the model to get
+            name: The tag of the model to get
 
         Returns:
             The model

--- a/src/bentoml/_internal/container/base.py
+++ b/src/bentoml/_internal/container/base.py
@@ -100,7 +100,6 @@ class OCIBuilder:
         Initialize the OCI builder.
 
         Args:
-            backend: The name of the OCI builder.
             env: Environment variables to be passed to the OCI builder.
             enable_buildkit: Whether to enable BuildKit support for given OCI builder.
             build_cmd: The build command to be used by the OCI builder, minus the backend name.

--- a/src/bentoml/_internal/frameworks/fastai.py
+++ b/src/bentoml/_internal/frameworks/fastai.py
@@ -137,7 +137,7 @@ def save_model(
     Args:
         name: The name to give to the model in the BentoML store. This must be a valid
               :obj:`~bentoml.Tag` name.
-        learner: :obj:`~fastai.learner.Learner` to be saved.
+        learner_: :obj:`~fastai.learner.Learner` to be saved.
         signatures: Signatures of predict methods to be used. If not provided, the signatures default to
                     ``predict``. See :obj:`~bentoml.types.ModelSignature` for more details.
         labels: A default set of management labels to be associated with the model. An example is ``{"training-set": "data-1"}``.

--- a/src/bentoml/_internal/frameworks/pytorch_lightning.py
+++ b/src/bentoml/_internal/frameworks/pytorch_lightning.py
@@ -47,12 +47,10 @@ def load_model(
     Load a model from BentoML local modelstore with given name.
 
     Args:
-        tag (:code:`Union[str, Tag]`):
+        bentoml_model (:code:`Union[str, Tag]`):
             Tag of a saved model in BentoML local modelstore.
         device_id (:code:`str`, `optional`):
             Optional devices to put the given model on. Refer to https://pytorch.org/docs/stable/tensor_attributes.html#torch.torch.device
-        model_store (:mod:`~bentoml._internal.models.store.ModelStore`, default to :mod:`BentoMLContainer.model_store`):
-            BentoML modelstore, provided by DI Container.
 
     Returns:
         :obj:`torch.ScriptModule`: an instance of :obj:`torch.ScriptModule` from BentoML modelstore.
@@ -104,8 +102,6 @@ def save_model(
             e.g. a tokenizer module, preprocessor module, model configuration module
         metadata (:code:`Dict[str, Any]`, `optional`, default to :code:`None`):
             Custom metadata for given model.
-        model_store (:mod:`~bentoml._internal.models.store.ModelStore`, default to :mod:`BentoMLContainer.model_store`):
-            BentoML modelstore, provided by DI Container.
 
     Returns:
         :obj:`~bentoml.Tag`: A :obj:`tag` with a format `name:version` where `name` is the user-defined model's name, and a generated `version` by BentoML.

--- a/src/bentoml/_internal/frameworks/torchscript.py
+++ b/src/bentoml/_internal/frameworks/torchscript.py
@@ -44,7 +44,7 @@ def load_model(
     Load a model from BentoML local modelstore with given name.
 
     Args:
-        tag:
+        bentoml_model:
             Tag of a saved model in BentoML local modelstore.
         device_id:
             Optional devices to put the given model on. Refer to https://pytorch.org/docs/stable/tensor_attributes.html#torch.torch.device

--- a/src/bentoml/_internal/io_descriptors/base.py
+++ b/src/bentoml/_internal/io_descriptors/base.py
@@ -148,7 +148,6 @@ class IODescriptor(ABC, _OpenAPIMeta, t.Generic[IOType]):
 
         Args:
             sample: The sample to create the instance from.
-            **kwargs: Additional keyword arguments to pass to the constructor.
 
         Returns:
             An instance of the IODescriptor.

--- a/src/bentoml/_internal/io_descriptors/file.py
+++ b/src/bentoml/_internal/io_descriptors/file.py
@@ -129,9 +129,6 @@ class File(
 
         Args:
             sample: Given File-like object, or a path to a file.
-            kind: The kind of file-like object to be used. Currently, the only accepted value is ``binaryio``.
-            mime_type: Optional MIME type for the descriptor. If not provided, ``from_sample``
-                       will try to infer the MIME type from the file extension.
 
         Returns:
             :class:`~bentoml._internal.io_descriptors.file.File`: IODescriptor from given users inputs.

--- a/src/bentoml/_internal/io_descriptors/image.py
+++ b/src/bentoml/_internal/io_descriptors/image.py
@@ -205,11 +205,6 @@ class Image(
 
         Args:
             sample: Given File-like object, or a path to a file.
-            pilmode: Optional color mode for PIL. Default to ``RGB``.
-            mime_type: The MIME type of the file type that this descriptor should return.
-                       If not specified, then ``from_sample`` will try to infer the MIME type
-                       from file extension.
-            allowed_mime_types: An optional list of MIME types to restrict input to.
 
         Returns:
             :class:`~bentoml._internal.io_descriptors.image.Image`: IODescriptor from given users inputs.

--- a/src/bentoml/_internal/io_descriptors/json.py
+++ b/src/bentoml/_internal/io_descriptors/json.py
@@ -229,7 +229,6 @@ class JSON(
                         @svc.api(input=input_spec, output=NumpyNdarray())
                         async def predict(input: NDArray[np.int16]) -> NDArray[Any]:
                             return await runner.async_run(input)
-            json_encoder: Optional JSON encoder.
 
         Returns:
             :class:`~bentoml._internal.io_descriptors.json.JSON`: IODescriptor from given users inputs.

--- a/src/bentoml/_internal/io_descriptors/numpy.py
+++ b/src/bentoml/_internal/io_descriptors/numpy.py
@@ -433,12 +433,6 @@ class NumpyNdarray(
         Args:
             sample: Given sample ``np.ndarray`` data. It also accepts a sequence-like data type that
                     can be converted to ``np.ndarray``.
-            enforce_dtype: Enforce a certain data type. :code:`dtype` must be specified at function
-                           signature. If you don't want to enforce a specific dtype then change
-                           :code:`enforce_dtype=False`.
-            enforce_shape: Enforce a certain shape. :code:`shape` must be specified at function
-                           signature. If you don't want to enforce a specific shape then change
-                           :code:`enforce_shape=False`.
 
         Returns:
             :class:`~bentoml._internal.io_descriptors.numpy.NumpyNdarray`: IODescriptor from given users inputs.
@@ -491,8 +485,7 @@ class NumpyNdarray(
         Process incoming protobuf request and convert it to ``numpy.ndarray``
 
         Args:
-            request: Incoming RPC request message.
-            context: grpc.ServicerContext
+            field: Incoming RPC request message.
 
         Returns:
             ``numpy.ndarray``: A ``np.array`` constructed from given protobuf message.

--- a/src/bentoml/_internal/io_descriptors/pandas.py
+++ b/src/bentoml/_internal/io_descriptors/pandas.py
@@ -347,31 +347,6 @@ class PandasDataFrame(
 
         Args:
             sample: Given sample ``pd.DataFrame`` data
-            orient: Indication of expected JSON string format. Compatible JSON strings can be
-                    produced by :func:`pandas.io.json.to_json()` with a corresponding orient value.
-                    Possible orients are:
-
-                    - :obj:`split` - :code:`dict[str, Any]` ↦ {``idx`` ↠ ``[idx]``, ``columns`` ↠ ``[columns]``, ``data`` ↠ ``[values]``}
-                    - :obj:`records` - :code:`list[Any]` ↦ [{``column`` ↠ ``value``}, ..., {``column`` ↠ ``value``}]
-                    - :obj:`index` - :code:`dict[str, Any]` ↦ {``idx`` ↠ {``column`` ↠ ``value``}}
-                    - :obj:`columns` - :code:`dict[str, Any]` ↦ {``column`` ↠ {``index`` ↠ ``value``}}
-                    - :obj:`values` - :code:`dict[str, Any]` ↦ Values arrays
-                    - :obj:`table` - :code:`dict[str, Any]` ↦ {``schema``: { schema }, ``data``: { data }}
-            apply_column_names: Update incoming DataFrame columns. ``columns`` must be specified at
-                                function signature. If you don't want to enforce a specific columns
-                                name then change ``apply_column_names=False``.
-            enforce_dtype: Enforce a certain data type. `dtype` must be specified at function
-                           signature. If you don't want to enforce a specific dtype then change
-                           ``enforce_dtype=False``.
-            enforce_shape: Enforce a certain shape. ``shape`` must be specified at function
-                           signature. If you don't want to enforce a specific shape then change
-                           ``enforce_shape=False``.
-            default_format: The default serialization format to use if the request does not specify a ``Content-Type`` Headers.
-                            It is also the serialization format used for the response. Possible values are:
-
-                            - :obj:`json` - JSON text format (inferred from content-type ``"application/json"``)
-                            - :obj:`parquet` - Parquet binary format (inferred from content-type ``"application/vnd.apache.parquet"``)
-                            - :obj:`csv` - CSV text format (inferred from content-type ``"text/csv"``)
 
         Returns:
             :class:`~bentoml._internal.io_descriptors.pandas.PandasDataFrame`: IODescriptor from given users inputs.
@@ -640,8 +615,7 @@ class PandasDataFrame(
         Process incoming protobuf request and convert it to ``pandas.DataFrame``
 
         Args:
-            request: Incoming RPC request message.
-            context: grpc.ServicerContext
+            field: Incoming RPC request message.
 
         Returns:
             a ``pandas.DataFrame`` object. This can then be used
@@ -698,7 +672,6 @@ class PandasDataFrame(
 
         Args:
             obj: ``pandas.DataFrame`` that will be serialized to protobuf
-            context: grpc.aio.ServicerContext from grpc.aio.Server
         Returns:
             ``service_pb2.Response``:
                 Protobuf representation of given ``pandas.DataFrame``
@@ -849,9 +822,6 @@ class PandasSeries(
                 - :obj:`index` - :code:`dict[str, Any]` ↦ {``idx`` ↠ {``column`` ↠ ``value``}}
                 - :obj:`columns` - :code:`dict[str, Any]` ↦ {``column`` ↠ {``index`` ↠ ``value``}}
                 - :obj:`values` - :code:`dict[str, Any]` ↦ Values arrays
-        columns: List of columns name that users wish to update.
-        apply_column_names: Whether to update incoming DataFrame columns. If :code:`apply_column_names=True`,
-                            then ``columns`` must be specified.
         dtype: Data type users wish to convert their inputs/outputs to. If it is a boolean,
                then pandas will infer dtypes. Else if it is a dictionary of column to
                ``dtype``, then applies those to incoming dataframes. If ``False``, then don't
@@ -898,21 +868,7 @@ class PandasSeries(
         Create a :class:`~bentoml._internal.io_descriptors.pandas.PandasSeries` IO Descriptor from given inputs.
 
         Args:
-            sample_input: Given sample ``pd.DataFrame`` data
-            orient: Indication of expected JSON string format. Compatible JSON strings can be
-                    produced by :func:`pandas.io.json.to_json()` with a corresponding orient value.
-                    Possible orients are:
-
-                    - :obj:`split` - :code:`dict[str, Any]` ↦ {``idx`` ↠ ``[idx]``, ``columns`` ↠ ``[columns]``, ``data`` ↠ ``[values]``}
-                    - :obj:`records` - :code:`list[Any]` ↦ [{``column`` ↠ ``value``}, ..., {``column`` ↠ ``value``}]
-                    - :obj:`index` - :code:`dict[str, Any]` ↦ {``idx`` ↠ {``column`` ↠ ``value``}}
-                    - :obj:`table` - :code:`dict[str, Any]` ↦ {``schema``: { schema }, ``data``: { data }}
-            enforce_dtype: Enforce a certain data type. `dtype` must be specified at function
-                           signature. If you don't want to enforce a specific dtype then change
-                           ``enforce_dtype=False``.
-            enforce_shape: Enforce a certain shape. ``shape`` must be specified at function
-                           signature. If you don't want to enforce a specific shape then change
-                           ``enforce_shape=False``.
+            sample: Given sample ``pd.DataFrame`` data
 
         Returns:
             :class:`~bentoml._internal.io_descriptors.pandas.PandasSeries`: IODescriptor from given users inputs.
@@ -1095,8 +1051,7 @@ class PandasSeries(
         Process incoming protobuf request and convert it to ``pandas.Series``
 
         Args:
-            request: Incoming RPC request message.
-            context: grpc.ServicerContext
+            field: Incoming RPC request message.
 
         Returns:
             a ``pandas.Series`` object. This can then be used
@@ -1157,7 +1112,6 @@ class PandasSeries(
 
         Args:
             obj: ``pandas.Series`` that will be serialized to protobuf
-            context: grpc.aio.ServicerContext from grpc.aio.Server
         Returns:
             ``service_pb2.Response``:
                 Protobuf representation of given ``pandas.Series``

--- a/src/bentoml/_internal/models/model.py
+++ b/src/bentoml/_internal/models/model.py
@@ -318,7 +318,7 @@ class Model(StoreItem):
             name:
             max_batch_size:
             max_latency_ms:
-            runnable_method_configs:
+            method_configs:
 
         Returns:
 

--- a/src/bentoml/_internal/utils/analytics/usage_stats.py
+++ b/src/bentoml/_internal/utils/analytics/usage_stats.py
@@ -292,7 +292,6 @@ def get_metrics_report(
 
     Args:
         metrics_client: Instance of bentoml._internal.server.metrics.prometheus.PrometheusClient
-        grpc: Whether the metrics are for gRPC server.
 
     Returns:
         A tuple of a list of metrics and an optional boolean to determine whether the return metrics are legacy metrics.

--- a/src/bentoml/bentos.py
+++ b/src/bentoml/bentos.py
@@ -133,7 +133,6 @@ def import_bento(
     `FS URL documentation <https://docs.pyfilesystem.org/en/latest/openers.html>`_.
 
     Args:
-        tag: the tag of the bento to export
         path: can be one of two things:
               * a folder on the local filesystem
               * an `FS URL <https://docs.pyfilesystem.org/en/latest/openers.html>`_,

--- a/src/bentoml/models.py
+++ b/src/bentoml/models.py
@@ -105,7 +105,6 @@ def import_model(
     `FS URL documentation <https://docs.pyfilesystem.org/en/latest/openers.html>`_.
 
     Args:
-        tag: the tag of the model to export
         path: can be one of two things:
               * a folder on the local filesystem
               * an `FS URL <https://docs.pyfilesystem.org/en/latest/openers.html>`_, for example :code:`'s3://my_bucket/folder/my_model.bentomodel'`

--- a/src/bentoml/testing/server.py
+++ b/src/bentoml/testing/server.py
@@ -427,7 +427,7 @@ def host_bento(
     Host a bentoml service, yields the host URL.
 
     Args:
-        bento: a bento tag or :code:`module_path:service`
+        bento_name: a bento tag or :code:`module_path:service`
         project_path: the path to the project directory
         config_file: the path to the config file
         deployment_mode: the deployment mode, one of :code:`standalone`, :code:`docker` or :code:`distributed`


### PR DESCRIPTION
Forty `Args:` entries name a parameter the function does not take. Docstrings only — no signature, no behaviour, no test touched.

The largest group is in `io_descriptors`. Every `_from_sample` there takes exactly `(self, sample)`, but the docstrings still list the constructor keywords alongside it — `enforce_dtype`, `enforce_shape`, `apply_column_names`, `orient`, `default_format`, `pilmode`, `mime_type`, `allowed_mime_types`, `kind`, `json_encoder`, `**kwargs`. In `PandasSeries._from_sample` the one real argument was documented under the old name `sample_input`, so that became `sample` rather than being dropped.

Also in `io_descriptors`: all three `from_proto` methods take `field` but document `request` and `context`, and both `_to_proto_impl` methods document a `context` they do not receive.

Ten are renames:

| Where | Documented | Actual |
|---|---|---|
| `from_proto` (numpy, pandas ×2) | `request` | `field` |
| `PandasSeries._from_sample` | `sample_input` | `sample` |
| `ModelAPI.get` | `tag` | `name` |
| `fastai.save_model` | `learner` | `learner_` |
| `pytorch_lightning.load_model`, `torchscript.load_model` | `tag` | `bentoml_model` |
| `Model.to_runner` | `runnable_method_configs` | `method_configs` |
| `host_bento` | `bento` | `bento_name` |

The rest document something that is not an argument: `model_store` on the two `pytorch_lightning` entry points, `backend` on `OCIBuilder.__init__`, `grpc` on `get_metrics_report`, `columns` and `apply_column_names` on the `PandasSeries` class, and `tag` on `import_bento` and `import_model` — the last two copied from the matching `export_*` functions, which do take a tag.

Every entry was opened and read against its signature. `ruff check` and `ruff format --check` pass on all sixteen files with the pinned `ruff==0.15.12` from `.pre-commit-config.yaml`.
