### PR TITLE
fix: preserve task response header bytes

### DIFF
--- a/src/_bentoml_impl/tasks/serde.py
+++ b/src/_bentoml_impl/tasks/serde.py
@@ -121,6 +121,7 @@ class JSONSerde(Serde):
             status_code=response_dict["status"],
         )
         response.raw_headers = [
-            tuple(map(str.encode, h)) for h in response_dict["headers"]
+            (key.encode(self.HEADERS_ENCODING), value.encode(self.HEADERS_ENCODING))
+            for key, value in response_dict["headers"]
         ]
         return response

--- a/tests/unit/bentoml_io/test_tasks_serde.py
+++ b/tests/unit/bentoml_io/test_tasks_serde.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+from starlette.responses import Response
+
+from _bentoml_impl.tasks.serde import JSONSerde
+
+
+@pytest.mark.asyncio
+async def test_response_headers_roundtrip_preserves_latin1_bytes():
+    serde = JSONSerde()
+    response = Response(content=b"ok", status_code=200)
+    response.raw_headers.append((b"x-raw-name", b"caf\xe9"))
+
+    data = await serde.serialize_response(response)
+    restored = await serde.deserialize_response(data)
+
+    restored_headers = dict(restored.raw_headers)
+    assert restored_headers[b"x-raw-name"] == b"caf\xe9"


### PR DESCRIPTION
## What does this PR address?

Task-result response headers are serialized from ASGI's Latin-1 byte representation, but deserialization currently uses UTF-8 through the default `str.encode()`. A header such as `b"caf\xe9"` therefore returns as `b"caf\xc3\xa9"` after a round trip.

This change uses the serde's existing `HEADERS_ENCODING` in the response path, matching request deserialization and restoring byte-for-byte symmetry. It adds a focused regression test for a non-ASCII Latin-1 header value.

This revisits the voluntarily closed #5693 from @feiiiiii5 after revalidating the behavior on current `main`.

Verification:

- direct async red/green round-trip reproduction — failed before the change and passed after it
- `ruff check src/_bentoml_impl/tasks/serde.py tests/unit/bentoml_io/test_tasks_serde.py`
- `ruff format --check src/_bentoml_impl/tasks/serde.py tests/unit/bentoml_io/test_tasks_serde.py`

AI assistance was used for implementation and test preparation; the reported commands were run locally.

## Before submitting:

- [x] Does the Pull Request follow Conventional Commits specification naming?
- [ ] Does the code follow BentoML's code style, `pre-commit run -a` script has passed? Focused Ruff lint and format checks passed; the full pre-commit suite was not run.
- [x] Did you read through contribution guidelines and follow development guidelines?
- [x] Did your changes require updates to the documentation? No user-facing documentation change is needed for this serialization bug.
- [x] Did you write tests to cover your changes?
