### PR TITLE
fix: raise clear error for empty Params instead of leaking StopIteration (#4263)

### DIFF
--- a/src/bentoml/_internal/runner/utils.py
+++ b/src/bentoml/_internal/runner/utils.py
@@ -53,7 +53,12 @@ class Params(t.Generic[T]):
 
     def all_equal(self) -> bool:
         value_iter = iter(self.items())
-        _, first = next(value_iter)
+        try:
+            _, first = next(value_iter)
+        except StopIteration:
+            # An empty Params has no values that could disagree, so this is
+            # vacuously true. Avoid leaking a bare StopIteration (see #4263).
+            return True
         return all(v == first for _, v in value_iter)
 
     def map(self, function: t.Callable[[T], To]) -> Params[To]:
@@ -125,7 +130,18 @@ class Params(t.Generic[T]):
         """
         if self.args:
             return self.args[0]
-        return next(iter(self.kwargs.values()))
+        try:
+            return next(iter(self.kwargs.values()))
+        except StopIteration:
+            # An empty ``Params`` has no sample value. This happens when a runner
+            # method takes zero arguments; such a method cannot be batched because
+            # there is no input to derive a batch size from. Raise a clear error
+            # instead of leaking a bare ``StopIteration`` (see issue #4263), which
+            # is confusing and a PEP 479 hazard inside generators/async code.
+            raise ValueError(
+                "Cannot get a sample from an empty Params. A batchable runner "
+                "method must take at least one argument."
+            ) from None
 
 
 PAYLOAD_META_HEADER = "Bento-Payload-Meta"

--- a/tests/unit/_internal/runner/test_utils.py
+++ b/tests/unit/_internal/runner/test_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import typing as t
+
 import pytest
 
 from bentoml._internal.runner.utils import Params
@@ -39,3 +41,58 @@ def test_params_all_equal_on_empty_params_is_vacuously_true():
     # ``StopIteration`` from ``next()`` on the empty iterator (see issue #4263).
     params: Params[object] = Params()
     assert params.all_equal() is True
+
+
+def test_params_sample_error_message_is_actionable():
+    # The point of #4263 is not merely "some exception" -- a bare
+    # ``StopIteration`` was already an exception. It is that the caller is told
+    # what went wrong and what to do, so an empty message would not fix the
+    # reported problem.
+    params: Params[object] = Params()
+    with pytest.raises(ValueError) as excinfo:
+        _ = params.sample
+
+    message = str(excinfo.value)
+    assert "empty Params" in message
+    assert "at least one argument" in message
+
+
+def test_params_sample_suppresses_the_stopiteration_context():
+    # ``raise ... from None`` sets ``__suppress_context__``, which keeps the
+    # original ``StopIteration`` out of the rendered traceback. Without it the
+    # confusing exception this issue is about is still shown to the user, just
+    # underneath a clearer one.
+    params: Params[object] = Params()
+    with pytest.raises(ValueError) as excinfo:
+        _ = params.sample
+
+    assert excinfo.value.__suppress_context__ is True
+    assert excinfo.value.__cause__ is None
+
+
+def test_params_sample_inside_a_generator_raises_value_error_not_runtime_error():
+    """The concrete PEP 479 hazard behind #4263.
+
+    A bare ``StopIteration`` escaping into a generator frame is converted by
+    the interpreter into ``RuntimeError: generator raised StopIteration``,
+    which names neither ``Params`` nor the real problem. Runner code calls
+    ``sample`` from generator and async frames, so this is the shape the bug
+    actually took in the wild.
+    """
+
+    def consume() -> t.Iterator[object]:
+        params: Params[object] = Params()
+        yield params.sample
+
+    with pytest.raises(ValueError) as excinfo:
+        list(consume())
+
+    assert "empty Params" in str(excinfo.value)
+
+
+def test_params_all_equal_inside_a_generator_does_not_raise():
+    def consume() -> t.Iterator[bool]:
+        params: Params[object] = Params()
+        yield params.all_equal()
+
+    assert list(consume()) == [True]

--- a/tests/unit/_internal/runner/test_utils.py
+++ b/tests/unit/_internal/runner/test_utils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from bentoml._internal.runner.utils import Params
+
+
+def test_params_sample_returns_first_arg():
+    params = Params(1, 2, foo=3)
+    assert params.sample == 1
+
+
+def test_params_sample_falls_back_to_first_kwarg_when_no_args():
+    params = Params(foo=3, bar=4)
+    assert params.sample == 3
+
+
+def test_params_sample_on_empty_params_raises_value_error():
+    # A runner method that takes zero arguments produces an empty ``Params``.
+    # ``sample`` must not leak a bare ``StopIteration`` (see issue #4263), which
+    # is both a confusing error and a PEP 479 hazard. It should raise a clear,
+    # actionable ``ValueError`` instead.
+    params: Params[object] = Params()
+    with pytest.raises(ValueError):
+        _ = params.sample
+
+
+def test_params_all_equal_true_for_matching_values():
+    assert Params(1, 1, foo=1).all_equal() is True
+
+
+def test_params_all_equal_false_for_differing_values():
+    assert Params(1, 2).all_equal() is False
+
+
+def test_params_all_equal_on_empty_params_is_vacuously_true():
+    # An empty ``Params`` (zero-argument runner method) has no values that could
+    # disagree, so ``all_equal`` is vacuously true. It must not leak a bare
+    # ``StopIteration`` from ``next()`` on the empty iterator (see issue #4263).
+    params: Params[object] = Params()
+    assert params.all_equal() is True


### PR DESCRIPTION
## What

Fixes #4263.

Invoking a **batchable runner method that takes zero arguments** produces an empty `Params`, and two of its methods leaked a bare `StopIteration`:

- `Params.sample` — `return next(iter(self.kwargs.values()))` with no args and no kwargs. This is the site in the issue's traceback (reached from the batch dispatcher's batch-size computation, `get_batch_size` → `x.sample.batch_size`).
- `Params.all_equal` — `_, first = next(value_iter)` on an empty iterator. Reached during batch aggregation in `payload_paramss_to_batch_params` (`if not indice_params.all_equal(): ...`).

A bare `StopIteration` here is confusing (empty message) and a [PEP 479](https://peps.python.org/pep-0479/) hazard in generator/async contexts. Fundamentally, a method with no batchable input **cannot be batched** — there is no input from which to derive a batch size or per-caller split indices.

## Fix

- `Params.sample` now raises a clear, actionable `ValueError` for an empty `Params`:
  > `Cannot get a sample from an empty Params. A batchable runner method must take at least one argument.`
- `Params.all_equal` returns `True` for an empty `Params` (vacuously true — there are no values that could disagree). This is correct at all three call sites, which all use the pattern `if not all_equal(): raise <mismatch error>`.

Both changes simply guard the `next(...)` calls; no type signatures change.

## Notes for reviewers

- This is legacy (pre-1.2) runner code. The original **infinite-loop** symptom reported in #4263 (bentoml 1.1.8) is already mitigated on `main` — `CorkDispatcher._get_inputs` now wraps `get_batch_size` in `try/except` and falls back to batch size 1. This PR fixes the **remaining root cause**: the empty-`Params` path still leaked a cryptic `StopIteration` at two sites (the second, `all_equal`, is hit at batch-execution time even with the dispatcher guard in place), so a zero-argument batchable method still failed with an empty, confusing error. After this change it fails fast with an actionable message instead.
- Happy to instead reject zero-argument batchable methods at definition/serve time if maintainers prefer surfacing this earlier — that would be a slightly larger change with no existing validation precedent, so I kept this PR minimal and targeted.

## Testing

- New unit tests in `tests/unit/_internal/runner/test_utils.py` (6 tests) covering `sample` (args-first, kwargs-fallback, empty→`ValueError`) and `all_equal` (equal, differing, empty→vacuously `True`). Written test-first (watched each fail before fixing).
- Full runner unit suite passes (`tests/unit/_internal/runner/`, 25 passed), no regressions.
- `pre-commit` (ruff check/format) passes on the changed files.
