### PR TITLE
docs: replace self-referential Transformers guide link

### DIFF
--- a/docs/source/reference/bentoml/frameworks/transformers.rst
+++ b/docs/source/reference/bentoml/frameworks/transformers.rst
@@ -4,9 +4,11 @@ Transformers
 
 .. admonition:: About this page
 
-   This is an API reference for 🤗 Transformers in BentoML. Please refer to
-   :doc:`Transformers guide </reference/bentoml/frameworks/transformers>` for more information about how to use
-   Hugging Face Transformers in BentoML.
+   This is an API reference for 🤗 Transformers in BentoML. For an end-to-end
+   example that uses a Transformers pipeline, see the
+   :doc:`Hello World tutorial </get-started/hello-world>`. For guidance on
+   loading Hugging Face models in a Service, see
+   :doc:`Model loading and management </build-with-bentoml/model-loading-and-management>`.
 
 .. currentmodule:: bentoml.transformers
 


### PR DESCRIPTION
## What does this PR address?

Fixes #4541.

The Transformers API reference currently sends readers to itself as its only guide. This replaces that self-reference with the existing in-repository Hello World tutorial for a pipeline example and the model-loading guide for Hugging Face Service usage.

## Validation

- `pdm lock --check`
- `pre-commit run trailing-whitespace --files docs/source/reference/bentoml/frameworks/transformers.rst`
- `pre-commit run end-of-file-fixer --files docs/source/reference/bentoml/frameworks/transformers.rst`
- `PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib pdm run sphinx-build -b html docs/source /private/tmp/bentoml-docs-html` (completed successfully; the repository has pre-existing warnings outside this file)

## Before submitting:

- [x] The Pull Request follows Conventional Commits naming.
- [ ] `pre-commit run -a` was not run because this documentation-only change has no affected Python or proto files; the applicable file hooks above passed.
- [x] I read and followed the contribution and development guidelines.
- [x] Documentation was updated.
- [ ] No runtime test applies to this documentation-only correction; the documentation build was run instead.