### PR TITLE
docs: fix pyproject link in development guide

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -307,7 +307,7 @@ Add a new job for your new framework under [framework.yml](./.github/workflows/f
 
 ## Python tools ecosystem
 
-Currently, BentoML is [PEP518](https://www.python.org/dev/peps/pep-0518/) compatible. We define package configuration via [`pyproject.toml`][https://github.com/bentoml/bentoml/blob/main/pyproject.toml].
+Currently, BentoML is [PEP518](https://www.python.org/dev/peps/pep-0518/) compatible. We define package configuration via [`pyproject.toml`](https://github.com/bentoml/bentoml/blob/main/pyproject.toml).
 
 ## Benchmark
 


### PR DESCRIPTION
## What does this PR address?

The `pyproject.toml` link in the Python tools section used reference-link brackets around an inline URL, so Markdown did not render it as a link. This switches it to the correct inline-link syntax.

## Validation

- Parsed `DEVELOPMENT.md` with `markdown-it-py` and confirmed the target is emitted as a link
- Confirmed the target `pyproject.toml` page returns HTTP 200

## Before submitting:

- [x] The title follows Conventional Commits
- [x] I read and followed the contribution and development guides
- [x] Documentation-only change; no code tests are applicable