### PR TITLE
fix(cloud/yatai): pull_bento/pull_model call the removed `fs` module

### DIFF
--- a/src/bentoml/_internal/cloud/yatai.py
+++ b/src/bentoml/_internal/cloud/yatai.py
@@ -7,7 +7,6 @@ import threading
 import typing as t
 import warnings
 from concurrent.futures import ThreadPoolExecutor
-from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import httpx
@@ -24,6 +23,7 @@ from ..models import ModelStore
 from ..models import copy_model
 from ..tag import Tag
 from ..utils.filesystem import calc_dir_size
+from ..utils.filesystem import safe_extract_tarfile
 from .base import FILE_CHUNK_SIZE
 from .base import CallbackIOWrapper
 from .base import Spinner
@@ -528,16 +528,11 @@ class YataiClient:
                 tar_file.seek(0, 0)
                 tar = tarfile.open(fileobj=tar_file, mode="r")
                 with self.spinner.spin(text=f'Extracting bento "{_tag}" tar file'):
-                    with fs.open_fs("temp://") as temp_fs:
-                        for member in tar.getmembers():
-                            f = tar.extractfile(member)
-                            if f is None:
-                                continue
-                            p = Path(member.name)
-                            if p.parent != Path("."):
-                                temp_fs.makedirs(str(p.parent), recreate=True)
-                            temp_fs.writebytes(member.name, f.read())
-                        bento = Bento._from_fs(temp_fs)
+                    with tempfile.TemporaryDirectory(
+                        prefix="bentoml-bento-"
+                    ) as temp_dir:
+                        safe_extract_tarfile(tar, temp_dir)
+                        bento = Bento.from_path(temp_dir)
                         for model_tag in remote_bento.manifest.models:
                             with self.spinner.spin(
                                 text=f'Copying model "{model_tag}" to model store'
@@ -963,15 +958,8 @@ class YataiClient:
             tar_file.seek(0, 0)
             tar = tarfile.open(fileobj=tar_file, mode="r")
             with self.spinner.spin(text=f'Extracting model "{_tag}" tar file'):
-                with fs.open_fs("temp://") as temp_fs:
-                    for member in tar.getmembers():
-                        f = tar.extractfile(member)
-                        if f is None:
-                            continue
-                        p = Path(member.name)
-                        if p.parent != Path("."):
-                            temp_fs.makedirs(str(p.parent), recreate=True)
-                        temp_fs.writebytes(member.name, f.read())
-                    model = Model._from_fs(temp_fs).save(model_store)
+                with tempfile.TemporaryDirectory(prefix="bentoml-model-") as temp_dir:
+                    safe_extract_tarfile(tar, temp_dir)
+                    model = Model.from_path(temp_dir).save(model_store)
                     self.spinner.log(f'[bold green]Successfully pulled model "{_tag}"')
                     return model


### PR DESCRIPTION
## Problem

`YataiClient.pull_bento()` and `YataiClient.pull_model()` (exported publicly as `bentoml.cloud.YataiClient`) both crash on the extraction step:

```python
# src/bentoml/_internal/cloud/yatai.py:531
with fs.open_fs("temp://") as temp_fs:
    ...
    bento = Bento._from_fs(temp_fs)
```

```python
# src/bentoml/_internal/cloud/yatai.py:966
with fs.open_fs("temp://") as temp_fs:
    ...
    model = Model._from_fs(temp_fs).save(model_store)
```

`fs` is not imported anywhere in the file (module level or function local), so both paths raise:

```
NameError: name 'fs' is not defined
```

Even with a working `fs` in scope there is a second wall: `Bento._from_fs` and `Model._from_fs` no longer exist — `Bento` and `Model` expose `from_path` today.

## Root cause

`feat: Replace usages of fs library with fsspec and pathlib` (#5424, 35623b5b) touched this file, but only mechanically:

```diff
+# ruff: noqa
 from __future__ import annotations
@@
-import fs
 import httpx
@@
-                        bento = Bento.from_fs(temp_fs)
+                        bento = Bento._from_fs(temp_fs)
@@
-                    model = Model.from_fs(temp_fs).save(model_store)
+                    model = Model._from_fs(temp_fs).save(model_store)
```

The same commit gave `cloud/bento.py` and `cloud/model.py` the real conversion, and the file-wide `# ruff: noqa` added in that diff is why the resulting undefined name has stayed invisible to lint ever since.

## Fix

Port both blocks to the shape the sibling call sites already use — that is the spec, verbatim:

`src/bentoml/_internal/cloud/bento.py:539-543`
```python
tar = tarfile.open(fileobj=tar_file, mode="r")
with self.spinner.spin(text=f'Extracting bento "{_tag}" tar file'):
    with tempfile.TemporaryDirectory(prefix="bentoml-bento-") as temp_dir:
        safe_extract_tarfile(tar, temp_dir)
        bento = Bento.from_path(temp_dir).save(bento_store)
```

`src/bentoml/_internal/cloud/model.py:501-505`
```python
with tempfile.TemporaryDirectory(prefix="bentoml-model-") as temp_dir:
    safe_extract_tarfile(tar, temp_dir)
    model = StoredModel.from_path(temp_dir).save(model_store)
```

`tempfile` was already imported; `safe_extract_tarfile` is added next to the existing `calc_dir_size` import, and `from pathlib import Path` is dropped because those two loops were its only users.

Using `safe_extract_tarfile` rather than the hand-rolled member loop also picks up the path-traversal and symlink guards from #5598 / #5689 for the Yatai path, which the old loop never had.

## Verification

`fs` and the surrounding pull machinery can't be imported without a live Yatai server, so both code blocks were pulled out of the real files with `ast.get_source_segment` (no hand-transcription) and executed against a real in-memory tar:

| check | result |
|---|---|
| `Bento` / `Model` class bodies (AST) | `from_path` present, `_from_fs` / `from_fs` absent |
| `yatai.py` on `main` (AST) | zero `fs` imports, `fs.open_fs(` present |
| BEFORE block, executed | `NameError: name 'fs' is not defined` |
| BEFORE block with a working `fs` shim + a `Model` stub shaped from the real class body | `AttributeError: ... has no attribute '_from_fs'` |
| AFTER block, executed with the real `safe_extract_tarfile` | tar members land as `['model.yaml', 'nested/blob.bin']` under a `bentoml-model-*` temp dir, `Model.from_path(temp_dir)` is what gets called, `Successfully pulled model "demo:latest"` is logged |

`ruff-check` and `ruff-format` at the pinned `v0.15.12` from `.pre-commit-config.yaml` are clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
