### PR TITLE
fix: SSRF guard race in make_safe_connect() unguards concurrent requests

### DIFF
--- a/src/bentoml/_internal/utils/uri.py
+++ b/src/bentoml/_internal/utils/uri.py
@@ -1,8 +1,11 @@
+import asyncio
 import contextlib
 import ipaddress
 import os
 import pathlib
 import socket
+import threading
+from typing import Any
 from typing import no_type_check
 from urllib.parse import quote
 from urllib.parse import unquote
@@ -56,24 +59,37 @@ def is_http_url(url: str) -> bool:
     return urlparse(url).scheme in {"http", "https"}
 
 
-original_create_connection = None
+# Reference-counted state for the create_connection() guard, keyed by event
+# loop class. Each entry maps the patched loop class to a tuple of
+# (number of open guarded windows, saved original unbound create_connection).
+_safe_connect_state: dict[type, tuple[int, Any]] = {}
+# Event loop classes are process-global, and guarded windows may be entered
+# from multiple threads (each running its own loop); this lock serializes
+# install/restore transitions.
+_safe_connect_lock = threading.Lock()
 
 
 @contextlib.contextmanager
 def make_safe_connect():
-    """Patch loop.create_connection() method to reject unsafe URLs."""
+    """Patch loop.create_connection() method to reject unsafe URLs.
+
+    The patch is reference-counted per event loop class: the first guarded
+    window installs it, and overlapping windows (e.g. concurrent requests)
+    only increment the reference count. An exiting window therefore never
+    restores the original method while another window still relies on the
+    guard; the restore happens only when the last window closes.
+    """
 
     from urllib.request import getproxies
 
     import httpx
-    from uvloop import Loop
 
     from bentoml.exceptions import BadInput
 
-    global original_create_connection
-
-    if original_create_connection is None:
-        original_create_connection = Loop.create_connection
+    # Patch the class of the loop that is currently running, so that the
+    # guard also applies to plain asyncio (or Windows) event loops instead
+    # of only uvloop.
+    loop_class = type(asyncio.get_running_loop())
 
     # Do not check connections with proxy servers
     proxies = [
@@ -93,18 +109,35 @@ def make_safe_connect():
             else:
                 if ip.is_private or ip.is_loopback or ip.is_link_local:
                     raise socket.gaierror(f"Blocked private IP address {host}")
-        return await original_create_connection(
-            self, protocol_factory, host=host, port=port, **kwargs
-        )
+        original = _safe_connect_state[loop_class][1]
+        return await original(self, protocol_factory, host=host, port=port, **kwargs)
 
-    Loop.create_connection = safe_create_connection
+    with _safe_connect_lock:
+        state = _safe_connect_state.get(loop_class)
+        if state is None:
+            # No guarded window is open for this loop class: install the
+            # patch and remember the original method for the final restore.
+            original = loop_class.create_connection
+            _safe_connect_state[loop_class] = (1, original)
+            loop_class.create_connection = safe_create_connection
+        else:
+            depth, original = state
+            _safe_connect_state[loop_class] = (depth + 1, original)
     try:
         yield
     except httpx.ConnectError as e:
         if "All connection attempts failed" in str(e):
             raise BadInput("Connection blocked due to insecure input URL") from e
     finally:
-        Loop.create_connection = original_create_connection
+        with _safe_connect_lock:
+            depth, original = _safe_connect_state[loop_class]
+            if depth <= 1:
+                # This is the last open guarded window for this loop class:
+                # it is now safe to restore the original method.
+                del _safe_connect_state[loop_class]
+                loop_class.create_connection = original
+            else:
+                _safe_connect_state[loop_class] = (depth - 1, original)
 
 
 def join_paths(*paths: str) -> str:


### PR DESCRIPTION
## What does this PR address?

Fixes a race condition in `make_safe_connect()` (`src/bentoml/_internal/utils/uri.py`) that allows the SSRF protection of the api-server to be bypassed whenever two URL-fetching requests overlap in time.

### The bug, in plain English

BentoML's api-server will, by design, fetch a URL supplied in the request body or a multipart field. The only thing standing between an attacker and the server's private network is `make_safe_connect()`, a context manager that temporarily replaces `uvloop.Loop.create_connection` with a checking version (rejects loopback/private/link-local IPs, so `http://169.254.169.254/...` cloud-metadata and internal services are unreachable) and restores the original method in a `finally` when the window closes.

The patched attribute lives on the *class*, so it is global to the whole event loop — but the bookkeeping was per-window. When two requests overlap:

1. Request A enters its guarded window (patch installed).
2. Request B enters its guarded window (patch re-installed; `original_create_connection` already saved, so B's exit will restore the true original).
3. Request A finishes first and its `finally` restores the ORIGINAL method globally.
4. Request B is still inside its window believing it is guarded, but its `create_connection` call now goes to the unpatched original.

Two concurrent requests suffice; no special timing beyond an overlap. The victim's fetch of a private IP — e.g. the instance metadata endpoint — succeeds. The same fetch is blocked when only one request is in flight, which is what makes the guard deceptive: it passes every single-threaded test.

Entry → sink: attacker-controlled URL string in the request body (`src/_bentoml_impl/serde.py`, `JSONSerde.parse_request`) or multipart field (`MultipartSerde.ensure_file`) → `with make_safe_connect():` → `httpx.AsyncClient.get(attacker_url)` → `loop.create_connection(host=<attacker-resolved-IP>)`, with the response body fed back into the request pipeline.

### Reproduction, before → after

Before the fix (two overlapping guarded windows; control fetch done solo first):

```
control: blocked (guard effective solo)
victim: FETCHED status=200 body=SSRF-REACHED internal_hits=1
VERDICT: GUARD BYPASSED VIA RACE
```

After the fix (same concurrency shape, stable across repeated runs):

```
control: blocked (guard effective solo)
benign-public: FETCHED status=200 (guard does not over-block)
victim: blocked (ConnectError) internal_hits=0
post-unguarded: FETCHED status=200 (original method restored, no leak)
VERDICT: FIX HOLDS
checks: {'control': 'PASS', 'benign': 'PASS', 'race': 'PASS', 'post': 'PASS'}
```

Both directions hold: the previously-FETCHED victim is now BLOCKED under the same concurrency shape, the benign negative control shows a public fetch (`http://example.com`) still succeeds inside a guarded window (no over-blocking), and the post-unguarded check proves the original method really is restored once the last window closes (loopback fetch succeeds with no guard active — no patch leak).

### The fix: reference-counted patch, restore at depth 0

- A module-level `_safe_connect_state: dict[type, tuple[int, Any]]` maps each event-loop class to (open-window count, saved original unbound `create_connection`). A `threading.Lock` serializes install/restore transitions — class attributes are process-global even though each loop is single-threaded, and windows can be entered from different threads/loops.
- On enter: if no entry exists for the running loop's class (depth 0), save `loop_class.create_connection` as the original and install the checking wrapper; otherwise just increment the depth. Entry state is decided under the lock, so the "who installs" race between two simultaneous first-entries cannot double-save a wrapper as the original.
- On exit (`finally`): decrement; only when the depth reaches 0 — i.e. the LAST open window for that loop class closes — restore the saved original.

Why depth-0 restore is the unique correct point: the guard property needed is "any `create_connection` made while at least one window is open must be checked", and the installed wrapper enforces exactly that. Restoring early (the bug) breaks the property for still-open windows; restoring late would needlessly guard unguarded connections. Depth 0 is precisely the moment when no window remains. Nested and overlapping windows are therefore equivalent: only the entry count matters, not which task entered first or how windows nest.

Why the wrapper looks up the original at call time (`_safe_connect_state[loop_class][1]`) rather than closing over a global: successive outermost windows each install a fresh wrapper with a fresh saved original; call-time lookup always dispatches to the original that is currently saved, never a stale or `None` reference.

### Bonus coverage: plain asyncio loops and Windows

The fix patches `type(asyncio.get_running_loop())` instead of importing `uvloop.Loop` unconditionally. Consequences:

- On a plain asyncio loop the guard now actually applies — previously it was silently absent because only the uvloop class was patched (verified: a loopback fetch inside the guard is blocked under `asyncio.run` with no uvloop policy).
- On Windows, the `from uvloop import Loop` import no longer exists, so the previous `ModuleNotFoundError`-on-entry (request 500s) is gone.
- Both call sites (`serde.py:179`, `:209`) are `async def`, so a running loop always exists.

### Edge cases

- Nested guarded calls (same task): the inner exit decrements 2→1 and does NOT restore; verified that a loopback fetch is still blocked after the inner window closes while the outer is open, and an unguarded fetch succeeds after both close.
- Different loop classes (two threads, two loops, e.g. one uvloop + one asyncio): state is keyed per class, so each class is installed/restored independently — no cross-class clobber.
- Calling `make_safe_connect()` from a non-async context now raises `RuntimeError` (no running loop) instead of blindly patching uvloop's class; no such caller exists in the repo (grep-verified: only the two serde.py sites).
- Known limitation (unchanged from before): while windows overlap, only the outermost window's proxy-allowlist (`getproxies`) is live. Proxies are process-wide environment config and do not change between concurrent requests, so this is acceptable and documented.

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))? — pinned ruff 0.15.12 (the repo's own pin in `.pre-commit-config.yaml`) passes both `ruff check` and `ruff format --check` on the changed file.
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [x] Did your changes require updates to the documentation? Have you updated
      those accordingly? — not applicable, internal fix with no user-facing API change.
- [ ] Did you write tests to cover your changes? — verification was done with a standalone race-reproduction harness (before/after output above); happy to add an in-tree regression test if maintainers prefer.
