### PR TITLE
fix: mark task FAILED and persist a 500 response when the endpoint raises

### DIFF
--- a/src/_bentoml_impl/server/app.py
+++ b/src/_bentoml_impl/server/app.py
@@ -592,6 +592,21 @@ class ServiceAppFactory(BaseAppFactory):
             )
         except Exception:
             logger.exception("Task(%s) %s failed", name, task_id)
+            try:
+                await self._result_store.set_result(
+                    task_id,
+                    JSONResponse(
+                        {
+                            "error": "An unexpected error has occurred, please check the server log."
+                        },
+                        status_code=500,
+                    ),
+                    ResultStatus.FAILED,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to persist failure status for task %s", task_id
+                )
         else:
             logger.info("Task(%s) %s is completed", name, task_id)
 

--- a/tests/unit/bentoml_io/test_task_failure_status.py
+++ b/tests/unit/bentoml_io/test_task_failure_status.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+from starlette.requests import Request
+
+from _bentoml_impl.server.app import ServiceAppFactory
+from _bentoml_impl.tasks.result import ResultStatus
+from _bentoml_impl.tasks.result import Sqlite3Store
+from _bentoml_sdk import service
+from _bentoml_sdk import task
+
+
+def _make_request() -> Request:
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/process",
+            "raw_path": b"/process",
+            "query_string": b"",
+            "headers": [(b"host", b"testserver")],
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+        },
+        receive,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_task_persists_failed_status_when_endpoint_raises(
+    tmp_path, monkeypatch
+):
+    @service
+    class S:
+        @task
+        def process(self, x: str) -> str:
+            return x
+
+    factory = ServiceAppFactory(
+        service=S,
+        is_main=True,
+        enable_metrics=False,
+        services={S.name: {"traffic": {}, "workers": None}},
+        enable_access_control=False,
+        access_control_options={},
+    )
+    db_file = tmp_path / "results.db"
+    Sqlite3Store.init_db(str(db_file))
+    store = Sqlite3Store(str(db_file))
+    factory._result_store = store
+
+    async def boom(name, request):
+        raise RuntimeError("endpoint exploded")
+
+    monkeypatch.setattr(factory, "api_endpoint_wrapper", boom)
+
+    request = _make_request()
+    async with store:
+        with S.context.in_request(request):
+            task_id = await store.new_entry("process", request)
+            await factory._run_task(task_id, "process", request)
+        row = await store.get(task_id)
+
+    assert row.status == ResultStatus.FAILED
+    assert row.completed_at is not None
+    assert row.result.status_code == 500


### PR DESCRIPTION
## What does this PR address?

In the new-SDK task pipeline (`ServiceAppFactory._run_task`, `src/_bentoml_impl/server/app.py`), when the endpoint wrapper raised an exception the handler only logged it and returned. The task row stayed `IN_PROGRESS` forever:

- `GET /status` never reached a terminal state.
- `GET /get` returned `400 "task is not completed yet"` indefinitely, so polling clients hang until the 24h retention silently deletes the row (then it becomes a confusing 404).
- `/retry` was unreachable (it reads the row via `get()`, which raises `RuntimeError` while `completed_at` is NULL).

`ResultStatus.FAILED` was only reachable when the endpoint *returned* an HTTP ≥400 response, never when it raised — so exception failures were invisible in the state machine.

**Fix**: in the exception path, persist a `FAILED` status and a 500 error response via `set_result` (which also sets `completed_at`), mirroring the message already used for unexpected errors elsewhere in the module. If persisting itself fails (e.g. DB down), log and let the background task end instead of raising from the handler.

## Test

Added `tests/unit/bentoml_io/test_task_failure_status.py`: builds a real `ServiceAppFactory` + `Sqlite3Store`, submits a task, makes the endpoint wrapper raise, runs `_run_task`, and asserts the stored row is `FAILED` with `completed_at` set and a 500 response. Fails on `main` (`RuntimeError: Task ... is not completed`), passes with the fix.

Local: `tests/unit/bentoml_io` 14 passed; the 2 pre-existing `test_mount_asgi_app{,_later}` failures are an opentelemetry `_HTTPStabilityMode` ImportError in the local environment (fail on `main` too, unrelated to this change). `ruff check` + `ruff format --check` clean (v0.15.12).

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming?
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated those accordingly?
- [x] Did you write tests to cover your changes?
