### PR TITLE
fix: send one multipart part per URL in list file fields

### DIFF
--- a/src/_bentoml_impl/client/http.py
+++ b/src/_bentoml_impl/client/http.py
@@ -336,7 +336,11 @@ class HTTPClient(AbstractClient, t.Generic[C]):
             for v in value:
                 file = self._file_manager.get_file(v)
                 if isinstance(file, str):
-                    data[name] = file
+                    # URL-backed values are sent as multipart text parts
+                    # (filename=None) so a list field emits one same-name
+                    # part per value instead of overwriting earlier values
+                    # in the ``data`` dict.
+                    files.append((name, (None, file)))
                 else:
                     files.append((name, file))
         headers.pop("content-type", None)

--- a/src/_bentoml_impl/client/proxy2.py
+++ b/src/_bentoml_impl/client/proxy2.py
@@ -482,6 +482,7 @@ class AsyncClient(AbstractClient):
             fields = {t.cast(str, k): getattr(model, k) for k in model.model_fields}
         data: dict[str, t.Any] = {}
         files: list[tuple[str, tuple[str, t.IO[bytes], str | None]]] = []
+        url_parts: list[tuple[str, str]] = []
 
         for name, value in fields.items():
             if not is_file_field(name):
@@ -493,13 +494,18 @@ class AsyncClient(AbstractClient):
             for v in value:
                 file = self._file_manager.get_file(v)
                 if isinstance(file, str):
-                    data[name] = file
+                    # URL-backed values are added as text parts directly so
+                    # a list field emits one same-name part per value instead
+                    # of overwriting earlier values in the ``data`` dict.
+                    url_parts.append((name, file))
                 else:
                     files.append((name, file))
         headers.pop("content-type", None)
         payload = aiohttp.FormData()
         for key, val in data.items():
             payload.add_field(key, val)
+        for key, url in url_parts:
+            payload.add_field(key, url)
         for key, (filename, fileobj, content_type) in files:
             payload.add_field(
                 key,

--- a/src/_bentoml_impl/client/proxy2.py
+++ b/src/_bentoml_impl/client/proxy2.py
@@ -481,8 +481,7 @@ class AsyncClient(AbstractClient):
         else:
             fields = {t.cast(str, k): getattr(model, k) for k in model.model_fields}
         data: dict[str, t.Any] = {}
-        files: list[tuple[str, tuple[str, t.IO[bytes], str | None]]] = []
-        url_parts: list[tuple[str, str]] = []
+        file_parts: list[tuple[str, str | tuple[str, t.IO[bytes], str | None]]] = []
 
         for name, value in fields.items():
             if not is_file_field(name):
@@ -493,26 +492,25 @@ class AsyncClient(AbstractClient):
 
             for v in value:
                 file = self._file_manager.get_file(v)
-                if isinstance(file, str):
-                    # URL-backed values are added as text parts directly so
-                    # a list field emits one same-name part per value instead
-                    # of overwriting earlier values in the ``data`` dict.
-                    url_parts.append((name, file))
-                else:
-                    files.append((name, file))
+                # URL-backed values are text parts; binary values are file
+                # parts. Both stay in one ordered list so a mixed field keeps
+                # the caller's value order (a list field must not reorder).
+                file_parts.append((name, file))
         headers.pop("content-type", None)
         payload = aiohttp.FormData()
         for key, val in data.items():
             payload.add_field(key, val)
-        for key, url in url_parts:
-            payload.add_field(key, url)
-        for key, (filename, fileobj, content_type) in files:
-            payload.add_field(
-                key,
-                fileobj,
-                filename=filename,
-                content_type=content_type,
-            )
+        for key, part in file_parts:
+            if isinstance(part, str):
+                payload.add_field(key, part)
+            else:
+                filename, fileobj, content_type = part
+                payload.add_field(
+                    key,
+                    fileobj,
+                    filename=filename,
+                    content_type=content_type,
+                )
         return payload
 
     # ==========================

--- a/tests/unit/_internal/client/test_multipart.py
+++ b/tests/unit/_internal/client/test_multipart.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import typing as t
 from urllib.parse import parse_qs
 
@@ -58,6 +59,21 @@ def _async_client() -> AsyncClient:
     return client
 
 
+class _MixedFileManager(ClientFileManager):
+    """Pass both URL strings and binary file tuples through unchanged."""
+
+    def get_file(self, value: t.Any) -> t.Any:
+        if isinstance(value, str):
+            return value
+        return value
+
+
+def _async_mixed_client() -> AsyncClient:
+    client = object.__new__(AsyncClient)
+    client._file_manager = _MixedFileManager()
+    return client
+
+
 def _encode_aiohttp_form(form: t.Any) -> bytes:
     payload = form()
     value = getattr(payload, "_value", None)
@@ -107,3 +123,22 @@ class TestMultipartURLListField:
         assert parsed["files"] == [self.url_a, self.url_b], (
             "each URL in a list field must produce its own same-name part"
         )
+
+    def test_aiohttp_client_preserves_mixed_url_file_order(self):
+        client = _async_mixed_client()
+        fileobj = io.BytesIO(b"BBB")
+        form = client._build_multipart(
+            _files_endpoint(),
+            {
+                "files": [
+                    self.url_a,
+                    ("b.txt", fileobj, "text/plain"),
+                ]
+            },  # type: ignore[dict-item]
+            {"content-type": "multipart/form-data"},
+        )
+
+        fields = list(form._fields)
+        assert len(fields) == 2
+        assert fields[0][2] == self.url_a
+        assert fields[1][2] is fileobj

--- a/tests/unit/_internal/client/test_multipart.py
+++ b/tests/unit/_internal/client/test_multipart.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import asyncio
+import typing as t
+from urllib.parse import parse_qs
+
+import httpx
+
+from _bentoml_impl.client.base import ClientEndpoint
+from _bentoml_impl.client.base import ClientFileManager
+from _bentoml_impl.client.http import HTTPClient
+from _bentoml_impl.client.proxy2 import AsyncClient
+
+
+class _ConcreteHTTPClient(HTTPClient):
+    """Concrete stand-in so the abstract client can be instantiated."""
+
+    def _call(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
+        raise NotImplementedError
+
+    def _get_stream(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
+        raise NotImplementedError
+
+    def _submit(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
+        raise NotImplementedError
+
+
+class _URLOnlyFileManager(ClientFileManager):
+    """File manager whose URL values stay URL strings (no network fetch)."""
+
+    def get_file(self, value: t.Any) -> str | tuple[str, t.IO[bytes], str | None]:
+        if isinstance(value, str):
+            return value
+        return super().get_file(value)
+
+
+def _files_endpoint() -> ClientEndpoint:
+    return ClientEndpoint(
+        name="echo",
+        route="/echo",
+        input={
+            "properties": {"files": {"type": "array", "items": {"type": "file"}}},
+            "required": ["files"],
+        },
+    )
+
+
+def _http_client() -> HTTPClient:
+    client = object.__new__(_ConcreteHTTPClient)
+    client.client = httpx.Client()
+    client._file_manager = _URLOnlyFileManager()
+    return client
+
+
+def _async_client() -> AsyncClient:
+    client = object.__new__(AsyncClient)
+    client._file_manager = _URLOnlyFileManager()
+    return client
+
+
+def _encode_aiohttp_form(form: t.Any) -> bytes:
+    payload = form()
+    value = getattr(payload, "_value", None)
+    if value is not None:
+        return value
+    return asyncio.run(payload.read())
+
+
+class TestMultipartURLListField:
+    url_a = "https://files.example.invalid/a.txt"
+    url_b = "https://files.example.invalid/b.txt"
+
+    def test_httpx_client_sends_one_part_per_url(self):
+        client = _http_client()
+        request = client._build_multipart(
+            _files_endpoint(),
+            {"files": [self.url_a, self.url_b]},  # type: ignore[dict-item]
+            httpx.Headers(),
+        )
+        body = request.read()
+        assert body.count(b'name="files"') == 2, (
+            "each URL in a list field must produce its own same-name part"
+        )
+        assert b"https://files.example.invalid/a.txt" in body
+        assert b"https://files.example.invalid/b.txt" in body
+
+    def test_httpx_client_single_url_unchanged(self):
+        client = _http_client()
+        request = client._build_multipart(
+            _files_endpoint(),
+            {"files": [self.url_a]},  # type: ignore[dict-item]
+            httpx.Headers(),
+        )
+        assert request.read().count(b'name="files"') == 1
+
+    def test_aiohttp_client_sends_one_part_per_url(self):
+        client = _async_client()
+        form = client._build_multipart(
+            _files_endpoint(),
+            {"files": [self.url_a, self.url_b]},  # type: ignore[dict-item]
+            {"content-type": "multipart/form-data"},
+        )
+        body = _encode_aiohttp_form(form)
+        # URL-only forms are urlencoded; the server aggregates repeated
+        # field names via form.getlist, so both values must be present.
+        parsed = parse_qs(body.decode())
+        assert parsed["files"] == [self.url_a, self.url_b], (
+            "each URL in a list field must produce its own same-name part"
+        )


### PR DESCRIPTION
## What does this PR address?

Remote clients (HTTPX sync/async and the aiohttp proxy2 clients) serialise a `list[Path]` endpoint field with URL-backed values by writing each URL into the multipart `data` dict under the same field name. The dict can only hold one value per name, so every URL except the last is silently dropped before the request reaches the service.

Repro at current main (`73c4dbe`): a `list[Path]` field receiving `[url_a, url_b]` delivers only `[url_b]` to the service — reproduced through the HTTPX sync/async clients and the proxy2 client (issue #5675).

## Fix

- `http.py`: URL-backed values are appended to the multipart `files` list as text parts (`(name, (None, url))`) instead of overwriting the `data` dict entry, so a list field emits one same-name part per value.
- `proxy2.py`: URL-backed values are collected in `url_parts` and added to the `aiohttp.FormData` via repeated `add_field` calls, again producing one same-name field per value.

The server already aggregates repeated field names via `form.getlist(k)` in `MultipartSerde.parse_request`, so both clients now deliver the complete list.

## Test

New `tests/unit/_internal/client/test_multipart.py` builds multipart requests directly from both client implementations with an in-memory URL file manager and asserts one same-name part per URL:

```
PYTHONPATH=src python3 -m pytest tests/unit/_internal/client/test_multipart.py -q
3 passed
```

Neighbouring client and multipart io tests also pass (9 passed).

Fixes #5675
