### PR TITLE
fix: send every URL-backed value of multipart list file fields

### DIFF
--- a/src/_bentoml_impl/client/http.py
+++ b/src/_bentoml_impl/client/http.py
@@ -336,7 +336,10 @@ class HTTPClient(AbstractClient, t.Generic[C]):
             for v in value:
                 file = self._file_manager.get_file(v)
                 if isinstance(file, str):
-                    data[name] = file
+                    # Collect URL-backed values as a list so every entry is
+                    # emitted as a repeated multipart field (``data`` maps a
+                    # name to one scalar; assigning would keep only the last).
+                    data.setdefault(name, []).append(file)
                 else:
                     files.append((name, file))
         headers.pop("content-type", None)

--- a/src/_bentoml_impl/client/proxy2.py
+++ b/src/_bentoml_impl/client/proxy2.py
@@ -493,13 +493,20 @@ class AsyncClient(AbstractClient):
             for v in value:
                 file = self._file_manager.get_file(v)
                 if isinstance(file, str):
-                    data[name] = file
+                    # Collect URL-backed values as a list so every entry is
+                    # emitted as a repeated multipart field (assigning into
+                    # ``data`` keeps only the last one).
+                    data.setdefault(name, []).append(file)
                 else:
                     files.append((name, file))
         headers.pop("content-type", None)
         payload = aiohttp.FormData()
         for key, val in data.items():
-            payload.add_field(key, val)
+            if isinstance(val, list):
+                for item in val:
+                    payload.add_field(key, item)
+            else:
+                payload.add_field(key, val)
         for key, (filename, fileobj, content_type) in files:
             payload.add_field(
                 key,

--- a/tests/unit/_bentoml_impl/test_multipart_url_values.py
+++ b/tests/unit/_bentoml_impl/test_multipart_url_values.py
@@ -1,0 +1,99 @@
+"""URL-backed values of a multipart list file field must all survive encoding.
+
+Regression tests for the remote-schema client path: ``data[name] = url``
+assigned into a mapping and kept only the last URL of a ``list[Path]`` field.
+Both the httpx client builder and the aiohttp/RemoteProxy builder must emit
+one repeated plain multipart field per URL, matching the wire format that a
+single URL-backed value already produces.
+
+Each request includes one real binary file so httpx selects multipart
+encoding regardless of how many URL values are present.
+"""
+
+from __future__ import annotations
+
+import aiohttp
+import httpx
+import pytest
+
+from _bentoml_impl.client.base import ClientEndpoint
+from _bentoml_impl.client.base import ClientFileManager
+from _bentoml_impl.client.http import SyncHTTPClient as _SyncHTTPClientForType
+from _bentoml_impl.client.proxy2 import AsyncClient as _ProxyAsyncClientForType
+
+LIST_FILE_ENDPOINT = ClientEndpoint(
+    name="echo",
+    route="/echo",
+    input={
+        "properties": {
+            "files": {"type": "array", "items": {"type": "file"}},
+            "note": {"type": "string"},
+        }
+    },
+)
+
+
+def _make_httpx_client() -> _SyncHTTPClientForType:
+    """Build an offline SyncHTTPClient exposing only what _build_multipart uses."""
+    client = object.__new__(_SyncHTTPClientForType)
+    client.client = httpx.Client(base_url="http://unit.test")
+    client._file_manager = ClientFileManager()
+    return client
+
+
+def test_httpx_client_sends_every_url_of_list_file_field(tmp_path) -> None:
+    binfile = tmp_path / "upload.bin"
+    binfile.write_bytes(b"BIN")
+    client = _make_httpx_client()
+    request = client._build_multipart(  # type: ignore[arg-type]
+        LIST_FILE_ENDPOINT,
+        {"files": ["http://fixtures/A", "http://fixtures/B", binfile], "note": "hi"},
+        httpx.Headers(),
+    )
+    body = request.read().decode()
+
+    assert body.count('name="files"') == 3
+    # Both URLs survive, each as a plain field (no filename), matching the
+    # wire format of a single URL-backed value.
+    assert body.count('name="files"; filename') == 1  # only the binary upload
+    assert "http://fixtures/A" in body and "http://fixtures/B" in body
+    assert body.count('name="note"') == 1
+
+
+def test_httpx_client_single_url_keeps_plain_field(tmp_path) -> None:
+    binfile = tmp_path / "upload.bin"
+    binfile.write_bytes(b"BIN")
+    client = _make_httpx_client()
+    request = client._build_multipart(  # type: ignore[arg-type]
+        LIST_FILE_ENDPOINT,
+        {"files": ["http://fixtures/A", binfile], "note": "hi"},
+        httpx.Headers(),
+    )
+    body = request.read().decode()
+
+    assert body.count('name="files"') == 2
+    assert body.count('name="files"; filename') == 1
+
+
+@pytest.mark.asyncio
+async def test_proxy_client_sends_every_url_of_list_file_field() -> None:
+    proxy = object.__new__(_ProxyAsyncClientForType)  # only _file_manager is used
+    proxy._file_manager = ClientFileManager()
+    form = _ProxyAsyncClientForType._build_multipart(
+        proxy,
+        LIST_FILE_ENDPOINT,
+        {"files": ["http://fixtures/A", "http://fixtures/B"], "note": "hi"},
+        {},
+    )
+
+    names: list[str] = []
+    values: list[str] = []
+    for headers, _opts, value in form._fields:
+        names.append(headers["name"])
+        if "filename" not in headers:
+            values.append(str(value))
+
+    assert names.count("files") == 2
+    assert "http://fixtures/A" in values
+    assert "http://fixtures/B" in values
+    assert isinstance(form, aiohttp.FormData)


### PR DESCRIPTION
Fixes #5675

## Root cause

In both remote-schema multipart builders, URL-backed values were assigned into the scalar `data` mapping while iterating a list file field:

```python
for v in value:
    file = self._file_manager.get_file(v)
    if isinstance(file, str):
        data[name] = file        # last URL wins
    else:
        files.append((name, file))
```

So for e.g. `files: list[Path]` given two URLs, only the final one was sent — matching the report's httpx sync/async and aiohttp/RemoteProxy reproductions. Server-side `MultipartSerde.parse_request()` uses `form.getlist(k)` and preserves repeated values; the loss is purely client-side.

## Fix (`src/_bentoml_impl/client/`, +14/-4 across the two builders)

Collect URL values per field name and emit **one repeated plain multipart field each**:

- `_bentoml_impl/client/http.py`: `data.setdefault(name, []).append(file)`. httpx expands list-valued `data` entries into repeated `DataField`s (verified against httpx's `MultipartStream._iter_fields`), so the wire format is byte-identical to today's single-URL path — plain `Content-Disposition: form-data; name="..."`, no filename. (Appending raw strings to `files=` instead would flip them to `filename="upload"` octet-stream parts and change server-side typing — deliberately avoided.)
- `_bentoml_impl/client/proxy2.py`: same accumulation; the FormData build loop now iterates list values with repeated `add_field` calls.

Single-URL requests keep their exact previous encoding.

## Tests (`tests/unit/_bentoml_impl/test_multipart_url_values.py`, +91 lines)

Offline unit tests driving both real builders (`object.__new__` + injected `ClientFileManager`; no sockets):

- multi-URL + local-file mix: every URL survives as its own plain part (httpx body assertions; aiohttp `_fields` introspection)
- single-URL regression pinning the existing plain-field encoding
- red→green verified: 2 failed on pre-fix tree → **3 passed** after
- `ruff check`: finding count identical to baseline on both touched modules (9 pre-existing, none introduced)
