### PR TITLE
fix(test): stop the static_http e2e fixture from hanging the CI job

### DIFF
--- a/tests/e2e/fixtures/static_http/service.py
+++ b/tests/e2e/fixtures/static_http/service.py
@@ -6,6 +6,13 @@ import bentoml
 THIS_DIR = Path(__file__).parent
 
 
+# `workers: 1` is required, not a tuning choice: the command below binds a fixed
+# port itself, so it cannot be replicated. Left unset, a custom-command service
+# defaults to min(16, cpu/2) workers (see _bentoml_sdk/service/factory.py); only
+# the first one starts the process, and the rest wait forever on a health check
+# that can never pass if that one failed to bind — which hangs shutdown.
+# The two services here also use different ports so that running them
+# back-to-back cannot collide on a lingering child from the previous test.
 StaticHTTP1 = bentoml.Service(
     "StaticHTTP1",
     cmd=[
@@ -16,18 +23,18 @@ StaticHTTP1 = bentoml.Service(
         "--directory",
         str(THIS_DIR),
     ],
-    config={"endpoints": {"livez": "/"}},
+    config={"endpoints": {"livez": "/"}, "workers": 1, "http": {"proxy_port": 8000}},
 )
 
 
-@bentoml.service(endpoints={"livez": "/"})
+@bentoml.service(endpoints={"livez": "/"}, workers=1, http={"proxy_port": 8001})
 class StaticHTTP2:
     def __command__(self) -> list[str]:
         return [
             sys.executable,
             "-m",
             "http.server",
-            "8000",
+            "8001",
             "--directory",
             str(THIS_DIR),
         ]


### PR DESCRIPTION
`bento_new_sdk-e2e-tests` intermittently hangs in
`test_custom_command.py::test_command_in_method` until the job's 90-minute cap kills it.
The run is then marked **cancelled** (so `report-coverage` and `evergreen` are skipped),
which reads like a CI failure while every other job is green.

Seen on the merge commit for #5689 — [run 32459681347](https://github.com/bentoml/BentoML/actions/runs/32459681347):
42 jobs green, that one job `07:40:41 → 09:10:57`, ending in
`Terminate orphan process: pid (nox) / (pytest) / (python)`. The same commit passes on the
scheduled run (43 green, that job in 3m37s), and it happened once more in the previous 40 CI runs.

## Root cause (in this fixture, not in product code)

Both services in `tests/e2e/fixtures/static_http/service.py` run
`python -m http.server` on a **hard-coded port** and neither declared `workers`, so they
inherit the custom-command default of `min(16, cpu/2)` workers
(`_bentoml_sdk/service/factory.py:150`).

Reproduced locally: one `bentoml.serve()` of `StaticHTTP1` starts **12 workers** on a
24-core machine, with only **2** `http.server` processes alive. Only the first worker starts
the process (`proxy.py`'s `should_start_process`); every other worker then sits in

```python
while proc is None or proc.returncode is None:
    if await _check_health(client, health_endpoint): break
    await anyio.sleep(0.5)
```

waiting for a health check that can never pass if that one process failed to bind. Those
worker processes **do not exit on SIGTERM** (verified: two SIGTERMs ignored, SIGKILL
required), so the test's `with bentoml.serve(...)` teardown blocks forever. A 4-core runner
gets 2 workers, which is why it only bites sometimes.

## The change

- **`workers: 1` on both services** — required rather than a tuning choice: a command that
  binds its own fixed port cannot be replicated. With one worker, a failed bind raises
  promptly instead of leaving spinners behind.
- **Separate ports (8000 / 8001, with a matching `http.proxy_port`)** so running the two
  tests back-to-back cannot collide on a child that has not been reaped yet. That second
  failure mode was also reproducible: at `workers: 1` but a shared port, the run failed with
  `OSError: [Errno 98] Address already in use` surfacing as
  `httpx.RemoteProtocolError: illegal status line`.

## Verification

| | before | after |
|---|---|---|
| `test_custom_command.py` | hangs indefinitely, or ~179 s of readiness timeouts | `2 passed in 2.7s`, **5 consecutive runs** |
| orphan processes left behind | yes (SIGKILL needed) | none |
| `test_asgi.py` (same suite) | passes | passes |

## Deliberately not included

The product-side hardening this exposes: `serve()` teardown should escalate to SIGKILL after
a grace period, so that **no** user command which ignores SIGTERM can hang a run. Worth doing
separately — this PR only stops the fixture from tripping it.
