### PR TITLE
fix: reject control characters in docker.env values (Dockerfile injection)

### DIFF
--- a/src/bentoml/_internal/bento/build_config.py
+++ b/src/bentoml/_internal/bento/build_config.py
@@ -98,6 +98,41 @@ def _convert_cuda_version(
     )
 
 
+# Control characters (including newline/carriage return) must never appear in
+# env keys or values: Dockerfile instructions are newline-delimited and quotes
+# do not span lines, so a raw control character would terminate the ARG/ENV
+# instruction and any following lines are executed as instructions.
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _validate_env_entry(key: str, value: str) -> None:
+    if _CONTROL_CHARS_RE.search(key) or _CONTROL_CHARS_RE.search(value):
+        raise BentoMLException(
+            f"Invalid environment entry '{key}': environment names and values must not contain "
+            "newline or control characters, as they would break out of the generated Dockerfile's "
+            "ARG/ENV instruction. Use the `env` list form or an `.env` file for complex values."
+        )
+
+
+def _validate_bento_env_name(
+    instance: t.Any, attribute: attr.Attribute[str], value: str
+) -> None:
+    if not value or _CONTROL_CHARS_RE.search(value):
+        raise BentoMLException(
+            f"Environment name must be a non-empty string without control characters, got {value!r}"
+        )
+
+
+def _validate_bento_env_value(
+    instance: t.Any, attribute: attr.Attribute[str], value: str
+) -> None:
+    if _CONTROL_CHARS_RE.search(value):
+        raise BentoMLException(
+            f"Environment values must not contain newline or control characters (they would break out of the "
+            f"generated Dockerfile's ARG/ENV instruction), got {value!r}"
+        )
+
+
 def _convert_env(
     env: str | list[str] | dict[str, str] | None,
 ) -> dict[str, str] | dict[str, str | None] | None:
@@ -136,8 +171,15 @@ def _convert_env(
         return env_dict
 
     if isinstance(env, dict):
-        # convert all dict key and values to string
-        return {str(k): str(v) for k, v in env.items()}
+        # convert all dict key and values to string, rejecting control
+        # characters that could inject Dockerfile instructions (GHSA-class
+        # issue: bentofile `docker.env` values are interpolated into ARG/ENV)
+        converted: dict[str, str] = {}
+        for k, v in env.items():
+            key, value = str(k), str(v)
+            _validate_env_entry(key, value)
+            converted[key] = value
+        return converted
 
     raise BentoMLException(
         f"`env` must be either a list, a dict, or a path to a dot environment file, got type '{type(env)}' instead."
@@ -780,8 +822,9 @@ EnvStage = t.Literal["all", "build", "runtime"]
 @attr.define(eq=True)
 class BentoEnvSchema:
     __forbid_extra_keys__ = False
-    name: str
-    value: str = ""
+
+    name: str = attr.field(validator=_validate_bento_env_name)
+    value: str = attr.field(default="", validator=_validate_bento_env_value)
     stage: EnvStage = attr.field(
         default="all",
         validator=attr.validators.in_(("all", "build", "runtime")),

--- a/tests/unit/_internal/container/test_generate.py
+++ b/tests/unit/_internal/container/test_generate.py
@@ -64,3 +64,49 @@ def test_generate_containerfile_normalizes_custom_base_image(tmp_path) -> None:
 
     assert "FROM python:3.11-slim RUN touch /tmp/pwned as base-container" in dockerfile
     assert "\nRUN touch /tmp/pwned" not in dockerfile
+
+
+def test_generate_containerfile_rejects_newline_in_env_dict(tmp_path) -> None:
+    import pytest
+
+    from bentoml.exceptions import BentoMLException
+
+    with pytest.raises(BentoMLException, match="control characters"):
+        DockerOptions(
+            distro="debian",
+            python_version="3.11",
+            env={"X": "a\nRUN echo PWNED_VIA_ENV_INJECTION\n"},
+        )
+
+
+def test_generate_containerfile_allows_plain_env_dict_values(tmp_path) -> None:
+    dockerfile = generate_containerfile(
+        DockerOptions(
+            distro="debian",
+            python_version="3.11",
+            env={"GREETING": "hello world", "API_URL": "http://host:8080/v1"},
+        ),
+        str(tmp_path),
+        conda=CondaOptions(),
+        bento_fs=tmp_path,
+    )
+
+    assert "ARG GREETING=hello world" in dockerfile
+    assert "ARG API_URL=http://host:8080/v1" in dockerfile
+    # no instruction injection from env values
+    assert "PWNED" not in dockerfile
+
+
+def test_bento_env_schema_rejects_control_chars() -> None:
+    import pytest
+
+    from bentoml._internal.bento.build_config import BentoEnvSchema
+    from bentoml.exceptions import BentoMLException
+
+    with pytest.raises(BentoMLException, match="control characters"):
+        BentoEnvSchema(name="X", value="a\nRUN echo PWNED")
+    with pytest.raises(BentoMLException, match="Environment name"):
+        BentoEnvSchema(name="WEIRD\nNAME", value="ok")
+    # legit entries still construct
+    env = BentoEnvSchema(name="GREETING", value="hello world", stage="runtime")
+    assert env.name == "GREETING"


### PR DESCRIPTION
Fixes #5656

## Root cause

Dict-form `docker.env` entries were interpolated into the generated Dockerfile completely raw (`ARG {{ key }}={{ value }}` in `base.j2`), while sibling paths were already hardened:

- list-form `env` → regex-validated in `_convert_env` (`build_config.py`)
- `system_packages` → `bash_quote`
- `base_image` → `normalize_line`

A newline in a value terminates the `ARG` instruction — Dockerfile instructions are newline-delimited and quotes do **not** span lines, so any following lines execute as instructions at build time (reproduced offline via `generate_containerfile`; the reporter's exact payload renders a live `RUN echo PWNED...` step).

## Fix (`src/bentoml/_internal/bento/build_config.py`, +45/-3)

1. **Dict branch of `_convert_env`**: keys/values are checked against a control-character class (`[\x00-\x1f\x7f]`) and raise `BentoMLException` with guidance to use the list form or an `.env` file for complex values. This is the single choke point every template renders from, so v1/v2/debian/alpine/ubi8 are all covered.
   - Plain values keep working byte-identically: spaces are legal unquoted on `ARG KEY=value` lines (`{"GREETING": "hello world"}` renders exactly as before).
2. **`BentoEnvSchema` (the v2 `envs:` path)**: same guard added as attr validators on `name`/`value`. The issue notes this path as "hardened", but `bash_quote` only wraps in single quotes — a raw newline inside still breaks the instruction, so the guard is needed at definition time.

## Tests (`tests/unit/_internal/container/test_generate.py`, +40 lines)

Following the existing same-family patterns (`test_generate_containerfile_quotes_system_packages`, `..._normalizes_custom_base_image`):

- newline payload in dict env raises `BentoMLException` at `DockerOptions` construction (before any template rendering)
- legit values (`"hello world"`, URL) render unchanged and no payload appears
- `BentoEnvSchema` rejects control chars in value and name, accepts legit entries

Red→green verified against the pre-fix tree: 5 passed → **8 passed** (the 3 new tests fail without the fix; the reporter's repro script also flips from "Injection present: True" to raising at construction). `ruff check`/`format --check`: zero new findings vs. baseline on both touched files.
