### PR TITLE
fix: preserve latin-1 response header bytes in task result serde

### DIFF
--- a/src/_bentoml_impl/tasks/serde.py
+++ b/src/_bentoml_impl/tasks/serde.py
@@ -121,6 +121,7 @@ class JSONSerde(Serde):
             status_code=response_dict["status"],
         )
         response.raw_headers = [
-            tuple(map(str.encode, h)) for h in response_dict["headers"]
+            (k.encode(self.HEADERS_ENCODING), v.encode(self.HEADERS_ENCODING))
+            for k, v in response_dict["headers"]
         ]
         return response

--- a/tests/unit/bentoml_io/test_tasks_serde.py
+++ b/tests/unit/bentoml_io/test_tasks_serde.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+from starlette.responses import Response
+
+from _bentoml_impl.tasks.serde import JSONSerde
+
+
+@pytest.mark.asyncio
+async def test_response_headers_roundtrip_preserves_latin1_bytes():
+    serde = JSONSerde()
+    response = Response(content=b"ok", status_code=200)
+    response.raw_headers.append((b"x-raw-name", b"caf\xe9"))
+
+    data = await serde.serialize_response(response)
+    restored = await serde.deserialize_response(data)
+
+    restored_headers = dict(restored.raw_headers)
+    assert restored_headers[b"x-raw-name"] == b"caf\xe9"


### PR DESCRIPTION
## What does this PR address?

Task results are persisted to SQLite through `JSONSerde.serialize_response` and restored with `deserialize_response` (`src/_bentoml_impl/tasks/result.py`). The serialize side decodes raw header bytes as **latin-1** (Starlette `Headers.items()`), but the deserialize side re-encoded them with `str.encode()`, whose default is **utf-8**. Any response header containing non-ASCII latin-1 bytes — for example a `Content-Disposition` filename with accents — is silently mutated on the roundtrip: `b"r\xe9sum\xe9"` comes back as `b"r\xc3\xa9sum\xc3\xa9"`.

The request side of the same class already encodes/decodes symmetrically with `HEADERS_ENCODING` (iso-8859-1); the response side was the asymmetric one.

**Fix**: encode restored response headers with the same `HEADERS_ENCODING` charset instead of the utf-8 default, so the roundtrip is byte-exact.

## Test

Added `tests/unit/bentoml_io/test_tasks_serde.py` with `test_response_headers_roundtrip_preserves_latin1_bytes`: a response with a raw `b"caf\xe9"` header is serialized + deserialized and the raw header bytes are asserted to be unchanged. Fails on `main` (`b'caf\xc3\xa9' != b'caf\xe9'`), passes with the fix.

Local: `tests/unit/bentoml_io/test_tasks_serde.py` 1 passed; `ruff check` + `ruff format --check` clean (v0.15.12, repo pin).

`tests/unit/bentoml_io/test_decorators.py::test_mount_asgi_app{,_later}` fail locally with `ImportError: cannot import name '_HTTPStabilityMode' from 'opentelemetry.instrumentation._semconv'` — a pre-existing opentelemetry version mismatch in the local environment, unrelated to this change (the failing import happens before BentoML code is reached).

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming?
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated those accordingly?
- [x] Did you write tests to cover your changes?
