### PR TITLE
fix: stop cancel_task from wedging the task row in a half-canceled state

### DIFF
--- a/src/_bentoml_impl/server/app.py
+++ b/src/_bentoml_impl/server/app.py
@@ -571,7 +571,11 @@ class ServiceAppFactory(BaseAppFactory):
             resp = JSONResponse({"error": "task_id is required"}, status_code=400)
             self._add_response_headers(resp)
             return resp
-        await self._result_store.set_status(task_id, ResultStatus.CANCELED)
+        # Cancellation is not supported in the local development server:
+        # return the not-supported error WITHOUT mutating the task row. The
+        # previous set_status(CANCELED) left the task wedged — /status reported
+        # canceled while /get and /retry kept returning 400 "not completed
+        # yet" forever (completed_at stays NULL on the set_status path).
         resp = JSONResponse(
             {"error": "task cancellation is not supported in local development server"},
             status_code=400,

--- a/tests/unit/bentoml_io/test_task_cancel_noop.py
+++ b/tests/unit/bentoml_io/test_task_cancel_noop.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+from starlette.requests import Request
+
+from _bentoml_impl.server.app import ServiceAppFactory
+from _bentoml_impl.tasks.result import ResultStatus
+from _bentoml_impl.tasks.result import Sqlite3Store
+from _bentoml_sdk import service
+from _bentoml_sdk import task
+
+
+def _make_request(query: dict[str, str]) -> Request:
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    query_string = "&".join(f"{k}={v}" for k, v in query.items()).encode()
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "PUT",
+            "scheme": "http",
+            "path": "/process/cancel",
+            "raw_path": b"/process/cancel",
+            "query_string": query_string,
+            "headers": [(b"host", b"testserver")],
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+        },
+        receive,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_does_not_mutate_status(tmp_path, monkeypatch):
+    @service
+    class S:
+        @task
+        def process(self, x: str) -> str:
+            return x
+
+    factory = ServiceAppFactory(
+        service=S,
+        is_main=True,
+        enable_metrics=False,
+        services={S.name: {"traffic": {}, "workers": None}},
+        enable_access_control=False,
+        access_control_options={},
+    )
+    db_file = tmp_path / "results.db"
+    Sqlite3Store.init_db(str(db_file))
+    store = Sqlite3Store(str(db_file))
+    factory._result_store = store
+
+    request = _make_request({})
+    async with store:
+        with S.context.in_request(request):
+            task_id = await store.new_entry("process", request)
+
+        cancel_request = _make_request({"task_id": task_id})
+        resp = await factory.cancel_task(cancel_request)
+
+        assert resp.status_code == 400
+        row = await store.get_status(task_id)
+        assert row.status == ResultStatus.IN_PROGRESS


### PR DESCRIPTION
## What does this PR address?

`cancel_task` (the `PUT /.../cancel` route in `ServiceAppFactory`) marked the task row `CANCELED` via `set_status`, then returned `400 "task cancellation is not supported in local development server"`. Two problems:

1. **The response contradicts the mutation** — the client is told cancellation failed, while the task row actually changed to `CANCELED`.
2. **The task ends up wedged** — `set_status` updates `executed_at` but never `completed_at`, so afterwards `/status` reports `canceled` while `/get` and `/retry` keep returning `400 "not completed yet"` forever. The row is stuck in a half-canceled state that no other endpoint can move.

Cancellation is genuinely not supported in the local development server (the background task keeps running), so the honest behavior is to return the not-supported error **without mutating the row**, letting the task run to completion.

## Fix

Removed the `set_status(CANCELED)` mutation from `cancel_task` (src/_bentoml_impl/server/app.py), with a comment explaining why the mutation must not come back.

## Test

Added `tests/unit/bentoml_io/test_task_cancel_noop.py`: builds a real `ServiceAppFactory` + `Sqlite3Store`, submits a task, calls `cancel_task`, and asserts the response is 400 **and** the stored status is still `IN_PROGRESS` (fails on main, where the status flips to `CANCELED`).

Local: the new test 1 passed (pre-fix FAIL verified); `test_task_failure_status.py` still passes; ruff 0.15.12 check + format clean on both changed files.

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming?
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated those accordingly?
- [x] Did you write tests to cover your changes?