### PR TITLE
fix: distinguish task cancel OpenAPI operation IDs

### DIFF
--- a/src/_bentoml_sdk/service/openapi.py
+++ b/src/_bentoml_sdk/service/openapi.py
@@ -211,9 +211,9 @@ def _get_api_routes(svc: Service[t.Any]) -> dict[str, PathItem]:
                         **error_responses,
                     },
                     "tags": [APP_TAG.name],
-                    "x-bentoml-name": f"{api.name}_retry",
+                    "x-bentoml-name": f"{api.name}_cancel",
                     "description": f"Cancel an in-progress task of {api.name}",
-                    "operationId": f"{svc.name}__{api.name}_retry",
+                    "operationId": f"{svc.name}__{api.name}_cancel",
                     "parameters": [
                         {
                             "name": "task_id",

--- a/tests/unit/_bentoml_sdk/test_openapi.py
+++ b/tests/unit/_bentoml_sdk/test_openapi.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import bentoml
+
+
+def test_task_cancel_openapi_operation_name() -> None:
+    @bentoml.service
+    class TaskService:
+        @bentoml.task
+        def predict(self, value: int) -> int:
+            return value
+
+    spec = TaskService.openapi_spec.asdict()
+    retry_operation = spec["paths"]["/predict/retry"]["post"]
+    cancel_operation = spec["paths"]["/predict/cancel"]["put"]
+
+    assert retry_operation["x-bentoml-name"] == "predict_retry"
+    assert retry_operation["operationId"] == "TaskService__predict_retry"
+    assert cancel_operation["x-bentoml-name"] == "predict_cancel"
+    assert cancel_operation["operationId"] == "TaskService__predict_cancel"


### PR DESCRIPTION
## What does this PR address?

Task API OpenAPI generation currently labels both the retry and cancel routes with the retry operation name and ID. This produces duplicate `operationId` values and causes generated clients and OpenAPI tooling to identify the cancel endpoint as a retry operation.

This change:

- gives the cancel route its own `<api>_cancel` BentoML name;
- gives it a unique `<service>__<api>_cancel` OpenAPI operation ID;
- adds a regression test covering the retry and cancel operation metadata.

The runtime task behavior and route paths are unchanged.

### Validation

- `python -m pytest tests/unit/_bentoml_sdk/test_openapi.py tests/e2e/bento_new_sdk/test_asgi.py -q` (5 passed)
- `pre-commit run --all-files`

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming?
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed?
- [x] Did you read through the contribution guidelines and follow the development guidelines?
- [x] Documentation updates are not required because this corrects generated metadata without changing the public routes or task behavior.
- [x] Did you write tests to cover your changes?
