### PR TITLE
Fix the gRPC client error log dropping its exception

### DIFF
--- a/src/bentoml/_internal/client/grpc.py
+++ b/src/bentoml/_internal/client/grpc.py
@@ -414,7 +414,7 @@ if __name__ == '__main__':
                     doc=api.docs,
                 )
             except BentoMLException as e:
-                logger.error("Failed to instantiate client for API %s: ", api.name, e)
+                logger.error("Failed to instantiate client for API %s: %s", api.name, e)
 
         return cls(server_url, dummy_service, **kwargs)
 
@@ -767,7 +767,7 @@ if __name__ == '__main__':
                     doc=api.docs,
                 )
             except BentoMLException as e:
-                logger.error("Failed to instantiate client for API %s: ", api.name, e)
+                logger.error("Failed to instantiate client for API %s: %s", api.name, e)
 
         return cls(server_url, dummy_service, **kwargs)
 


### PR DESCRIPTION
## Summary

Two call sites in `src/bentoml/_internal/client/grpc.py` pass the exception as a third argument to a format string that only has one placeholder:

```python
except BentoMLException as e:
    logger.error("Failed to instantiate client for API %s: ", api.name, e)
```

`logging` then fails while rendering the record:

```
--- Logging error ---
TypeError: not all arguments converted during string formatting
Message: 'Failed to instantiate client for API %s: '
Arguments: ('predict', BentoMLException(...))
```

so the record is replaced by a logging error and **the exception never reaches the log**. The trailing `": "` shows the intent was clearly to append it.

This matters because both sites are in the `BentoMLException` handler that runs while constructing the client from the service's API list — the moment when you most want to know *why* an API failed to bind. As it stands the API is silently skipped and the reason is discarded.

`ruff --select PLE1205` flags both.

## Fix

Add the missing `%s`. One character per line, two lines.

## Notes

Heads up on overlap: #5713 also touches this file (`fix: use sync grpc channel factory in sync client`). I checked its diff and it does not touch these `logger.error` lines, so the two are independent.
