### PR TITLE
fix: close CGNAT/reserved-range gaps in make_safe_connect SSRF guard

### DIFF
--- a/src/bentoml/_internal/utils/uri.py
+++ b/src/bentoml/_internal/utils/uri.py
@@ -58,6 +58,12 @@ def is_http_url(url: str) -> bool:
 
 original_create_connection = None
 
+# Networks that are never valid targets for user-supplied URLs on top of what
+# ipaddress already classifies as private/loopback/link-local/reserved:
+# - 100.64.0.0/10 (RFC 6598 shared address space / CGNAT) is not globally
+#   routable, but ipaddress does not flag it via any built-in property (#5644).
+BLOCKED_IP_NETWORKS = (ipaddress.ip_network("100.64.0.0/10"),)
+
 
 @contextlib.contextmanager
 def make_safe_connect():
@@ -91,7 +97,17 @@ def make_safe_connect():
             except ValueError:
                 raise socket.gaierror(f"Blocked invalid IP address {host}")
             else:
-                if ip.is_private or ip.is_loopback or ip.is_link_local:
+                # Unwrap IPv4-mapped IPv6 literals (e.g. ::ffff:100.64.1.1) so
+                # every check below sees the embedded IPv4 address.
+                if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+                    ip = ip.ipv4_mapped
+                if (
+                    ip.is_private
+                    or ip.is_loopback
+                    or ip.is_link_local
+                    or ip.is_reserved
+                    or any(ip in net for net in BLOCKED_IP_NETWORKS)
+                ):
                     raise socket.gaierror(f"Blocked private IP address {host}")
         return await original_create_connection(
             self, protocol_factory, host=host, port=port, **kwargs

--- a/tests/unit/_internal/utils/test_uri.py
+++ b/tests/unit/_internal/utils/test_uri.py
@@ -32,3 +32,91 @@ def test_uri_path_conversion(
     for path in example_paths:
         restored = uri_to_path(path_to_uri(path))
         assert restored == path or restored == os.path.abspath(path)
+
+
+def _seed_fake_original(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Stub the 'original' create_connection so blocked targets never dial out."""
+    from bentoml._internal.utils import uri
+
+    attempts: list[str] = []
+
+    async def fake_original(self, protocol_factory, host=None, port=None, **kwargs):  # type: ignore[no-untyped-def]
+        assert host is not None
+        attempts.append(host)
+        return object()  # sentinel; the real connect is never reached
+
+    monkeypatch.setattr(uri, "original_create_connection", fake_original, raising=False)
+    return attempts
+
+
+@pytest.mark.asyncio
+async def test_safe_connect_blocks_cgnat_range(monkeypatch: pytest.MonkeyPatch) -> None:
+    """100.64.0.0/10 (RFC 6598 CGNAT) must be rejected (#5644)."""
+    import socket
+
+    import uvloop
+
+    from bentoml._internal.utils import uri
+
+    _seed_fake_original(monkeypatch)
+    with uri.make_safe_connect(), pytest.raises(socket.gaierror):
+        await uvloop.Loop.create_connection(
+            None,
+            None,
+            host="100.64.1.1",
+            port=80,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    ("host", "blocked"),
+    [
+        # RFC 6598 boundaries: block exactly 100.64.0.0 - 100.127.255.255.
+        ("100.63.255.255", False),
+        ("100.64.0.0", True),
+        ("100.96.0.1", True),
+        ("100.127.255.255", True),
+        ("100.128.0.0", False),
+        # IPv4-mapped IPv6 literals resolve to their embedded IPv4 address.
+        ("::ffff:100.64.1.1", True),
+        ("::ffff:192.168.0.1", True),
+        ("::ffff:8.8.8.8", False),
+        # Pre-existing CVE-2025-54381 behavior still holds.
+        ("192.168.0.1", True),
+        ("10.0.0.7", True),
+        ("127.0.0.1", True),
+        ("169.254.169.254", True),
+        # Public addresses pass through to the underlying connect.
+        ("8.8.8.8", False),
+        # Reserved ranges are now covered too.
+        ("240.0.0.1", True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_safe_connect_target_policy(
+    host: str, blocked: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import socket
+
+    import uvloop
+
+    from bentoml._internal.utils import uri
+
+    attempts = _seed_fake_original(monkeypatch)
+    with uri.make_safe_connect():
+        if blocked:
+            with pytest.raises(socket.gaierror):
+                await uvloop.Loop.create_connection(
+                    None,
+                    None,
+                    host=host,
+                    port=80,  # type: ignore[arg-type]
+                )
+        else:
+            await uvloop.Loop.create_connection(
+                None,
+                None,
+                host=host,
+                port=80,  # type: ignore[arg-type]
+            )
+        assert (host in attempts) is not blocked


### PR DESCRIPTION
Closes #5644

## Root cause

`make_safe_connect()` (added for CVE-2025-54381 / GHSA-mrmq-3q62-6cc8) rejects `private`/`loopback`/`link_local` targets, but Python's `ipaddress` has no dedicated flag for **RFC 6598 shared address space (100.64.0.0/10)** — so a user-supplied URL like `http://100.64.1.1/internal` reached the real connect instead of raising, exactly as reported in #5644.

## Fix (`src/bentoml/_internal/utils/uri.py`)

1. **CGNAT blocklist**: new module-level `BLOCKED_IP_NETWORKS = (ip_network("100.64.0.0/10"),)` checked alongside the existing properties. Kept as an explicit tuple so future non-routable ranges can be appended without touching the guard.
2. **Reserved ranges**: `ip.is_reserved` added per the issue's suggested fix.
3. **IPv4-mapped unwrapping** (found while analyzing sibling bypasses): `::ffff:100.64.1.1` previously passed every check because the mapped address itself is none of private/loopback/link-local/reserved; the guard now unwraps `ipv4_mapped` before evaluating. (For the pre-existing property checks modern CPython already delegates to the embedded IPv4 — this makes the behavior explicit and version-independent.)

Error type/message and the proxy exemption path are unchanged.

## Tests (`tests/unit/_internal/utils/test_uri.py`, +88 lines)

Driven through the real patched `Loop.create_connection` with the original connect stubbed, so no sockets are touched:

- CGNAT boundary matrix: `100.63.255.255` allowed / `100.64.0.0`, `100.96.0.1`, `100.127.255.255` blocked / `100.128.0.0` allowed
- Mapped literals: `::ffff:100.64.1.1`, `::ffff:192.168.0.1` blocked; `::ffff:8.8.8.8` passes
- Pre-existing CVE-2025-54381 behavior pinned: RFC1918, loopback, link-local still blocked
- Public pass-through asserted via stub call recording

Red→green verified against the pre-fix tree: 5 failed / 11 passed → **16 passed** after the fix. `ruff check` + `ruff format --check` clean on both touched files (the two remaining findings in them pre-date this change).
