### PR TITLE
fix: use sync grpc channel factory in sync client

### DIFF
--- a/src/bentoml/_internal/client/grpc.py
+++ b/src/bentoml/_internal/client/grpc.py
@@ -512,7 +512,7 @@ class SyncGrpcClient(SyncClient):
     ) -> None:
         protocol_version = kwargs.get("protocol_version", LATEST_PROTOCOL_VERSION)
 
-        with GrpcClient._create_channel(
+        with SyncGrpcClient._create_channel(
             f"{host}:{port}",
             ssl=kwargs.get("ssl", False),
             ssl_client_credentials=kwargs.get("ssl_client_credentials", None),
@@ -725,7 +725,7 @@ if __name__ == '__main__':
             raise BentoMLException("\n".join(exception_message))
         pb, _ = import_generated_stubs(protocol_version)
 
-        with GrpcClient._create_channel(
+        with cls._create_channel(
             server_url.replace(r"localhost", "0.0.0.0"),
             ssl=kwargs.get("ssl", False),
             ssl_client_credentials=kwargs.get("ssl_client_credentials", None),

--- a/tests/unit/_internal/client/test_grpc.py
+++ b/tests/unit/_internal/client/test_grpc.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+import bentoml._internal.client.grpc as grpc_client
+from bentoml._internal.client.grpc import SyncGrpcClient
+
+
+class _ChannelFactoryReached(Exception):
+    pass
+
+
+def _raise_when_channel_factory_is_used(server_url: str, **_: t.Any) -> t.NoReturn:
+    raise _ChannelFactoryReached(server_url)
+
+
+def _empty_generated_stubs(_: str) -> tuple[t.Any, t.Any]:
+    return None, None
+
+
+def test_sync_grpc_from_url_uses_its_channel_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class CustomSyncGrpcClient(SyncGrpcClient):
+        pass
+
+    monkeypatch.setattr(
+        CustomSyncGrpcClient,
+        "_create_channel",
+        staticmethod(_raise_when_channel_factory_is_used),
+    )
+    monkeypatch.setattr(grpc_client, "import_generated_stubs", _empty_generated_stubs)
+
+    with pytest.raises(_ChannelFactoryReached) as exc_info:
+        CustomSyncGrpcClient.from_url("localhost:3000")
+
+    assert exc_info.value.args == ("0.0.0.0:3000",)
+
+
+def test_sync_grpc_readiness_uses_sync_channel_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        SyncGrpcClient,
+        "_create_channel",
+        staticmethod(_raise_when_channel_factory_is_used),
+    )
+
+    with pytest.raises(_ChannelFactoryReached) as exc_info:
+        SyncGrpcClient.wait_until_server_ready("127.0.0.1", 3000)
+
+    assert exc_info.value.args == ("127.0.0.1:3000",)


### PR DESCRIPTION
## What does this PR address?

`SyncGrpcClient.from_url()` and `SyncGrpcClient.wait_until_server_ready()` both called `GrpcClient._create_channel`, but the wrapper `GrpcClient` does not define that method. Both sync paths therefore raised `AttributeError` before opening a channel.

This change:

- uses `cls._create_channel()` in the classmethod path, preserving subclass overrides
- uses `SyncGrpcClient._create_channel()` in the static readiness path
- adds offline regression tests that replace the expected sync factory with a sentinel and verify both paths reach it without making a network request

Fixes #4683

A previous pull request, #5601, identified the same two call sites but was closed by its author without merge or review. This PR was independently reproduced and adds focused offline tests for both paths.

## Validation

- unmodified `main`: both regression paths failed with `AttributeError: type object 'GrpcClient' has no attribute '_create_channel'`
- fixed focused tests: `2 passed`
- `pytest -q tests/unit/_internal/client tests/unit/grpc`: `30 passed`
- repository-pinned Ruff check and format: passed
- changed-file pre-commit hooks: Ruff check/format, trailing whitespace, and end-of-file checks passed; PDM and Buf hooks had no applicable files
- `compileall` and `git diff --check`: passed

## Before submitting

- [x] Pull request title follows Conventional Commits
- [ ] Full-repository `pre-commit run -a` was not run; all hooks applicable to the changed files passed
- [x] Contribution and development guidelines were reviewed
- [x] No documentation update is required; this restores the documented sync gRPC client path
- [x] Regression tests cover both changed call sites

## AI assistance

OpenAI Codex was used to investigate the issue, implement the patch, and run the validation described above.
