### PR TITLE
docs: fix stale example links in README and overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ For detailed explanations, read the [Hello World example](https://docs.bentoml.c
 
 ## Examples
 
-- LLMs: [Llama 3.2](https://github.com/bentoml/BentoVLLM/tree/main/llama3.2-11b-vision-instruct), [Mistral](https://github.com/bentoml/BentoVLLM/tree/main/ministral-8b-instruct-2410), [DeepSeek Distil](https://github.com/bentoml/BentoVLLM/tree/main/deepseek-r1-distill-llama3.1-8b-tool-calling), and more.
-- Image Generation: [Stable Diffusion 3 Medium](https://github.com/bentoml/BentoDiffusion/tree/main/sd3-medium), [Stable Video Diffusion](https://github.com/bentoml/BentoDiffusion/tree/main/svd), [Stable Diffusion XL Turbo](https://github.com/bentoml/BentoDiffusion/tree/main/sdxl-turbo), [ControlNet](https://github.com/bentoml/BentoDiffusion/tree/main/controlnet), and [LCM LoRAs](https://github.com/bentoml/BentoDiffusion/tree/main/lcm).
+- LLMs: [DeepSeek R1 Distill of Llama 3.3 70B](https://github.com/bentoml/BentoVLLM/tree/main/deepseek-r1-llama3.3-70b), [Llama 4 Scout](https://github.com/bentoml/BentoVLLM/tree/main/llama4-17b-scout-instruct), [Qwen3 8B](https://github.com/bentoml/BentoVLLM/tree/main/qwen3-8b), and more.
+- Image Generation: [Stable Diffusion 3.5 Large Turbo](https://github.com/bentoml/BentoDiffusion/tree/main/sd3.5-large-turbo), [Stable Diffusion 3 Medium](https://github.com/bentoml/BentoDiffusion/tree/main/sd3-medium), [Stable Diffusion XL Turbo](https://github.com/bentoml/BentoDiffusion/tree/main/sdxl-turbo), [ControlNet](https://github.com/bentoml/BentoDiffusion/tree/main/controlnet), and more.
 - Embeddings: [SentenceTransformers](https://github.com/bentoml/BentoSentenceTransformers) and [ColPali](https://github.com/bentoml/BentoColPali)
 - Audio: [ChatTTS](https://github.com/bentoml/BentoChatTTS), [XTTS](https://github.com/bentoml/BentoXTTS), [WhisperX](https://github.com/bentoml/BentoWhisperX), [Bark](https://github.com/bentoml/BentoBark)
-- Computer Vision: [YOLO](https://github.com/bentoml/BentoYolo) and [ResNet](https://github.com/bentoml/BentoResnet)
+- Computer Vision: [ResNet](https://github.com/bentoml/BentoResnet), [EasyOCR](https://github.com/bentoml/BentoOCR), and more in the [BentoML gallery](https://github.com/bentoml/gallery)
 - Advanced examples: [Function calling](https://github.com/bentoml/BentoFunctionCalling), [LangGraph](https://github.com/bentoml/BentoLangGraph), [CrewAI](https://github.com/bentoml/BentoCrewAI)
 
 Check out the [full list](https://docs.bentoml.com/en/latest/examples/overview.html) for more sample code and usage.

--- a/docs/source/examples/overview.rst
+++ b/docs/source/examples/overview.rst
@@ -11,7 +11,7 @@ Deploy an OpenAI-compatible LLM API service with BentoML and vLLM:
 
 - `DeepSeek R1 Distill of Llama 3.3 70B <https://github.com/bentoml/BentoVLLM/tree/main/deepseek-r1-llama3.3-70b>`_
 - `Llama 4 Scout <https://github.com/bentoml/BentoVLLM/tree/main/llama4-17b-scout-instruct>`_
-- `Mistral Small 24B <https://github.com/bentoml/BentoVLLM/tree/main/mistral-small-3.1-24b-instruct-2503>`_
+- `Qwen3 8B <https://github.com/bentoml/BentoVLLM/tree/main/qwen3-8b>`_
 - Check out the `BentoVLLM project <https://github.com/bentoml/BentoVLLM/#featured-models>`_ to see more supported models.
 
 Customize your LLM inference runtime:
@@ -67,9 +67,9 @@ Computer vision
 
 Serve computer vision models with BentoML:
 
-- `YOLO: Object detection <https://github.com/bentoml/BentoYolo>`_
 - `ResNet: Image classification <https://github.com/bentoml/BentoResnet>`_
 - `EasyOCR: Optical character recognition <https://github.com/bentoml/BentoOCR>`_
+- Check out the `BentoML gallery <https://github.com/bentoml/gallery>`_ for additional computer vision examples.
 
 Embeddings
 ----------


### PR DESCRIPTION
## Summary
- replace stale BentoVLLM and BentoDiffusion example links in `README.md` with currently published example paths
- remove the dead `bentoml/BentoYolo` link from the docs overview and README, and point readers to the public BentoML gallery for additional computer vision examples
- keep the curated example lists aligned with currently accessible public resources

Closes #5686.

## Validation
- ran a targeted URL check for the GitHub links referenced from `README.md` and `docs/source/examples/overview.rst`; all 53 validated URLs returned HTTP 200 after this change
- parsed the changed files locally (`docutils` for `overview.rst`, `markdown-it-py` for `README.md`)
- built the docs locally with Sphinx after pinning to Sphinx 7.4.7 and temporarily removing the optional `sphinxcontrib.spelling` extension from the local build config because the workstation is missing the Enchant C library; the build completed successfully and the rendered `examples/overview.html` contains the updated links

## Notes
- the local docs build still reports a number of pre-existing repository warnings unrelated to this change (missing static assets, duplicate labels, and a few unrelated docstring/reference warnings)
