### PR TITLE
feat: agent skill for creating a BentoML project

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "bentoml",
-  "description": "Official BentoML agent skills: containerize BentoML services and deploy them to Kubernetes or EC2",
+  "description": "Official BentoML agent skills: create Bento projects, containerize them, and deploy them to Kubernetes or EC2",
   "owner": {
     "name": "BentoML Team",
     "url": "https://github.com/bentoml"
@@ -10,7 +10,7 @@
       "name": "bentoml-deploy",
       "source": ".",
       "strict": false,
-      "description": "Agent skills for containerizing BentoML services and deploying them to Kubernetes or EC2 with a fully open-source stack",
+      "description": "Agent skills for creating BentoML projects, containerizing them, and deploying them to Kubernetes or EC2 with a fully open-source stack",
       "author": {
         "name": "BentoML Team"
       },
@@ -18,6 +18,7 @@
       "license": "Apache-2.0",
       "keywords": [
         "bentoml",
+        "bento",
         "deployment",
         "kubernetes",
         "ec2",

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,13 +1,13 @@
-# BentoML Deployment Agent Skills
+# BentoML Agent Skills
 
 [Agent Skills](https://agentskills.io/specification) — the open, agent-neutral `SKILL.md`
-format — for deploying BentoML services to infrastructure **you** own: a vanilla Kubernetes
-cluster or plain AWS EC2 instances. They run in Claude Code, OpenAI Codex, Cursor and any other host
+format — for creating BentoML projects and deploying them to infrastructure **you** own: a
+vanilla Kubernetes cluster or plain AWS EC2 instances. They run in Claude Code, OpenAI Codex, Cursor and any other host
 implementing the standard ([installation](#installation)). The stack is fully open source: the
 `bentoml` CLI, Docker, `kubectl` with plain manifests, `ssh`, the AWS CLI. No Helm charts, no
 operators or CRDs, no Yatai, no BentoCloud.
 
-Scope is **basic deployment**. Commercial BentoCloud features — scale-to-zero, inference-metric
+Scope is **authoring plus basic deployment**. Commercial BentoCloud features — scale-to-zero, inference-metric
 autoscaling, canary/blue-green rollouts, model registry sync, observability dashboards — are out
 of scope for every target. Where a standard building block exists (Kubernetes HPA, an AWS ALB),
 the skills point at it in one line and stop.
@@ -16,18 +16,21 @@ the skills point at it in one line and stop.
 
 | Skill | What it does |
 |---|---|
+| [`bentoml-create-bento`](bentoml-create-bento/SKILL.md) | Creates the project itself — the `service.py`, its runtime image and a built Bento — from scratch (gathers requirements, scaffolds the files) or by converting existing code (a script, a notebook, a FastAPI/Flask app, an MLflow model, a BentoML 1.1 Runner project). Ends at a served, content-verified `bentoml build`. Start here if there is no bento yet. |
 | [`bentoml-containerize`](bentoml-containerize/SKILL.md) | Builds your local BentoML project into a Bento, containerizes it, smoke-tests the container locally, and pushes it to your registry (Docker Hub, GHCR, ECR, private, `kind`/`minikube` local load, or ttl.sh). The entry point for every deploy target. |
 | [`bentoml-k8s-deploy`](bentoml-k8s-deploy/SKILL.md) | Deploys a pushed image to your Kubernetes cluster: writes one `deploy/config.yml`, renders plain manifests from it — **one Deployment + Service per BentoML service the bento declares**, plus optional HPA/Ingress — applies them in dependency order, and verifies with a real inference request. Its [`references/troubleshooting.md`](bentoml-k8s-deploy/references/troubleshooting.md) is the diagnostic runbook: ImagePullBackOff, CrashLoopBackOff, OOM, Pending, probe failures, unreachable services, inference 4xx/5xx. |
 | [`bentoml-ec2-deploy`](bentoml-ec2-deploy/SKILL.md) | Runs a pushed image under Docker on one or more plain EC2 instances — your existing instances over SSH, or a fresh instance provisioned via the AWS CLI. Includes ECR auth, verification, teardown, and its own troubleshooting section. |
 | [`bentoml-deploy-scriptgen`](bentoml-deploy-scriptgen/SKILL.md) | Generates a standalone, committable deploy bundle (`deploy/deploy.py` + one `config.yml`) that builds, pushes, deploys and verifies without any agent. Manifests are rendered from the config on every run, so there is no YAML to keep in sync. For production and CI/CD. Kubernetes and EC2 targets. |
 
-A typical session chains **containerize → one deploy target**.
+A typical session chains **create-bento (if needed) → containerize → one deploy target**.
 
 ## Which target should I choose?
 
 ```mermaid
 flowchart TD
-    S([service.py]) --> C["bentoml-containerize<br/>(always the first step)"]
+    M([model or existing code]) -->|no bento yet| W["bentoml-create-bento"]
+    W --> S
+    S([service.py]) --> C["bentoml-containerize<br/>(first step of every deploy)"]
     C --> Q{Where should it run?}
     Q -->|"I have (or want) a Kubernetes cluster<br/>— incl. local kind/minikube"| K8S["bentoml-k8s-deploy"]
     Q -->|"AWS, keep it simple:<br/>a VM I control, SSH access"| EC2["bentoml-ec2-deploy"]
@@ -52,31 +55,32 @@ Zero cloud spend: `bentoml-containerize` with the kind/minikube path, then
 
 | Path | What it is |
 |---|---|
-| **Interactive skills** (`bentoml-containerize` → `bentoml-k8s-deploy` / `bentoml-ec2-deploy`) | The agent is in the loop: it detects your project, asks the right questions, confirms every mutation, provisions infrastructure where allowed (EC2), and troubleshoots on the spot. Use for a service's **first** deploy, a new target, and anything needing judgment. |
+| **Interactive skills** (`bentoml-create-bento` → `bentoml-containerize` → `bentoml-k8s-deploy` / `bentoml-ec2-deploy`) | The agent is in the loop: it detects your project, asks the right questions, confirms every mutation, provisions infrastructure where allowed (EC2), and troubleshoots on the spot. Use for a service's **first** deploy, a new target, and anything needing judgment. |
 | **The script bundle** (`bentoml-deploy-scriptgen`) | Every deploy after that: a committable `deploy/` directory (plain Python ≥ 3.9, stdlib only) repeating the exact build → containerize → push → deploy → verify pipeline with no agent and no questions, from your terminal or CI/CD. Preflight checks fail fast, exit codes are a stable contract (0 ok · 1 generic · 2 config · 3 preflight · 4 build · 5 push · 6 deploy · 7 verify), and the last stdout line is always a JSON summary. It does **less**: it never provisions EC2 instances and never edits your service. Its generated `deploy/README.md` ships a CI/CD chapter — a GitHub Actions workflow (fork-safe `--check-only --local-only` PR gate; deploy jobs with AWS OIDC, EKS kubeconfig, an SSH-key secret for EC2) plus a GitLab CI equivalent. |
 
 First deploy interactive, then generate the bundle, commit it, wire CI.
 
 ## Prerequisites
 
-| Prerequisite | containerize | k8s-deploy | ec2-deploy |
-|---|---|---|---|
-| Python + `bentoml` ≥ 1.4 | required | — | — |
-| Docker daemon running | required | — | on the instance only (installed by user-data on new instances; offered with confirmation on existing ones) |
-| `kubectl` + cluster access | — | required | — |
-| AWS CLI v2 + valid credentials | only for ECR pushes | — | required for provisioning mode and for ECR images; not needed for existing instance + non-ECR image |
-| `ssh` client | — | — | required |
-| A container registry | chosen here | cluster must be able to pull from it | instance must be able to pull from it |
+| Prerequisite | create-bento | containerize | k8s-deploy | ec2-deploy |
+|---|---|---|---|---|
+| Python + `bentoml` ≥ 1.4 | required | required | — | — |
+| Docker daemon running | — | required | — | on the instance only (installed by user-data on new instances; offered with confirmation on existing ones) |
+| `kubectl` + cluster access | — | — | required | — |
+| AWS CLI v2 + valid credentials | — | only for ECR pushes | — | required for provisioning mode and for ECR images; not needed for existing instance + non-ECR image |
+| `ssh` client | — | — | — | required |
+| A container registry | — | chosen here | cluster must be able to pull from it | instance must be able to pull from it |
 
 Each skill runs its own preflight checks and stops with a clear message if something is missing.
+`bentoml-create-bento` needs nothing but Python and whatever the model itself imports.
 
 ## Installation
 
 Each skill is a directory holding a `SKILL.md` with `name` + `description` frontmatter, plus
-optional `references/` and bundled files. Nothing is Claude-specific and all four validate
+optional `references/` and bundled files. Nothing is Claude-specific and all five validate
 against the [reference implementation](#working-inside-a-bentoml-checkout). Only the scanned
 **directory** differs per host, so the skills live in this repo's tool-neutral top-level
-`skills/` rather than one agent's dotfolder. Every option below lands the same four directories.
+`skills/` rather than one agent's dotfolder. Every option below lands the same five directories.
 
 | Host | Project scope | User scope (every project) |
 |---|---|---|
@@ -109,7 +113,7 @@ $ claude plugin marketplace add bentoml/BentoML    # or from a shell
 $ claude plugin install bentoml-deploy@bentoml
 ```
 
-Confirm the trust prompt and pick a scope (user = all projects). All four skills install
+Confirm the trust prompt and pick a scope (user = all projects). All five skills install
 together and auto-load like local skills, namespaced as `/bentoml-deploy:bentoml-k8s-deploy`
 (bare names resolve when unambiguous). Update with `/plugin update bentoml-deploy@bentoml`, or
 auto-update the `bentoml` marketplace under `/plugin` → Marketplaces. Smaller clone:
@@ -144,12 +148,13 @@ $ git pull && rm -rf ~/.codex/skills/bentoml-* && cp -r skills/bentoml-* ~/.code
 
 ### Verify the host picked them up
 
-**Codex** — in a new session run `/skills` (or type `$` to mention one); the four appear by
+**Codex** — in a new session run `/skills` (or type `$` to mention one); the five appear by
 name. From a shell:
 
 ```console
 $ ls ~/.codex/skills
-bentoml-containerize  bentoml-deploy-scriptgen  bentoml-ec2-deploy  bentoml-k8s-deploy
+bentoml-containerize   bentoml-deploy-scriptgen  bentoml-k8s-deploy
+bentoml-create-bento   bentoml-ec2-deploy
 $ head -4 ~/.codex/skills/bentoml-k8s-deploy/SKILL.md
 ```
 
@@ -163,6 +168,7 @@ $ claude
   /bentoml-ec2-deploy         Deploy a containerized BentoML service directly onto... EC2...
   /bentoml-k8s-deploy         Deploy a containerized BentoML service to a vanilla Kubernetes...
   /bentoml-deploy-scriptgen   Generate a standalone, committable production deploy-script...
+  /bentoml-create-bento       Create a BentoML project: the service.py whose typed...
 ```
 
 Plain requests work too — "deploy my BentoML service to my Kubernetes cluster" loads
@@ -203,6 +209,25 @@ purpose, it tells you what that costs and how to stop it later.
 ## What each skill will ask you
 
 Questions come up front, in as few rounds as possible, with defaults you can accept in one go.
+
+### `bentoml-create-bento`
+
+Only for a project it has to create from scratch, and all in one round — a conversion asks
+nothing it can read from the existing code. Every answer accepts "you decide".
+
+| Question | Default | How to choose |
+|---|---|---|
+| What does it do, one endpoint or several? | one, named after the verb | Start with one even if the target is bigger |
+| Where do the weights come from? | the HF ID you named, else no model | HF ID · local files (moved into the model store) · an existing model-store tag |
+| Input and output types per endpoint | the model's natural pair | Annotations are the API schema, so this is the one answer worth thinking about |
+| GPU? | no | Only if the model needs it |
+| Python version and pinned packages | your current Python, unpinned | Pin when reproducibility matters |
+| Response profile | interactive | interactive · long-running · token-streaming · fire-and-forget (a task queue) |
+
+It also asks for **one concrete input and its expected output** and refuses to declare success
+without it: verification judges the response body against that anchor, not the status code.
+Never asked: workers, threads, replicas, ports, batching, timeouts — defaults hold until
+something is measured.
 
 ### `bentoml-containerize`
 

--- a/skills/bentoml-create-bento/SKILL.md
+++ b/skills/bentoml-create-bento/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: bentoml-create-bento
+description: >
+  Create a BentoML project: the `service.py` whose typed `@bentoml.api` methods become an
+  HTTP API, plus its runtime image and a built Bento. Writes one from scratch, or converts
+  existing code — a script, a notebook, a FastAPI/Flask app, an MLflow model, a BentoML 1.1
+  Runner project. Use for "create a bento", "wrap my model in BentoML", "convert my FastAPI
+  app to BentoML", "add an endpoint to my bento", or a bento that will not start, rejects
+  valid input, or serves one request at a time.
+license: Apache-2.0
+compatibility: >-
+  Requires Python >= 3.9 and the bentoml CLI >= 1.4 (`pip install bentoml`). Serving needs
+  whatever the model itself needs; nothing else. Docker is not needed until bentoml-containerize.
+---
+
+# Create a BentoML project
+
+A **Bento** is the artifact `bentoml build` produces; a **project** is the directory it is
+built from, normally one `service.py` plus its dependencies. `@bentoml.service` on a class
+makes it a **Service** — the unit that gets deployed and scaled, and there may be several in
+one bento — and `@bentoml.api` on a method makes it an HTTP endpoint whose **schema is the
+method's type annotations**. BentoML supplies the server, the OpenAPI spec, the Swagger UI,
+the client, health checks and metrics. You write the class.
+
+Two paths, same steps 2-5: **A** from scratch (§1A) · **B** convert existing code (§1B).
+
+It also covers an existing project: adding an endpoint, switching an API to streaming or
+adaptive batching, moving long work to a background task, splitting one Service into several,
+and diagnosing a bento that will not start, rejects valid input, or serves one request at a
+time (last section).
+
+## What you produce
+
+| File | When | Purpose |
+|---|---|---|
+| `service.py` | always | The Services and their APIs. The whole surface. |
+| `requirements.txt` | always | Runtime deps, referenced by the `Image` and pip-installed locally |
+| `.bentoignore` | always | Keeps data, venvs, checkpoints, `__pycache__` out of the bento |
+| `test_service.py` | always | The anchor case as a test (§4) |
+| `save_model.py` | own weights | One-shot script that puts weights in the model store |
+| `bentofile.yaml` / `pyproject.toml` | legacy only | Alternative to `Image`; use `Image` instead ([build options]) |
+
+No Dockerfile, no `uvicorn`/`gunicorn` call, no `main()`, no route table, no request/response
+plumbing. If you are writing any of those, you are working against the framework.
+
+## Step 0 — get the anchor case
+
+Before writing anything, get **one concrete input and its expected output** from the user (or
+from the existing code's tests/README). This is the anchor: §4 verifies against it. Without it
+you can only confirm that a bento returns *something*, which is how a wrong one ships.
+
+If the user cannot supply one, derive it from the model card / existing code and state the
+assumption explicitly.
+
+## Step 1A — new project: ask once
+
+Ask these together, with defaults, in one round. Accept "you decide" for any of them.
+
+| Ask | Default when the user has no preference |
+|---|---|
+| What does it do, and is it one endpoint or several? | One, named after the verb (`summarize`, `classify`) |
+| Where do the weights come from: a Hugging Face ID, local files, an existing model-store tag, or no model at all? | HF ID if the user named a model; else no model |
+| Input and output types, per endpoint | `str -> str`, or the model's natural pair (§ [io-types]) |
+| GPU required? | No |
+| Python version and pinned packages? | Your current Python; unpinned packages |
+| Response profile: interactive, long-running, token-streaming, or fire-and-forget? | Interactive |
+
+**Do not ask** about workers, threads, replicas, ports, batching, registries or timeouts. The
+defaults are correct until something is measured, and every one of them is a one-line change
+later.
+
+Then scaffold the file set above and go to §2. Keep the first version to one Service and one
+API even if the target is bigger — get it green, then grow.
+
+## Step 1B — convert existing code
+
+Read the existing code first. Find and write down: (1) the inference entry point, (2) where the
+weights live, (3) the real dependency list, (4) the anchor case. Then translate:
+
+| In the existing code | In the Bento |
+|---|---|
+| Module-level model load, or a `load_model()` called per request | `__init__` — runs once per worker |
+| A pickle / `.pt` / directory of weights | `save_model.py` once, then a class attribute `BentoModel("name:latest")` |
+| `from_pretrained("org/model")` | class attribute `HuggingFaceModel("org/model")`, pass the returned path |
+| `@app.post("/predict")` handler | `@bentoml.api def predict(...) -> ...` with annotations |
+| Pydantic request/response models | Keep them verbatim — use as a parameter type, or `@bentoml.api(input_spec=Model)` |
+| `argparse` / `if __name__ == "__main__"` | Delete. `bentoml serve` is the entry point |
+| `uvicorn.run(...)`, gunicorn worker count | Delete; `@bentoml.service(workers=N)` |
+| `Dockerfile`, `pip install` lines | `bentoml.images.Image(...)` (§3) |
+| Custom routes, static files, webhooks, a UI | Keep the FastAPI app as-is and mount it under a prefix: `@bentoml.asgi_app(app, path="/v1")` |
+| Auth / rate limiting as a route dependency | ASGI middleware (`Service.add_asgi_middleware`) — FastAPI `Depends` never sees `@bentoml.api` routes |
+| A Flask/Django (WSGI) app | Port the inference route to `@bentoml.api`; a WSGI app needs an ASGI adapter to mount |
+| BentoML 1.1 `Runner` / `.to_runner()` | A second `@bentoml.service` + `bentoml.depends()`; `bentoml.runner_service(runner)` is a stopgap |
+| Celery / RQ / a background thread | `@bentoml.task` (§ [recipes]) |
+| A notebook | Cells to `__init__` (setup) and one `@bentoml.api` (the inference cell) |
+
+Rules for a conversion: **do not rewrite the model code.** Import it, call it, keep it
+importable so the old and new paths can be diffed. Convert the smallest slice that serves the
+anchor case, verify parity (§4), then move the rest. Detail and per-source playbooks:
+[conversion].
+
+## Step 2 — write `service.py`
+
+```python
+from __future__ import annotations
+
+import bentoml
+from bentoml.models import HuggingFaceModel
+
+with bentoml.importing():           # heavy/optional imports: skipped at build, required at serve
+    from transformers import pipeline
+
+
+@bentoml.service(
+    resources={"cpu": "2"},         # deployment hint (see rules), not a local limit
+    traffic={"timeout": 30},        # seconds; default 60
+)
+class Summarization:
+    model_path = HuggingFaceModel("sshleifer/distilbart-cnn-12-6")   # class scope, always
+
+    def __init__(self) -> None:     # once per worker
+        self.pipeline = pipeline("summarization", model=self.model_path)
+
+    @bentoml.api                    # -> POST /summarize
+    def summarize(self, text: str) -> str:
+        return self.pipeline(text)[0]["summary_text"]
+```
+
+Rules that are not guessable from the API surface:
+
+| Rule | Why it bites |
+|---|---|
+| Model references (`HuggingFaceModel`, `BentoModel`) go at **class scope**, not in `__init__` | Class scope is what declares the model a dependency of the bento. Inside `__init__` it is not packaged, and deployment fails with model `NotFound` |
+| Annotate **every** parameter and the return | The annotations *are* the schema, the OpenAPI spec and the client. An unannotated parameter becomes `Any`: no validation, no docs, no client typing |
+| `Optional[X]` requires an explicit default (`= None`); other unions are unsupported | Silent schema surprise otherwise |
+| Load models in `__init__`, never inside an API method | Per-request loading is the single most common cause of "BentoML is slow" |
+| Service name = class name; `@bentoml.service(name="...")` overrides. API route = `/<method_name>`; `@bentoml.api(route=...)` overrides | Deploy configs, `BENTOML_SERVE_DEPENDS` and clients all key off these names |
+| A method name may not start with `__` | Raises at import |
+| A **sync** API runs in a thread pool of size `threads` (default **1**) — one request at a time per worker | Concurrency comes from `async def`, or `threads=N`, or `workers=N`. Not from adding replicas |
+| Never block inside an `async def` API | It stalls the event loop; `/readyz` starts failing under load. Use `await self.dep.to_async.method(...)`, or `anyio.to_thread.run_sync` |
+| `resources={"cpu": ..., "memory": ...}` is a **hint for the deployment platform** — `bentoml serve` does not enforce it. `resources={"gpu": N}` does act locally: it sets `CUDA_VISIBLE_DEVICES` per worker | Expecting a local memory cap leads to debugging the wrong layer. On Kubernetes the real limits come from the deploy config |
+| `traffic={"timeout": 60}` is the default | Long generation gets cut off at 60 s with no other explanation |
+| Files: take a `pathlib.Path` in; write outputs into `ctx.temp_dir` and return the `Path` | Anything else leaks temp files across requests |
+| Raise `bentoml.exceptions.*` subclasses for client-visible errors (`InvalidArgument` -> 400); codes 401, 403 and >= 500 are reserved | Otherwise every failure is a 500 |
+| `/`, `/livez`, `/readyz`, `/healthz`, `/metrics`, `/docs.json` are taken by the server | An API or a mounted app route with one of those paths is silently shadowed — mount ASGI apps under a prefix |
+
+Multiple Services in one `service.py`: give each its own `@bentoml.service`, wire them with
+`dep = bentoml.depends(Other)` at class scope, and call `self.dep.method(...)` like a local
+method. The Service you serve is the **entry** service; BentoML starts its dependencies with
+it. Split only for a real reason — different hardware, independent scaling, or a shared
+downstream — since each split adds a network hop. Details: [distributed services].
+
+IO types beyond `str`/`int`/`dict` (numpy, pandas, `PIL.Image`, `Path`, pydantic models, root
+input, validators, streaming, batching): [io-types]. Config keys: [service-config]. Task
+queues, LLM streaming, model composition, FastAPI mounts, Gradio UIs: [recipes].
+
+## Step 3 — declare the runtime environment
+
+```python
+image = bentoml.images.Image(python_version="3.11").requirements_file("requirements.txt")
+
+@bentoml.service(image=image)
+class Summarization: ...
+```
+
+- `Image` is the current API (BentoML >= 1.3.20) and lives next to the code it describes.
+  Chainable: `.python_packages(...)`, `.requirements_file(...)`, `.system_packages(...)`,
+  `.run("cmd")`, `.run_script("scripts/setup.sh")`, `.build_include(...)`. `.run()` is
+  position-sensitive: before `.python_packages()` runs before pip, after it runs after.
+- `bentoml` itself is added automatically. Don't list it.
+- Versions are locked at build time unless you pass `lock_python_packages=False`.
+- A multi-Service bento uses **only the entry Service's image**; per-Service images are not
+  supported yet, so put every dependency there.
+- `.bentoignore` (gitignore syntax) is what keeps the bento small — always exclude the venv,
+  `__pycache__/`, datasets and checkpoints.
+
+## Step 4 — serve and verify (never skip)
+
+```bash
+bentoml serve                      # resolves bentofile.yaml -> pyproject.toml -> service.py
+bentoml serve service:Summarization --reload -p 3000    # explicit target, dev reload
+```
+
+Then, in this order — each check catches a different class of mistake:
+
+```bash
+curl -sf localhost:3000/readyz                       # 1. it started and loaded the model
+curl -s localhost:3000/docs.json | head -c 400       # 2. the schema is what you intended
+curl -s -X POST localhost:3000/summarize \           # 3. the anchor case, judged by its BODY
+     -H 'Content-Type: application/json' -d '{"text": "..."}'
+```
+
+Judge the **response body** against the anchor from §0, not the status code — a bento that
+returns `null`, an empty string or a stack trace with a 200 is a failed verification. For a
+conversion, run the original code on the same input and diff the two outputs; report the
+comparison, and if they differ, say so rather than adjusting the expectation.
+
+Commit the anchor as a test. No server needed:
+
+```python
+import pytest
+from starlette.testclient import TestClient
+from service import Summarization
+
+@pytest.fixture(scope="session")            # to_asgi() ONCE per process: it registers
+def client():                               # Prometheus collectors, and a second call
+    with TestClient(Summarization.to_asgi()) as c:   # raises "Duplicated timeseries"
+        yield c
+
+def test_summarize(client):                 # TestClient must be a context manager
+    r = client.post("/summarize", json={"text": "..."})
+    assert r.status_code == 200 and "expected substring" in r.text
+```
+
+`Summarization()` can also be instantiated directly and called as plain Python — the fastest
+loop while iterating. More: [testing].
+
+## Step 5 — build and hand off
+
+```bash
+bentoml build          # -> summarization:xxxxxxxx  (packages the cwd, minus .bentoignore)
+bentoml list
+bentoml serve summarization:latest      # serve the built artifact, not the source
+```
+
+The bento name is the entry Service's name in snake_case (`DiabetesRisk` -> `diabetes_risk`) —
+that, not the class name, is what the deploy skills and `bentoml containerize` take.
+
+A built Bento is the input to **`bentoml-containerize`** (image + registry push), then
+`bentoml-k8s-deploy` or `bentoml-ec2-deploy`. Tell the user that is the next step; do not
+build images or touch a cluster from this skill.
+
+## When it goes wrong
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `does not contain a valid bentofile.yaml or service.py` | Wrong cwd, or the file isn't named `service.py` | `cd` to the project, or `bentoml serve mymodule:MyService` |
+| Model `NotFound` at deploy, works locally | Model reference created inside `__init__` | Move it to class scope |
+| `400` + a pydantic `detail` array on an obviously valid request | Annotation mismatch; a missing `= None` on an `Optional`; a batchable API sent a scalar; a `ContentType`-annotated upload whose client-declared MIME type differs (`curl -F f=@x.csv` sends `application/octet-stream`) | Read the `detail` array, then `/docs.json` — it shows exactly what the server expects |
+| Import error at serve time only | A heavy import under `bentoml.importing()` is genuinely missing from the runtime env | Add it to `requirements.txt` / `.python_packages()` |
+| Throughput ~1 request at a time | Sync API, `threads=1` | `async def`, or `threads=N`, or `workers=N` |
+| Request dies at exactly 60 s | Default `traffic.timeout` | Raise it on the Service |
+| `/readyz` flaps under load | Blocking call inside an `async def` | Move to a sync API or `to_async`/`to_thread` |
+| Bento build takes forever, artifact is huge | Datasets/venv/checkpoints packaged | `.bentoignore` |
+| Dependency Service is never called | Depended-on class not `@bentoml.service`, or `depends()` result not a class attribute | Both are required |
+| GPU idle | `workers="cpu_count"` skips GPU assignment | Set an explicit `workers=N` with `resources={"gpu": N}` |
+
+## References
+
+Local, load when the task needs them:
+
+| File | Contents |
+|---|---|
+| [io-types] | Every supported input/output type, validators, root input, files/images/tensors/dataframes, streaming, batching, what is *not* supported |
+| [service-config] | `@bentoml.service` keys: workers, threads, traffic, resources, envs, labels, http, metrics, endpoints, `cmd`; which are local vs. platform-only |
+| [recipes] | Copy-pasteable: sklearn/XGBoost, HF transformers, LLM streaming, multi-Service composition, adaptive batching, task queue, FastAPI mount, Gradio UI, external server via `cmd` |
+| [conversion] | Per-source playbooks (script, notebook, FastAPI, Flask, MLflow, BentoML 1.1) and the parity procedure |
+
+Upstream docs (authoritative, versioned): [Services], [IO types], [runtime environment],
+[model loading], [distributed services], [batching], [tasks], [streaming], [ASGI], [hooks],
+[clients], [testing], [build options], [SDK reference], [examples].
+
+[io-types]: references/io-types.md
+[service-config]: references/service-config.md
+[recipes]: references/recipes.md
+[conversion]: references/conversion.md
+[Services]: https://docs.bentoml.com/en/latest/build-with-bentoml/services.html
+[IO types]: https://docs.bentoml.com/en/latest/build-with-bentoml/iotypes.html
+[runtime environment]: https://docs.bentoml.com/en/latest/build-with-bentoml/runtime-environment.html
+[model loading]: https://docs.bentoml.com/en/latest/build-with-bentoml/model-loading-and-management.html
+[distributed services]: https://docs.bentoml.com/en/latest/build-with-bentoml/distributed-services.html
+[batching]: https://docs.bentoml.com/en/latest/get-started/adaptive-batching.html
+[tasks]: https://docs.bentoml.com/en/latest/get-started/async-task-queues.html
+[streaming]: https://docs.bentoml.com/en/latest/build-with-bentoml/streaming.html
+[ASGI]: https://docs.bentoml.com/en/latest/build-with-bentoml/asgi.html
+[hooks]: https://docs.bentoml.com/en/latest/build-with-bentoml/lifecycle-hooks.html
+[clients]: https://docs.bentoml.com/en/latest/build-with-bentoml/clients.html
+[testing]: https://docs.bentoml.com/en/latest/build-with-bentoml/testing.html
+[build options]: https://docs.bentoml.com/en/latest/reference/bentoml/bento-build-options.html
+[SDK reference]: https://docs.bentoml.com/en/latest/reference/bentoml/sdk.html
+[examples]: https://docs.bentoml.com/en/latest/examples/overview.html

--- a/skills/bentoml-create-bento/references/conversion.md
+++ b/skills/bentoml-create-bento/references/conversion.md
@@ -1,0 +1,182 @@
+# Converting existing code into a Bento
+
+The goal is a Bento that produces byte-identical output for a known input, with the original
+code still importable. Nothing else counts as a successful conversion.
+
+## Order of operations
+
+1. **Capture the anchor.** Run the existing code on one real input; save input and output to
+   disk. If it already has tests, they are the anchor.
+2. **Inventory.** Inference entry point · where weights load from · the actual import list ·
+   anything stateful (DB, cache, queue) · anything web-only (auth, CORS, static files).
+3. **Move the weights first.** `save_model.py` into the model store, or a `HuggingFaceModel`
+   reference. Re-run the original against the store path to prove nothing changed.
+4. **Wrap the entry point.** One `@bentoml.service` class, one `@bentoml.api` method calling
+   the existing function. Import the old module; do not paste its body.
+5. **Serve and diff** against step 1. Only now change anything else.
+6. **Then** move web extras (§FastAPI), split Services if there is a hardware reason, and pin
+   the image.
+
+Resist rewriting the model code during a conversion. Two changed variables make a failed diff
+uninterpretable.
+
+## A script or a module
+
+```python
+# old: predict.py  (unchanged)
+def load(): ...
+def predict(model, text): ...
+```
+
+```python
+# service.py
+import bentoml
+import predict as impl
+
+@bentoml.service
+class Predictor:
+    def __init__(self) -> None:
+        self.model = impl.load()
+
+    @bentoml.api
+    def predict(self, text: str) -> dict:
+        return impl.predict(self.model, text)
+```
+
+Delete from the copy: `argparse`, `if __name__ == "__main__"`, `print()` progress, `sys.exit`,
+any `while True` loop. Keep the file on disk — the Bento can import it.
+
+## A notebook
+
+Split the cells: imports → module top level (heavy ones under `bentoml.importing()`); setup and
+model loading → `__init__`; the inference cell → the `@bentoml.api` body; the "try it" cell →
+the anchor test. Exploration cells are dropped. `%pip install` lines become
+`requirements.txt`.
+
+## A FastAPI app
+
+Two options; pick by whether the app has non-inference routes.
+
+**Inference only** — port the routes and delete the app. The pydantic models carry over
+unchanged:
+
+```python
+# old: @app.post("/predict") async def predict(req: PredictRequest) -> PredictResponse
+@bentoml.api
+async def predict(self, req: PredictRequest) -> PredictResponse:      # nested under "req"
+async def predict(self, **req: t.Any) -> PredictResponse:             # or flat, with input_spec
+```
+
+Note the shape change: a parameter typed with a model nests the payload under the parameter
+name. `@bentoml.api(input_spec=PredictRequest)` keeps the original flat request body — use it
+when existing clients must keep working.
+
+**Has auth / custom routes / static files / webhooks** — keep the app and mount it under a
+prefix:
+
+```python
+@bentoml.service
+@bentoml.asgi_app(app, path="/v1")        # the app's /healthz becomes /v1/healthz
+class Service:
+    @bentoml.api
+    def predict(self, ...): ...
+```
+
+Then: drop `uvicorn.run(...)`; `FastAPI(lifespan=...)`/`@app.on_event("startup")` becomes
+`__init__` or `@bentoml.on_startup`; `Depends(get_model)` becomes `self.model`; a route needing
+the Service instance uses `Depends(bentoml.get_current_service)`.
+
+Two verified traps:
+
+- **Mount under a prefix**, not `/`. `/`, `/livez`, `/readyz`, `/healthz`, `/metrics` and
+  `/docs.json` are the server's; a mounted `/healthz` is shadowed with no warning.
+- **Auth expressed as a route dependency stops protecting anything that matters.** The
+  inference route is now a `@bentoml.api`, which FastAPI's `Depends` never sees. Re-express it
+  as ASGI middleware (`Service.add_asgi_middleware(...)`, § 7 of [recipes.md](recipes.md)) and exclude the health
+  paths, or the probes fail.
+
+## A Flask or Django app (WSGI)
+
+WSGI is not ASGI. Port the inference route to `@bentoml.api` — that is nearly always less work
+than adapting the app. If the surrounding app must be kept, wrap it in a WSGI-to-ASGI adapter
+(e.g. `a2wsgi.WSGIMiddleware`) before `@bentoml.asgi_app`, and verify the adapted routes
+yourself; BentoML does not ship or test that adapter.
+
+## An MLflow model
+
+```python
+bentoml.mlflow.import_model("my-model", model_uri="runs:/<run_id>/model")   # once
+```
+
+```python
+@bentoml.service
+class Predictor:
+    model_ref = bentoml.models.BentoModel("my-model:latest")
+
+    def __init__(self) -> None:
+        self.model = bentoml.mlflow.load_model(self.model_ref)   # a pyfunc
+
+    @bentoml.api
+    def predict(self, df: pd.DataFrame) -> np.ndarray:
+        return self.model.predict(df)
+```
+
+The pyfunc flavour keeps MLflow's own signature; annotate the API with the types that signature
+actually takes. https://docs.bentoml.com/en/latest/examples/mlflow.html
+
+## A BentoML 1.1 project
+
+1.1's `bentoml.Service(...)` + `Runner` + `@svc.api(input=JSON(), output=JSON())` is replaced by
+one class per unit.
+
+| 1.1 | 1.2+ |
+|---|---|
+| `svc = bentoml.Service("name", runners=[r])` | `@bentoml.service class Name:` |
+| `bentoml.models.get(tag).to_runner()` | a second `@bentoml.service`, referenced with `bentoml.depends()` |
+| `@svc.api(input=NumpyNdarray(), output=JSON())` | `@bentoml.api def f(self, x: np.ndarray) -> dict:` |
+| `runner.predict.run(x)` | `self.dep.predict(x)` |
+| IO descriptors (`JSON()`, `Image()`, `Text()`) | type annotations |
+| `bentofile.yaml` | `bentoml.images.Image` (the yaml still works) |
+| `@svc.on_startup` | `__init__` / `@bentoml.on_startup` |
+
+`bentoml.runner_service(runner)` converts a legacy Runner into a Service with no code changes —
+a staging step, not an end state. Old `Runner` docs:
+https://docs.bentoml.com/en/v1.1.11/concepts/runner.html
+
+## A containerized custom server
+
+If the model already runs behind its own HTTP server (Triton, a Rust binary, a Node service),
+do not port it: run it as the Service's process and let BentoML proxy.
+
+```python
+@bentoml.service(cmd=["tritonserver", "--http-port", "8000"], http={"proxy_port": 8000}, workers=1)
+class Triton:
+    pass
+```
+
+The command's port and `http.proxy_port` must match; `$PORT` is not defined for you (§ 9 of
+[recipes.md](recipes.md)).
+
+You lose the typed schema and the Swagger UI (BentoML no longer sees the API), so prefer this
+only when the server cannot be replaced.
+
+## Verifying parity
+
+```bash
+# 1. before: the original code, on the original weights
+python -c "import model; print(model.predict_one(model.load_model(), INPUT))" > /tmp/before.json
+# 2. after the weights move: the original code, on the model-store copy  <- catches step 3 alone
+# 3. after the wrap: the Bento, same request body the old API took
+bentoml serve service:Predictor &
+curl -s -X POST localhost:3000/predict -H 'Content-Type: application/json' \
+     -d @anchor.json > /tmp/after.json
+python -c "import json;a=json.load(open('/tmp/before.json'));b=json.load(open('/tmp/after.json'));print('identical' if a==b else (a,b))"
+```
+
+Compare parsed JSON, not bytes: BentoML emits `{"score": 1.0}` where FastAPI emits
+`{"score":1.0}`, and the diff would be pure noise.
+
+Report the diff to the user rather than adjusting the expected value. Common legitimate
+differences: float formatting in JSON, `numpy` scalars rendered as JSON numbers, dict key
+order, and a `str` return arriving as `text/plain` instead of a JSON-quoted string. Anything
+else is a bug in the conversion.

--- a/skills/bentoml-create-bento/references/io-types.md
+++ b/skills/bentoml-create-bento/references/io-types.md
@@ -1,0 +1,156 @@
+# Input and output types
+
+The annotations on an `@bentoml.api` method are the request schema, the response schema, the
+OpenAPI spec and the generated client. Everything here is enforced by pydantic v2.
+
+## Supported types
+
+| Type | Parameter | Wire format in | Return | Wire format out |
+|---|---|---|---|---|
+| Scalars, `list`, `dict` | `text: str, n: int` | `application/json` object keyed by parameter name | `-> str`, `-> bytes` | `text/plain` |
+| | | | `-> int/float/dict/list` | `application/json` |
+| Pydantic model | `params: MyModel` | nested JSON object under the parameter name | `-> MyModel` | JSON |
+| `numpy.ndarray`, `torch.Tensor`, `tensorflow.Tensor` | `x: np.ndarray` | JSON nested lists | same | JSON nested lists |
+| `pandas.DataFrame` | `df: pd.DataFrame` | JSON records or columns | same | JSON records |
+| `PIL.Image.Image` | `img: Image` | `multipart/form-data` (file or URL) | same | `image/<detected>` |
+| `pathlib.Path` | `f: Path` | `multipart/form-data` (file or URL) | same | binary, MIME from suffix |
+| `Generator` / `AsyncGenerator` | — | — | `-> Generator[str, None, None]` | `text/event-stream` |
+| `list[...]` of the above | `imgs: list[Image]` | multipart | `-> list[dict]` | JSON |
+
+`bentoml.Context` (as `ctx: bentoml.Context` or `context:`) is not part of the schema.
+
+The **return** annotation is enforced too, not just documented: annotating `-> list[dict[str,
+float]]` turns an `int` row index into `0.0` on the wire. Use `dict[str, t.Any]`, or a pydantic
+model, when a field's type is not uniform.
+
+Validation failures return **400** with a pydantic `detail` array naming the offending field —
+not 422. A type the validator cannot even attempt (a string where a tensor is expected) comes
+back as a 500.
+
+Not supported: general unions (`int | str`); a response mixing raw binary with JSON fields;
+multiple binary values in one response. Return a `dict` of JSON plus a URL, or split the API.
+
+## Defaults, examples, descriptions
+
+```python
+from pydantic import Field
+
+@bentoml.api
+def generate(
+    self,
+    prompt: str = Field(description="The prompt text"),
+    temperature: float = Field(default=0.7, description="0-2"),
+    stop: list[str] | None = Field(default=None),          # Optional MUST have a default
+) -> str: ...
+```
+
+`Field(examples=[[0.1, 0.4]])` prefills the Swagger UI and is the cheapest way to make an
+endpoint self-documenting. A plain default value (`text: str = EXAMPLE_INPUT`) does the same.
+
+## Validators
+
+`bentoml.validators` adds ML-specific constraints; standard `annotated_types` (`Ge`, `Lt`,
+`MaxLen`, `MultipleOf`) and every pydantic annotation also work.
+
+```python
+from typing import Annotated
+from bentoml.validators import ContentType, DType, DataframeSchema, Shape
+
+audio: Annotated[Path, ContentType("audio/mp3")]
+x:     Annotated[torch.Tensor, Shape((1, 4)), DType("float32")]
+df:    Annotated[pd.DataFrame, DataframeSchema(orient="records", columns=["a", "b"])]
+prompt: Annotated[str, MaxLen(1000)]
+```
+
+| Validator | Applies to |
+|---|---|
+| `ContentType` | `Path`, `bytes`, `PIL.Image.Image` |
+
+| `Shape`, `DType` | `numpy.ndarray`, `torch.Tensor`, `tensorflow.Tensor` |
+| `DataframeSchema(orient="records"\|"columns", columns=[...])` | `pandas.DataFrame` |
+
+`ContentType` checks the MIME type **the client declares**, not the bytes. `curl -F
+"csv=@x.csv"` declares `application/octet-stream` and gets a 400 — the working form is
+`curl -F "csv=@x.csv;type=text/csv"`, and in Python
+`files={"csv": ("x.csv", data, "text/csv")}`. Annotate a content type only if you want that
+enforced; a bare `Path` accepts anything.
+
+## Pydantic models
+
+A model as a parameter type nests the payload under that parameter's name. To accept the
+model's fields at the top level of the request body instead, use `input_spec`:
+
+```python
+@bentoml.api(input_spec=GenerationParams)
+def generate(self, **params: t.Any) -> str:
+    return self.llm(params["prompt"], temperature=params["temperature"])
+```
+
+`pydantic.BaseModel` fields only accept built-in types. For a model with `numpy.ndarray`,
+`pandas.DataFrame` or tensor fields, subclass `bentoml.IODescriptor` instead:
+
+```python
+class MyInput(bentoml.IODescriptor):
+    data: np.ndarray[tuple[int], np.dtype[np.float16]]
+```
+
+## Files
+
+In: annotate `pathlib.Path`; BentoML writes the upload to a temp file and hands you the path.
+Out: write into the per-request `ctx.temp_dir` and return the `Path`.
+
+```python
+@bentoml.api
+def to_speech(self, text: str, ctx: bentoml.Context) -> Annotated[Path, ContentType("audio/mp3")]:
+    out = Path(ctx.temp_dir) / "out.mp3"
+    out.write_bytes(self.tts(text))
+    return out
+```
+
+Returning `bytes` with a `ContentType` annotation avoids touching disk at all.
+
+## Root input
+
+One positional-only parameter (before `/` in the signature) takes the whole request body with
+no JSON wrapper — the natural shape for raw image/audio/text uploads. At most one, and no other
+parameters except the context.
+
+```python
+@bentoml.api
+def upload(self, image: PILImage.Image, /) -> dict: ...
+# curl -X POST --data-binary @cat.png localhost:3000/upload
+# client.upload(path)          <- positional; client.upload(image=path) is wrong
+```
+
+## Streaming
+
+Return a generator. The response is `text/event-stream`; yield strings (or bytes).
+
+```python
+@bentoml.api
+async def chat(self, prompt: str) -> AsyncGenerator[str, None]:
+    async for chunk in self.engine.stream(prompt):
+        yield chunk
+```
+
+A `@bentoml.task` cannot stream.
+
+## Batching
+
+`@bentoml.api(batchable=True)` turns on server-side adaptive batching: the endpoint receives a
+*list* of what individual callers sent, and must return a list of the same length in the same
+order.
+
+```python
+@bentoml.api(batchable=True, max_batch_size=32, max_latency_ms=1000)
+def encode(self, sentences: list[str]) -> np.ndarray: ...
+```
+
+- Exactly one parameter besides the context. For several, wrap them in a pydantic model and
+  take `list[Model]`; a thin non-batchable wrapper Service gives clients the per-request shape.
+- `batch_dim` controls which axis is concatenated for arrays (default 0).
+- Exceeding `max_latency_ms` returns 503 to the caller.
+- A **sync** caller in another Service sends one request at a time (`threads=1`), so batches
+  never form: use `async` + `.to_async`, or raise `threads` on the caller.
+
+Full reference: https://docs.bentoml.com/en/latest/build-with-bentoml/iotypes.html

--- a/skills/bentoml-create-bento/references/recipes.md
+++ b/skills/bentoml-create-bento/references/recipes.md
@@ -1,0 +1,268 @@
+# Recipes
+
+Working shapes to copy. Each is complete except for the model logic. Official example projects
+for every domain (LLM, diffusion, embeddings, CV, audio, RAG, agents):
+https://docs.bentoml.com/en/latest/examples/overview.html
+
+## 1. Your own weights, via the model store
+
+Save once, reference by tag. Keeps weights out of git and out of the build context, and lets
+the deployment fetch them at image-build time instead of at startup.
+
+```python
+# save_model.py — run once: python save_model.py
+import bentoml, joblib
+from sklearn.ensemble import RandomForestClassifier
+
+model = RandomForestClassifier().fit(X, y)
+with bentoml.models.create(name="iris-clf") as ref:      # -> iris-clf:<version>
+    joblib.dump(model, ref.path_of("model.pkl"))
+```
+
+```python
+# service.py
+import bentoml, numpy as np
+from bentoml.models import BentoModel
+
+@bentoml.service(image=bentoml.images.Image(python_version="3.11")
+                 .requirements_file("requirements.txt"))
+class IrisClassifier:
+    model_ref = BentoModel("iris-clf:latest")            # class scope
+
+    def __init__(self) -> None:
+        import joblib
+        self.model = joblib.load(self.model_ref.path_of("model.pkl"))
+
+    @bentoml.api
+    def classify(self, features: np.ndarray) -> np.ndarray:
+        return self.model.predict(features)
+```
+
+`bentoml models list` / `get` / `delete` manage the store. Framework helpers
+(`bentoml.sklearn.save_model`, `bentoml.xgboost.load_model`, …) exist for many libraries but are
+not required — a directory of files and `joblib` work fine.
+
+## 2. Hugging Face model
+
+```python
+import bentoml
+from bentoml.models import HuggingFaceModel
+
+with bentoml.importing():
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+@bentoml.service(envs=[{"name": "HF_TOKEN"}])            # gated models only
+class Sentiment:
+    model_path = HuggingFaceModel("distilbert-base-uncased-finetuned-sst-2-english")
+
+    def __init__(self) -> None:
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_path)
+        self.model = AutoModelForSequenceClassification.from_pretrained(self.model_path)
+
+    @bentoml.api
+    def classify(self, text: str) -> dict[str, t.Any]:      # label + score
+        ...
+```
+
+`HuggingFaceModel` returns a **local path string**; pass it wherever you would pass a repo ID.
+Downloads happen at build time, so container start-up does not wait on the Hub.
+
+## 3. Streaming LLM output
+
+```python
+@bentoml.service(traffic={"timeout": 600}, workers=1, resources={"gpu": 1})
+class LLM:
+    model_path = HuggingFaceModel("meta-llama/Llama-3.1-8B-Instruct")
+
+    def __init__(self) -> None:
+        self.engine = build_engine(self.model_path)       # vLLM, TensorRT-LLM, transformers…
+
+    @bentoml.api
+    async def generate(self, prompt: str, max_tokens: int = 512) -> AsyncGenerator[str, None]:
+        async for chunk in self.engine.stream(prompt, max_tokens=max_tokens):
+            yield chunk
+```
+
+`workers=1` per GPU, a long `traffic.timeout`, and `async` throughout. For a real, maintained
+vLLM setup (OpenAI-compatible routes, continuous batching, quantization) start from
+https://github.com/bentoml/BentoVLLM instead of writing the engine glue by hand.
+
+## 4. Multiple Services
+
+```python
+@bentoml.service(resources={"cpu": "1"})
+class Embedder:
+    @bentoml.api
+    def embed(self, texts: list[str]) -> np.ndarray: ...
+
+@bentoml.service(resources={"gpu": 1})
+class Reranker:
+    @bentoml.api
+    def rank(self, query: str, docs: list[str]) -> list[float]: ...
+
+@bentoml.service()                                        # the entry Service
+class Search:
+    embedder = bentoml.depends(Embedder)                  # class scope
+    reranker = bentoml.depends(Reranker)
+
+    @bentoml.api
+    async def search(self, query: str) -> list[str]:
+        vec, scores = await asyncio.gather(               # run both hops in parallel
+            self.embedder.to_async.embed([query]),
+            self.reranker.to_async.rank(query, self.candidates(query)),
+        )
+        ...
+```
+
+- Serve the entry Service (`bentoml serve service:Search`); BentoML starts the others.
+- `self.dep.method(...)` is a sync call; `self.dep.to_async.method(...)` is awaitable — use it
+  in `async def` APIs, and to fan out with `asyncio.gather`.
+- Depend on something already running elsewhere: `bentoml.depends(url="http://host:3000")`, or
+  `bentoml.depends(deployment="name")` on BentoCloud. Pass `on=TheClass` too for typing.
+- Inter-Service payloads are pickled. Expose only the entry Service publicly.
+
+## 5. Adaptive batching with a per-request façade
+
+```python
+class Item(BaseModel):
+    image: Path
+    threshold: float
+
+@bentoml.service
+class Detector:
+    @bentoml.api(batchable=True, max_batch_size=16, max_latency_ms=500)
+    def detect(self, items: list[Item]) -> list[dict]: ...
+
+@bentoml.service
+class API:                                                # entry: normal one-at-a-time shape
+    detector = bentoml.depends(Detector)
+
+    @bentoml.api
+    async def detect(self, image: Path, threshold: float = 0.5) -> dict:
+        out = await self.detector.to_async.detect([Item(image=image, threshold=threshold)])
+        return out[0]
+```
+
+## 6. Fire-and-forget work
+
+```python
+@bentoml.service
+class Renderer:
+    @bentoml.task
+    def render(self, prompt: str) -> Path: ...
+```
+
+Generated routes, relative to the API's route: `POST /render/submit`, `GET /render/status`,
+`GET /render/get`, `POST /render/retry`, `PUT /render/cancel` (note the methods: retry is POST,
+cancel is PUT).
+
+```python
+task = client.render.submit(prompt="...")
+task.get_status().value    # pending | in_progress | completed | failed | canceled
+task.get()                 # the result
+task.retry()               # a new task with the same input
+```
+
+Identical body to an `@bentoml.api` — only the decorator changes. Results are kept ~24 h. A
+task cannot return a generator. Locally the queue is in-process and `cancel` is unsupported
+("task cancellation is not supported in local development server"), so exercise cancellation
+against a real deployment.
+
+## 7. Keep an existing FastAPI app
+
+The conversion path for a service that already has custom routes, webhooks, a UI or static
+files. The FastAPI app is mounted whole; the `@bentoml.api` methods stay first-class endpoints.
+Auth is the exception — see the second bullet below.
+
+```python
+from fastapi import Depends, FastAPI
+app = FastAPI()
+
+@bentoml.service
+@bentoml.asgi_app(app, path="/v1")                # everything in `app` moves under /v1
+class Service:
+    @bentoml.api                                  # still POST /predict
+    def predict(self, text: str) -> str: ...
+
+    @app.get("/custom")                           # inside the class: `self` works
+    def custom(self):
+        return {"model": self.name}
+
+@app.get("/other")                                # outside: inject the instance
+async def other(svc: Service = Depends(bentoml.get_current_service)):
+    ...
+```
+
+Two things that are easy to get wrong here:
+
+- **Mount under a prefix.** `/`, `/livez`, `/readyz`, `/healthz`, `/metrics` and `/docs.json`
+  belong to the server and win — a mounted app's `/healthz` is silently shadowed and returns
+  the built-in response.
+- **The mounted app's route dependencies do not protect `@bentoml.api` routes.** FastAPI
+  `Depends(...)` only guards FastAPI's own routes. Cross-cutting concerns (auth, rate limits)
+  belong in ASGI middleware, which covers everything:
+
+```python
+class ApiKeyMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path in ("/livez", "/readyz", "/healthz", "/metrics"):
+            return await call_next(request)          # never gate the probes
+        if request.headers.get("x-api-key") != os.environ["API_KEY"]:
+            return JSONResponse({"detail": "bad key"}, status_code=401)
+        return await call_next(request)
+
+Service.add_asgi_middleware(ApiKeyMiddleware)        # after the class definition
+```
+
+## 8. Gradio UI on the same server
+
+```python
+import bentoml, gradio as gr
+
+def ui_fn(text: str) -> str:
+    return bentoml.get_current_service().summarize(text)
+
+io = gr.Interface(fn=ui_fn, inputs="text", outputs="text")
+
+@bentoml.service
+@bentoml.gradio.mount_gradio_app(io, path="/ui")
+class Summarization: ...
+```
+
+Needs `gradio` in the image. Serves the demo at `/ui` next to the API.
+
+## 9. An external server binary
+
+When the real server is not Python, or is a pre-built binary: BentoML runs it and proxies to it.
+
+```python
+@bentoml.service(cmd=["my-server", "--port", "9000"], http={"proxy_port": 9000}, workers=1)
+class External:
+    pass
+```
+
+- **The command must listen on `http.proxy_port` (default 8000)** — that is where BentoML
+  proxies. Hard-code the two to the same number.
+- `$VAR` in `cmd` is expanded from the **process** environment, and BentoML defines neither
+  `PORT` nor `BENTOML_HOST`: `cmd=[..., "--port", "$PORT"]` dies at startup with
+  `KeyError: 'PORT'` unless you supply it yourself (e.g. via `envs=[{"name": "PORT", ...}]`).
+- `workers` defaults to `min(16, cpu/2)` for a custom command and only worker 1 starts the
+  process; the rest wait on a health check. Set `workers=1` unless the binary can share a port.
+- Compute the command at run time with `def __command__(self) -> list[str]`; rewrite the
+  metrics it exposes with `def __metrics__(self, original: str) -> str`.
+
+## 10. Calling the service
+
+```python
+import bentoml
+
+with bentoml.SyncHTTPClient("http://localhost:3000", server_ready_timeout=30) as client:
+    print(client.summarize(text="..."))          # method name == API name
+
+async with bentoml.AsyncHTTPClient("http://localhost:3000") as client:
+    async for chunk in client.generate(prompt="..."):    # streaming APIs yield
+        print(chunk, end="")
+```
+
+Root-input APIs take a positional argument. `curl` works equally well; the Swagger UI at `/`
+lists every endpoint with its schema.

--- a/skills/bentoml-create-bento/references/service-config.md
+++ b/skills/bentoml-create-bento/references/service-config.md
@@ -1,0 +1,64 @@
+# `@bentoml.service` configuration
+
+Everything is optional. The decorator takes named parameters plus any key of
+`bentoml.ServiceConfig`. Full list:
+https://docs.bentoml.com/en/latest/reference/bentoml/configurations.html
+
+## Decorator parameters
+
+| Parameter | Effect |
+|---|---|
+| `name="..."` | Overrides the Service name (default: the class name). Deploy configs, clients and `BENTOML_SERVE_DEPENDS` key off this — renaming is a breaking change |
+| `image=Image(...)` | Runtime environment. Only the **entry** Service's image is used |
+| `description="..."` | Shown in the Swagger UI |
+| `path_prefix="/v1"` | Prefixes every API route, mounted ASGI app **and** `/livez` + `/readyz` |
+| `envs=[{"name": "HF_TOKEN"}, {"name": "MODE", "value": "fast"}]` | Declares env vars. Value omitted = supplied at deploy time. Never put a secret value here |
+| `labels={"owner": "ml-team"}` | Metadata on the bento |
+| `cmd=["uvicorn", "app:api", "--port", "$PORT"]` | Run an external server instead of BentoML's; BentoML proxies to it. Pair with `http={"proxy_port": N}` if it doesn't listen on 8000 |
+
+## Config keys that matter locally
+
+| Key | Default | Notes |
+|---|---|---|
+| `workers` | `1` | Processes, each with its own model copy. `"cpu_count"` uses every core — but **skips GPU assignment** |
+| `threads` | `1` | Concurrent in-flight requests per worker for **sync** APIs (an `anyio` capacity limiter). Measured: four concurrent 1-second requests take 4.0 s at the default and 1.0 s with `threads=4`. The usual cause of serial throughput |
+| `traffic={"timeout": s}` | `60.0` | Per-request deadline. Raise it for long generation |
+| `traffic={"max_concurrency": n}` | unset | Requests beyond this are rejected rather than queued |
+| `resources={"gpu": n}` | unset | Sets `CUDA_VISIBLE_DEVICES` per worker locally. `BENTOML_DISABLE_GPU_ALLOCATION=1` turns that off |
+| `http={"port": 3000, "host": "0.0.0.0", "cors": {...}}` | as shown | CORS is **off** by default — a browser front end needs it enabled explicitly |
+| `endpoints={"livez": "/healthz"}` | `/livez`, `/readyz` | Rename health checks if a load balancer demands specific paths |
+| `metrics={"enabled": True, "namespace": "..."}` | enabled | Prometheus at `/metrics` |
+| `logging={"access": {"skip_paths": [...]}}` | health paths skipped | Access-log noise control |
+| `extra_ports=[8080]` | unset | Additional ports the container should expose |
+
+## Config keys that are hints only
+
+Set them for the deployment platform; `bentoml serve` ignores them.
+
+| Key | Consumed by |
+|---|---|
+| `resources={"cpu": "2", "memory": "4Gi"}` | BentoCloud instance sizing; on Kubernetes the real requests/limits come from the deploy config, not from here |
+| `resources={"gpu_type": "nvidia-l4", "tpu_type": ...}` | BentoCloud instance selection |
+| `traffic={"concurrency": n, "external_queue": True}` | BentoCloud autoscaling and its request queue |
+
+## Overriding at run time without editing code
+
+```bash
+BENTOML_CONFIG_OPTIONS='services.Summarization.workers=4' bentoml serve
+BENTOML_CONFIG=./bentoml_config.yaml bentoml serve
+```
+
+Useful for retuning a built bento or a running container. In a Kubernetes deployment this is
+what `config_overrides` in the deploy config compiles down to. Note the key is the Service's
+**own** name — an override on the caller does not reach its dependency.
+
+## Lifecycle hooks
+
+| Hook | Runs | Signature | Use for |
+|---|---|---|---|
+| `@bentoml.on_deployment` | Once, before any worker starts | no `self` (static) | One-time global setup: a migration, a download, a cache warm |
+| `@bentoml.on_startup` | Once per worker, before the APIs accept traffic | takes `self`; may be `async` | Per-worker resources: DB connections, clients |
+| `__init__` | Once per worker | `self` | Loading the model. The usual place |
+| `@bentoml.on_shutdown` | Per worker, on shutdown | `self` | Closing connections, flushing buffers |
+
+https://docs.bentoml.com/en/latest/build-with-bentoml/lifecycle-hooks.html


### PR DESCRIPTION
## What

A fifth agent skill, `bentoml-create-bento`, covering the step *before* the deployment skills merged in #5683: creating the project itself — `service.py`, its runtime image, and a Bento built from it. Skill files only, no `src/` or `docs/` changes.

The vocabulary is deliberate, because it is easy to blur: a **Bento** is the artifact `bentoml build` produces, a **project** is the directory it is built from, and a **Service** is one `@bentoml.service` class — a bento may hold several. The skill produces a project and a bento; "Service" is used only for the class.

Two entry paths, one pipeline:

| Path | What the skill does |
|---|---|
| **New project** | One round of questions with defaults (what it does · where the weights come from · IO types · GPU · Python/pins · response profile), then scaffolds `service.py`, `requirements.txt`, `.bentoignore`, `test_service.py`, and `save_model.py` when the user owns the weights |
| **Conversion** | A script, a notebook, a FastAPI/Flask app, an MLflow model or a BentoML 1.1 Runner project — mapping table, per-source playbooks, and a parity procedure that diffs the Bento against the original code |

Both end identically: an **anchor case** (one concrete input and its expected output) collected up front, `bentoml serve`, verification judged on the response *body*, the anchor committed as a test, `bentoml build`, hand off to `bentoml-containerize`.

`SKILL.md` is 281 lines and states only what an agent gets wrong unaided — model references must be class attributes, annotations *are* the schema, a sync API is serialized by `threads=1`, `resources` cpu/memory are platform hints `bentoml serve` does not enforce, `/livez` and friends are reserved paths. Depth lives in four references (`io-types`, `service-config`, `recipes`, `conversion`) and in links to docs.bentoml.com, not in the body. The frontmatter `description` is 491 characters — what it does and when to reach for it; the situations it used to enumerate (streaming, batching, background work, splitting a Service, a bento that will not start) are stated in the body instead.

## End-to-end test

Every claim was checked against the SDK source and then exercised on bentoml 1.4.39 by installing the skill and following it:

1. **New project** — a scikit-learn regressor: `save_model.py` into the model store, two APIs (`numpy.ndarray` in, and a `text/csv` upload out to `list[dict]`), an `Image` from `requirements.txt`, served, verified against a precomputed anchor (`200.8733737178485`), 3 tests green, `bentoml build`, then served again **by tag** from the built bento.
2. **Conversion** — a FastAPI app (module-level model load, pydantic request model, API-key dependency, `uvicorn.run` in `__main__`, weights as loose pickles) → a Bento that returns **byte-identical output** for the anchor, keeps its auth (re-expressed as ASGI middleware), keeps `/healthz` under a prefix, and preserves the original flat request body via `input_spec`.
3. **A probe service** for the reference claims: `depends` + `to_async` + `asyncio.gather`, adaptive batching, tasks, streaming, root input, `Path` output, `input_spec`, and the `SyncHTTPClient`.

That run corrected the skill on seven points, all now reflected in the text: validation failures are **400**, not 422; `ContentType` validates the **client-declared** MIME type (`curl -F f=@x.csv` sends `application/octet-stream` and gets rejected); `to_asgi()` may be called only **once per process** (it registers Prometheus collectors); `/healthz` is built in and **shadows** a mounted app's route of the same name; a mounted app's route dependencies **do not** protect `@bentoml.api` routes; `$PORT` is not defined for a custom `cmd`; and `threads=1` measurably serializes — four concurrent one-second requests took **4.02 s** at the default versus **1.03 s** with `threads=4`.

The same run turned up four upstream bugs, split out into **#5706** (an async-task client crash, a path-resolution bug, and two doc pages whose examples cannot work). This PR does not depend on it — the skill documents the behaviour as it actually is.

## Notes

- `skills/README.md` now leads with this skill and the chain reads **create-bento → containerize → one deploy target**; the prerequisites matrix gained a column (this skill needs nothing but Python and whatever the model imports).
- The marketplace plugin keeps the name `bentoml-deploy` so existing install commands stay valid; only its description broadened. Renaming it is a separate decision.
- All five skills pass `skills-ref validate` (the agentskills.io reference implementation) and `claude plugin validate . --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>The head branch is still named `feat/bentoml-write-service-skill` — the skill was renamed to `bentoml-create-bento` after review feedback, and GitHub cannot retarget an open PR's head branch. It squash-merges, so the name does not survive into main.</sub>
