### PR TITLE
fix: avoid double decoding percent escapes in URI paths

### DIFF
--- a/src/bentoml/_internal/utils/uri.py
+++ b/src/bentoml/_internal/utils/uri.py
@@ -5,7 +5,6 @@ import pathlib
 import socket
 from typing import no_type_check
 from urllib.parse import quote
-from urllib.parse import unquote
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
@@ -44,7 +43,7 @@ def uri_to_path(uri: str) -> str:
     if parsed.scheme not in ("file", "filesystem", "unix"):
         raise ValueError("Unsupported URI scheme")
     host = "{0}{0}{mnt}{0}".format(os.path.sep, mnt=parsed.netloc)
-    return os.path.normpath(os.path.join(host, url2pathname(unquote(parsed.path))))
+    return os.path.normpath(os.path.join(host, url2pathname(parsed.path)))
 
 
 def encode_path_for_uri(path: str) -> str:

--- a/tests/unit/_internal/utils/test_uri.py
+++ b/tests/unit/_internal/utils/test_uri.py
@@ -1,5 +1,6 @@
 import os
 import typing as t
+from pathlib import Path
 
 import psutil
 import pytest
@@ -32,3 +33,20 @@ def test_uri_path_conversion(
     for path in example_paths:
         restored = uri_to_path(path_to_uri(path))
         assert restored == path or restored == os.path.abspath(path)
+
+
+@pytest.mark.parametrize("scheme", ["file", "filesystem", "unix"])
+@pytest.mark.parametrize(
+    "filename",
+    ["model%20name", "model%2Fname", "model%25name", "model%2520name", "model%FFname"],
+)
+def test_uri_to_path_preserves_literal_percent_escapes(
+    tmp_path: Path, scheme: str, filename: str
+) -> None:
+    from bentoml._internal.utils.uri import path_to_uri
+    from bentoml._internal.utils.uri import uri_to_path
+
+    path = str(tmp_path / filename)
+    uri = path_to_uri(path).replace("file:", f"{scheme}:", 1)
+
+    assert uri_to_path(uri) == path


### PR DESCRIPTION
## What does this PR address?

`uri_to_path()` percent-decodes paths twice: once via `unquote()` and again inside the standard library's `url2pathname()`. As a result, filenames containing literal percent-escape sequences do not survive a `path_to_uri()` / `uri_to_path()` round trip.

For example, on Linux:

```python
from bentoml._internal.utils.uri import path_to_uri, uri_to_path

path = "/tmp/model%20name.sock"
assert uri_to_path(path_to_uri(path)) == path
# Before: AssertionError; actual path is '/tmp/model name.sock'
```

This also affects `unix:` URIs consumed by the HTTP clients and runner connections. Literal `%2F` becomes a path separator, and `%FF` becomes a replacement character.

Remove the redundant `unquote()` call and let `url2pathname()` perform the decoding once. Add 15 regression cases covering literal `%20`, `%2F`, `%25`, `%2520`, and `%FF` across all three supported schemes (`file`, `filesystem`, `unix`). The existing tests continue to cover ordinary paths, spaces, Unicode, and relative paths.

### Validation

On Linux, Python 3.11:

- Before the fix: URI tests **15 failed, 1 passed** (all newly added cases fail).
- After the fix: `BENTOML_DO_NOT_TRACK=True python -m pytest tests/unit/_internal/utils/test_uri.py tests/unit/_internal/test_utils.py -q` — **19 passed**.
- Ruff **0.15.12** (matching the pre-commit configuration): check and format check pass for both changed files.
- `git diff --check` passes.

The full test suite, Windows execution, and full pre-commit suite were not run. No documentation changes are needed for this internal bug fix.

## Before submitting:

- [x] PR title follows Conventional Commits.
- [ ] Full `pre-commit run -a` passes (targeted Ruff checks passed; see above).
- [x] Read the contribution and development guidelines.
- [ ] Documentation updated (not applicable).
- [x] Added regression tests.

Implementation and tests were prepared with AI assistance and validated locally as described above.
