### PR TITLE
feat(server): add X-Trust human presence middleware

### DIFF
--- a/src/bentoml/_internal/server/http/x_trust.py
+++ b/src/bentoml/_internal/server/http/x_trust.py
@@ -4,6 +4,7 @@ Annotates requests with human presence score via X-Trust header.
 Zero KYC, zero PII. Doctrine AIR: annotate, never block.
 github.com/htl-syterme/htl-core
 """
+
 import base64
 import hashlib
 import hmac

--- a/src/bentoml/_internal/server/http/x_trust.py
+++ b/src/bentoml/_internal/server/http/x_trust.py
@@ -1,0 +1,74 @@
+"""
+X-Trust Middleware for BentoML
+Annotates requests with human presence score via X-Trust header.
+Zero KYC, zero PII. Doctrine AIR: annotate, never block.
+github.com/htl-syterme/htl-core
+"""
+import base64
+import hashlib
+import hmac
+import json
+import time
+from typing import Optional
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class XTrustMiddleware(BaseHTTPMiddleware):
+    """
+    Validates X-Trust header and annotates request state.
+    Never blocks — doctrine AIR.
+    """
+
+    def __init__(self, app, secret: str, min_score: float = 0.0):
+        super().__init__(app)
+        self.secret = secret
+        self.min_score = min_score
+
+    def _verify(self, token: str) -> Optional[dict]:
+        try:
+            parts = token.split(".")
+            if len(parts) != 3 or parts[0] != "v1":
+                return None
+            _, payload_b64, sig_b64 = parts
+
+            def b64url_decode(s: str) -> bytes:
+                padding = 4 - len(s) % 4
+                return base64.b64decode(
+                    s.replace("-", "+").replace("_", "/") + "=" * padding
+                )
+
+            expected = hmac.new(
+                self.secret.encode(),
+                payload_b64.encode(),
+                hashlib.sha256,
+            ).digest()
+            if not hmac.compare_digest(expected, b64url_decode(sig_b64)):
+                return None
+            payload = json.loads(b64url_decode(payload_b64))
+            now = int(time.time())
+            if now > payload.get("exp", 0):
+                return None
+            if now - payload.get("iat", 0) > 120:
+                return None
+            score = payload.get("score", 0)
+            if not (0 <= score <= 1):
+                return None
+            return payload
+        except Exception:
+            return None
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        token = request.headers.get("x-trust", "")
+        payload = self._verify(token) if token else None
+        score = payload["score"] if payload else 0.0
+        trusted = payload is not None and score >= self.min_score
+        request.state.x_trust = {
+            "trusted": trusted,
+            "score": score,
+            "annotated": True,
+        }
+        response = await call_next(request)
+        return response


### PR DESCRIPTION
## What does this PR address?
- Introduces `x_trust.py` under `src/bentoml/_internal/server/http/`
- Validates X-Trust header (HMAC-SHA256) and annotates request.state.x_trust
- Doctrine AIR: annotate, never block — zero KYC, zero PII
- Helps ML serving teams distinguish human vs bot inference requests

## Checklist
- [x] Does the Pull Request follow Conventional Commits specification naming?
- [x] Did you read through contribution guidelines?
- [ ] Did your changes require updates to the documentation?
- [ ] Did you write tests to cover your changes?

OSS spec: github.com/htl-syterme/htl-core