### PR TITLE
fix(io): preserve dataframe dtype specs inferred from samples

### DIFF
--- a/src/bentoml/_internal/io_descriptors/pandas.py
+++ b/src/bentoml/_internal/io_descriptors/pandas.py
@@ -436,16 +436,15 @@ class PandasDataFrame(
         return sample
 
     def _convert_dtype(
-        self, value: ext.PdDTypeArg | None
+        self, value: bool | ext.PdDTypeArg | pd.Series[ext.PdDType] | None
     ) -> str | dict[str, t.Any] | None:
-        # TODO: support extension dtypes
         if LazyType["ext.NpNDArray"]("numpy", "ndarray").isinstance(value):
             return str(value.dtype)
-        elif isinstance(value, bool):
+        elif isinstance(value, (bool, np.dtype, pd.api.extensions.ExtensionDtype)):
             return str(value)
         elif isinstance(value, str):
             return value
-        elif isinstance(value, dict):
+        elif isinstance(value, (dict, pd.Series)):
             return {str(k): self._convert_dtype(v) for k, v in value.items()}
         elif value is None:
             return "null"

--- a/tests/unit/_internal/io/test_pandas.py
+++ b/tests/unit/_internal/io/test_pandas.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from bentoml.io import PandasDataFrame
+
+
+def test_from_sample_serializes_dataframe_dtypes():
+    dataframe = pd.DataFrame(
+        {
+            "int64": np.array([1, 2], dtype=np.int64),
+            "float32": np.array([1.0, 2.0], dtype=np.float32),
+            "bool": np.array([True, False], dtype=np.bool_),
+            "nullable_int": pd.array([1, None], dtype="Int64"),
+            "nullable_bool": pd.array([True, None], dtype="boolean"),
+            "string": pd.array(["a", None], dtype="string"),
+        }
+    )
+
+    descriptor = PandasDataFrame.from_sample(dataframe)
+
+    assert descriptor.to_spec()["args"]["dtype"] == {
+        "int64": "int64",
+        "float32": "float32",
+        "bool": "bool",
+        "nullable_int": "Int64",
+        "nullable_bool": "boolean",
+        "string": "string",
+    }
+
+
+def test_from_sample_keeps_explicit_dtype_dict():
+    descriptor = PandasDataFrame.from_sample(
+        pd.DataFrame({"inferred": [1, 2]}),
+        dtype={"configured": "string"},
+    )
+
+    assert descriptor.to_spec()["args"]["dtype"] == {"configured": "string"}


### PR DESCRIPTION
## What does this PR address?

Fixes #4633.

`PandasDataFrame.from_sample()` stores `DataFrame.dtypes` as a Pandas Series, but `_convert_dtype()` did not recognize that Series or its dtype objects. Generating the IO descriptor spec therefore logged `pandas.Series is not yet supported` and discarded the inferred dtypes as `None`.

This recognizes Series alongside dtype dictionaries and serializes NumPy and Pandas extension dtype objects to their string names. The parameter annotation now reflects the accepted values. Regression coverage includes ordinary and nullable/string dtypes, plus preserving an explicitly configured dtype dictionary.

## Testing

- Baseline `add7dd5`, retaining the new tests: **1 failed, 1 passed**; inferred dtype spec was `None`.
- `pytest tests/unit/_internal/io -q`: **78 passed**.
- Ruff 0.15.12 check and format check on both changed files: passed.
- `git diff --check`: passed.
- `uv build --wheel`: passed.
- Strict Pyright comparison: base has 65 errors / 30 warnings; this change has 64 errors / 29 warnings, with no new diagnostics. The file-wide type check is not clean on the base, including existing optional-dependency and dtype-annotation issues.

Local runtime: Python 3.11, Pandas 3.0.5, NumPy 2.4.6. Protobuf/gRPC versions used for the wider IO tests match `pdm.lock`.

## Before submitting

- [x] PR title follows Conventional Commits.
- [ ] Full `pre-commit run -a` (changed-file Ruff checks were run instead).
- [x] Contribution and development guidelines read.
- [x] No documentation change is needed for this existing API bug fix.
- [x] Regression tests added.

AI assistance: Codex prepared the patch; a separate coordinating agent inspected the diff and independently executed the baseline, regression, IO suite, lint, type-difference, and build checks above.
