### PR TITLE
docs: remove broken BentoYolo link from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For detailed explanations, read the [Hello World example](https://docs.bentoml.c
 - Image Generation: [Stable Diffusion 3 Medium](https://github.com/bentoml/BentoDiffusion/tree/main/sd3-medium), [Stable Video Diffusion](https://github.com/bentoml/BentoDiffusion/tree/main/svd), [Stable Diffusion XL Turbo](https://github.com/bentoml/BentoDiffusion/tree/main/sdxl-turbo), [ControlNet](https://github.com/bentoml/BentoDiffusion/tree/main/controlnet), and [LCM LoRAs](https://github.com/bentoml/BentoDiffusion/tree/main/lcm).
 - Embeddings: [SentenceTransformers](https://github.com/bentoml/BentoSentenceTransformers) and [ColPali](https://github.com/bentoml/BentoColPali)
 - Audio: [ChatTTS](https://github.com/bentoml/BentoChatTTS), [XTTS](https://github.com/bentoml/BentoXTTS), [WhisperX](https://github.com/bentoml/BentoWhisperX), [Bark](https://github.com/bentoml/BentoBark)
-- Computer Vision: [YOLO](https://github.com/bentoml/BentoYolo) and [ResNet](https://github.com/bentoml/BentoResnet)
+- Computer Vision: [ResNet](https://github.com/bentoml/BentoResnet)
 - Advanced examples: [Function calling](https://github.com/bentoml/BentoFunctionCalling), [LangGraph](https://github.com/bentoml/BentoLangGraph), [CrewAI](https://github.com/bentoml/BentoCrewAI)
 
 Check out the [full list](https://docs.bentoml.com/en/latest/examples/overview.html) for more sample code and usage.

--- a/docs/source/examples/overview.rst
+++ b/docs/source/examples/overview.rst
@@ -67,7 +67,6 @@ Computer vision
 
 Serve computer vision models with BentoML:
 
-- `YOLO: Object detection <https://github.com/bentoml/BentoYolo>`_
 - `ResNet: Image classification <https://github.com/bentoml/BentoResnet>`_
 - `EasyOCR: Optical character recognition <https://github.com/bentoml/BentoOCR>`_
 


### PR DESCRIPTION
## What does this PR address?

Fixes #5686

The `BentoYolo` repository (`https://github.com/bentoml/BentoYolo`) no longer exists and returns a 404 error. This PR removes the broken link from:

- `docs/source/examples/overview.rst` (Computer vision section)
- `README.md` (Examples section)

All other links in both files have been verified as valid.

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming?
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [x] Did your changes require updates to the documentation? Have you updated those accordingly?
- [ ] Did you write tests to cover your changes? *(N/A — docs-only change)*
