### PR TITLE
docs: fix broken YOLO repository link in documentation and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For detailed explanations, read the [Hello World example](https://docs.bentoml.c
 - Image Generation: [Stable Diffusion 3 Medium](https://github.com/bentoml/BentoDiffusion/tree/main/sd3-medium), [Stable Video Diffusion](https://github.com/bentoml/BentoDiffusion/tree/main/svd), [Stable Diffusion XL Turbo](https://github.com/bentoml/BentoDiffusion/tree/main/sdxl-turbo), [ControlNet](https://github.com/bentoml/BentoDiffusion/tree/main/controlnet), and [LCM LoRAs](https://github.com/bentoml/BentoDiffusion/tree/main/lcm).
 - Embeddings: [SentenceTransformers](https://github.com/bentoml/BentoSentenceTransformers) and [ColPali](https://github.com/bentoml/BentoColPali)
 - Audio: [ChatTTS](https://github.com/bentoml/BentoChatTTS), [XTTS](https://github.com/bentoml/BentoXTTS), [WhisperX](https://github.com/bentoml/BentoWhisperX), [Bark](https://github.com/bentoml/BentoBark)
-- Computer Vision: [YOLO](https://github.com/bentoml/BentoYolo) and [ResNet](https://github.com/bentoml/BentoResnet)
+- Computer Vision: [ResNet](https://github.com/bentoml/BentoResnet) and [EasyOCR](https://github.com/bentoml/BentoOCR)
 - Advanced examples: [Function calling](https://github.com/bentoml/BentoFunctionCalling), [LangGraph](https://github.com/bentoml/BentoLangGraph), [CrewAI](https://github.com/bentoml/BentoCrewAI)
 
 Check out the [full list](https://docs.bentoml.com/en/latest/examples/overview.html) for more sample code and usage.

--- a/docs/source/examples/overview.rst
+++ b/docs/source/examples/overview.rst
@@ -67,7 +67,6 @@ Computer vision
 
 Serve computer vision models with BentoML:
 
-- `YOLO: Object detection <https://github.com/bentoml/BentoYolo>`_
 - `ResNet: Image classification <https://github.com/bentoml/BentoResnet>`_
 - `EasyOCR: Optical character recognition <https://github.com/bentoml/BentoOCR>`_
 


### PR DESCRIPTION
## Description

Fixes #5686.

The link to \https://github.com/bentoml/BentoYolo\ under Computer Vision in \README.md\ and \docs/source/examples/overview.rst\ returned 404 Not Found.

This PR updates the Computer Vision examples in the \README.md\ and \docs/source/examples/overview.rst\ to link to the active [BentoResnet](https://github.com/bentoml/BentoResnet) and [BentoOCR](https://github.com/bentoml/BentoOCR) example repositories.

## Changes
- \README.md\: update Computer Vision line to link to \BentoResnet\ and \BentoOCR\.
- \docs/source/examples/overview.rst\: remove 404 \BentoYolo\ entry and retain \BentoResnet\ and \BentoOCR\.