### PR TITLE
fix: serialize runner images without an explicit format

### DIFF
--- a/src/bentoml/_internal/runner/container.py
+++ b/src/bentoml/_internal/runner/container.py
@@ -442,7 +442,7 @@ class PILImageContainer(DataContainer["ext.PILImage", "ext.PILImage"]):
     @classmethod
     def to_payload(cls, batch: ext.PILImage, batch_dim: int) -> Payload:
         buffer = io.BytesIO()
-        batch.save(buffer, format=batch.format)
+        batch.save(buffer, format=batch.format or "PNG")
         return cls.create_payload(buffer.getvalue(), batch_size=1)
 
     @classmethod

--- a/tests/unit/_internal/runner/test_container.py
+++ b/tests/unit/_internal/runner/test_container.py
@@ -1,12 +1,48 @@
 from __future__ import annotations
 
+import io
 import typing as t
 
 import numpy as np
 import pandas as pd
 import pytest
+from PIL import Image
 
 import bentoml._internal.runner.container as c
+
+
+@pytest.mark.parametrize("mode", ["L", "RGB", "RGBA"])
+@pytest.mark.parametrize("image_format", [None, ""])
+def test_pil_image_container_without_format(
+    mode: t.Literal["L", "RGB", "RGBA"], image_format: str | None
+):
+    image = Image.frombytes(mode, (3, 2), bytes(range(6 * len(mode))))
+    image.format = image_format
+
+    payload = c.AutoContainer.to_payload(image, batch_dim=0)
+    restored = c.AutoContainer.from_payload(payload)
+
+    assert payload.container == "PILImageContainer"
+    assert payload.batch_size == 1
+    assert restored.format == "PNG"
+    assert restored.mode == image.mode
+    assert restored.size == image.size
+    assert restored.tobytes() == image.tobytes()
+    assert image.format == image_format
+
+
+@pytest.mark.parametrize("image_format", ["PNG", "BMP"])
+def test_pil_image_container_preserves_existing_format(image_format: str):
+    buffer = io.BytesIO()
+    Image.new("RGB", (3, 2), color=(12, 34, 56)).save(buffer, format=image_format)
+    buffer.seek(0)
+    image = Image.open(buffer)
+
+    payload = c.AutoContainer.to_payload(image, batch_dim=0)
+    restored = c.AutoContainer.from_payload(payload)
+
+    assert restored.format == image_format
+    assert restored.tobytes() == image.tobytes()
 
 
 @pytest.mark.parametrize("batch_dim_exc", [AssertionError])


### PR DESCRIPTION
## What does this PR address?

Remote runners cannot transfer PIL images created from pixels or produced by transformations when `image.format` is `None` or empty. `PILImageContainer.to_payload()` passes that value to `Image.save()` on a `BytesIO`, so Pillow cannot infer an encoder and raises `ValueError: unknown file extension`.

Default to PNG when the format is absent, matching the existing `PILImageEncoder` in the new SDK. Explicit image formats are preserved. The regression tests use the real `AutoContainer` dispatch and round-trip grayscale, RGB and RGBA pixels, including alpha, without changing the source image's format.

Related to the format error reported in #4863; this does not claim to resolve that issue's latency report. The closed, unmerged #4368 proposed a clearer exception; this implements the PNG fallback [suggested in its review](https://github.com/bentoml/BentoML/pull/4368#issuecomment-1869920722).

### Validation

Python 3.11.15 with the repository's locked `grpc,io,testing,tooling` dependencies and `PYTEST_PLUGINS=bentoml.testing.pytest.plugin`:

- On unchanged `517b343b81aeb0b01bbd908e58e53ad9c12ef7eb`, `pdm run pytest tests/unit/_internal/runner/test_container.py -k pil_image_container -q`: **6 failed, 2 passed**; after the fix: **8 passed**.
- `pdm run pytest tests/unit/_internal/runner tests/unit/_internal/io/test_image.py -q`: **36 passed**.
- `pdm run pytest --cov=bentoml --cov-report=term-missing --cov-config=pyproject.toml -q -n 2 tests/unit`: **306 passed, 5 skipped**.
- `pre-commit run --all-files`: passed; source distribution and wheel builds passed.

Type-checking limitation: `make type` fails identically on the base and patch because the `typecheck` hook no longer exists. Direct Pyright on the two changed files reports the same **39 errors and 25 warnings** on each; a line-mapped comparison confirms **no new diagnostics**. No type-check settings or unrelated source were changed.

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [x] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [x] Did your changes require updates to the documentation? Have you updated those accordingly? No documentation update is needed: this restores serialization for an already-supported input type.
- [x] Did you write tests to cover your changes?
